### PR TITLE
feat: add multi-environment R2 storage and backup system

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,108 @@
+name: BACKUP - Database and R2 Storage
+
+on:
+  # Weekly scheduled backup (Sunday 3am UTC)
+  schedule:
+    - cron: '0 3 * * 0'
+  
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      full_r2_backup:
+        type: boolean
+        description: "Create dated R2 snapshot (vs incremental sync)"
+        default: false
+      backup_db:
+        type: boolean
+        description: "Backup database"
+        default: true
+      backup_r2:
+        type: boolean
+        description: "Backup R2 storage"
+        default: true
+
+  # Triggered by backend after artist submission
+  repository_dispatch:
+    types: [backup-on-submission]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backup
+  cancel-in-progress: false  # Don't cancel running backups
+
+env:
+  LIGHTSAIL_HOST: ${{ secrets.LIGHTSAIL_HOST }}
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60  # R2 backup can take a while for large buckets
+
+    steps:
+      - name: Determine backup type
+        id: backup-type
+        run: |
+          # Default: DB only for submission triggers, full backup for cron/manual
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "backup_db=true" >> $GITHUB_OUTPUT
+            echo "backup_r2=false" >> $GITHUB_OUTPUT
+            echo "full_r2=false" >> $GITHUB_OUTPUT
+            echo "trigger=artist-submission" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "backup_db=true" >> $GITHUB_OUTPUT
+            echo "backup_r2=true" >> $GITHUB_OUTPUT
+            echo "full_r2=true" >> $GITHUB_OUTPUT
+            echo "trigger=weekly-cron" >> $GITHUB_OUTPUT
+          else
+            echo "backup_db=${{ inputs.backup_db || 'true' }}" >> $GITHUB_OUTPUT
+            echo "backup_r2=${{ inputs.backup_r2 || 'true' }}" >> $GITHUB_OUTPUT
+            echo "full_r2=${{ inputs.full_r2_backup || 'false' }}" >> $GITHUB_OUTPUT
+            echo "trigger=manual" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log backup configuration
+        run: |
+          echo "Backup trigger: ${{ steps.backup-type.outputs.trigger }}"
+          echo "Backup DB: ${{ steps.backup-type.outputs.backup_db }}"
+          echo "Backup R2: ${{ steps.backup-type.outputs.backup_r2 }}"
+          echo "Full R2 snapshot: ${{ steps.backup-type.outputs.full_r2 }}"
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "Artist ID: ${{ github.event.client_payload.artist_id }}"
+          fi
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.LIGHTSAIL_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H "$LIGHTSAIL_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Run database backup
+        if: steps.backup-type.outputs.backup_db == 'true'
+        run: |
+          echo "Running database backup on Lightsail..."
+          ssh -o StrictHostKeyChecking=no ubuntu@"$LIGHTSAIL_HOST" \
+            "cd ~/unheard-backend && ./scripts/backup/backup-db.sh"
+
+      - name: Run R2 backup
+        if: steps.backup-type.outputs.backup_r2 == 'true'
+        run: |
+          echo "Running R2 backup on Lightsail..."
+          FULL_FLAG=""
+          if [[ "${{ steps.backup-type.outputs.full_r2 }}" == "true" ]]; then
+            FULL_FLAG="--full"
+          fi
+          ssh -o StrictHostKeyChecking=no ubuntu@"$LIGHTSAIL_HOST" \
+            "cd ~/unheard-backend && ./scripts/backup/backup-r2.sh $FULL_FLAG"
+
+      - name: Backup summary
+        if: always()
+        run: |
+          echo "=== Backup Job Complete ==="
+          echo "Trigger: ${{ steps.backup-type.outputs.trigger }}"
+          echo "Status: ${{ job.status }}"
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "Artist ID: ${{ github.event.client_payload.artist_id }}"
+          fi

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -40,6 +40,12 @@ rand = "0.8"
 # S3/R2 storage
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
 
+# HTTP client (for GitHub API dispatch)
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
+
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }

--- a/backend/scripts/backup/backup-all.sh
+++ b/backend/scripts/backup/backup-all.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Run all backups (database + R2)
+# Usage: ./backup-all.sh [--full]  # --full creates dated R2 snapshot
+#
+# This script is designed to be called:
+# - Manually for ad-hoc backups
+# - By cron for scheduled backups
+# - By GitHub Actions for CI/CD triggered backups
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FULL_BACKUP="${1:-}"
+
+echo "========================================"
+echo "  UNHEARD BACKUP - $(date)"
+echo "========================================"
+echo ""
+
+# Track errors
+ERRORS=0
+
+# Backup database
+echo ">>> Step 1/2: Database Backup"
+echo ""
+if ! "$SCRIPT_DIR/backup-db.sh"; then
+    echo ""
+    echo "⚠ Database backup failed!"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo ">>> Step 2/2: R2 Media Backup"
+echo ""
+if ! "$SCRIPT_DIR/backup-r2.sh" $FULL_BACKUP; then
+    echo ""
+    echo "⚠ R2 backup failed!"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "========================================"
+if [[ $ERRORS -eq 0 ]]; then
+    echo "  ✓ ALL BACKUPS COMPLETED SUCCESSFULLY"
+else
+    echo "  ⚠ BACKUP COMPLETED WITH $ERRORS ERROR(S)"
+fi
+echo "========================================"
+
+exit $ERRORS

--- a/backend/scripts/backup/backup-db.sh
+++ b/backend/scripts/backup/backup-db.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Backup SQLite database to R2 backup bucket
+# Usage: ./backup-db.sh [--local-only]
+#
+# Environment variables:
+#   DATABASE_PATH    - SQLite database path (default: /app/data/unheard.db)
+#   BACKUP_BUCKET    - R2 backup bucket name (default: unheard-backups)
+#   BACKUP_RETENTION - Number of backups to keep (default: 28 = 4 weeks daily)
+#   RCLONE_REMOTE    - rclone remote name for backup bucket (default: r2-backup)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+DB_PATH="${DATABASE_PATH:-/app/data/unheard.db}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-unheard-backups}"
+BACKUP_RETENTION="${BACKUP_RETENTION:-28}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-r2-backup}"
+LOCAL_ONLY="${1:-}"
+
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+BACKUP_NAME="unheard-db-$TIMESTAMP.db"
+LOCAL_BACKUP_DIR="/tmp/db-backups"
+LOCAL_BACKUP_PATH="$LOCAL_BACKUP_DIR/$BACKUP_NAME"
+
+echo "=== Database Backup ==="
+echo "Source: $DB_PATH"
+echo "Timestamp: $TIMESTAMP"
+echo ""
+
+# Check database exists
+if [[ ! -f "$DB_PATH" ]]; then
+    echo "Error: Database not found at $DB_PATH"
+    exit 1
+fi
+
+# Create local backup directory
+mkdir -p "$LOCAL_BACKUP_DIR"
+
+# Create backup using SQLite's backup command (safe for concurrent access)
+echo "Creating local backup..."
+sqlite3 "$DB_PATH" ".backup '$LOCAL_BACKUP_PATH'"
+
+# Compress backup
+echo "Compressing backup..."
+gzip "$LOCAL_BACKUP_PATH"
+LOCAL_BACKUP_PATH="${LOCAL_BACKUP_PATH}.gz"
+BACKUP_NAME="${BACKUP_NAME}.gz"
+
+BACKUP_SIZE=$(du -h "$LOCAL_BACKUP_PATH" | cut -f1)
+echo "  Created: $LOCAL_BACKUP_PATH ($BACKUP_SIZE)"
+
+if [[ "$LOCAL_ONLY" == "--local-only" ]]; then
+    echo ""
+    echo "Local-only mode: Skipping R2 upload"
+    echo "Backup saved to: $LOCAL_BACKUP_PATH"
+    exit 0
+fi
+
+# Upload to R2 backup bucket
+echo ""
+echo "Uploading to R2..."
+if ! command -v rclone &> /dev/null; then
+    echo "Error: rclone is not installed"
+    echo "Install with: curl https://rclone.org/install.sh | sudo bash"
+    exit 1
+fi
+
+rclone copy "$LOCAL_BACKUP_PATH" "$RCLONE_REMOTE:$BACKUP_BUCKET/db/" --progress
+
+echo "  Uploaded to: $RCLONE_REMOTE:$BACKUP_BUCKET/db/$BACKUP_NAME"
+
+# Cleanup old local backups (keep last 3 locally)
+echo ""
+echo "Cleaning up old local backups (keeping last 3)..."
+ls -t "$LOCAL_BACKUP_DIR"/unheard-db-*.db.gz 2>/dev/null | tail -n +4 | xargs -r rm -v
+
+# Cleanup old remote backups
+echo ""
+echo "Cleaning up old remote backups (keeping last $BACKUP_RETENTION)..."
+REMOTE_BACKUPS=$(rclone lsf "$RCLONE_REMOTE:$BACKUP_BUCKET/db/" --files-only 2>/dev/null | sort -r)
+BACKUP_COUNT=$(echo "$REMOTE_BACKUPS" | grep -c . || true)
+
+if [[ $BACKUP_COUNT -gt $BACKUP_RETENTION ]]; then
+    TO_DELETE=$(echo "$REMOTE_BACKUPS" | tail -n +$((BACKUP_RETENTION + 1)))
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        echo "  Deleting: $file"
+        rclone delete "$RCLONE_REMOTE:$BACKUP_BUCKET/db/$file"
+    done <<< "$TO_DELETE"
+else
+    echo "  No old backups to delete ($BACKUP_COUNT backups exist)"
+fi
+
+echo ""
+echo "=== Backup Complete ==="
+echo "Local: $LOCAL_BACKUP_PATH"
+echo "Remote: $RCLONE_REMOTE:$BACKUP_BUCKET/db/$BACKUP_NAME"

--- a/backend/scripts/backup/backup-r2.sh
+++ b/backend/scripts/backup/backup-r2.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Backup R2 media bucket to backup bucket (incremental sync)
+# Usage: ./backup-r2.sh [--full]
+#
+# Environment variables:
+#   R2_BUCKET_NAME   - Source bucket name (default: unheard-artists-prod)
+#   BACKUP_BUCKET    - Destination backup bucket (default: unheard-backups)
+#   BACKUP_RETENTION - Number of full snapshots to keep (default: 2)
+#   RCLONE_REMOTE    - rclone remote for backup bucket (default: r2-backup)
+#   RCLONE_SOURCE    - rclone remote for source bucket (default: r2-prod)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+SOURCE_BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-unheard-backups}"
+BACKUP_RETENTION="${BACKUP_RETENTION:-2}"
+RCLONE_SOURCE="${RCLONE_SOURCE:-r2-prod}"
+RCLONE_BACKUP="${RCLONE_REMOTE:-r2-backup}"
+FULL_BACKUP="${1:-}"
+
+TIMESTAMP=$(date +%Y-%m-%d)
+
+echo "=== R2 Media Backup ==="
+echo "Source: $RCLONE_SOURCE:$SOURCE_BUCKET"
+echo "Destination: $RCLONE_BACKUP:$BACKUP_BUCKET"
+echo "Date: $TIMESTAMP"
+echo ""
+
+if ! command -v rclone &> /dev/null; then
+    echo "Error: rclone is not installed"
+    echo "Install with: curl https://rclone.org/install.sh | sudo bash"
+    exit 1
+fi
+
+# Check source bucket is accessible
+echo "Checking source bucket..."
+if ! rclone lsd "$RCLONE_SOURCE:$SOURCE_BUCKET" &>/dev/null; then
+    echo "Error: Cannot access source bucket $RCLONE_SOURCE:$SOURCE_BUCKET"
+    echo "Check rclone configuration"
+    exit 1
+fi
+
+SOURCE_COUNT=$(rclone size "$RCLONE_SOURCE:$SOURCE_BUCKET" --json 2>/dev/null | jq -r '.count // 0')
+SOURCE_SIZE=$(rclone size "$RCLONE_SOURCE:$SOURCE_BUCKET" --json 2>/dev/null | jq -r '.bytes // 0' | numfmt --to=iec 2>/dev/null || echo "unknown")
+echo "  Source contains $SOURCE_COUNT objects ($SOURCE_SIZE)"
+
+if [[ "$FULL_BACKUP" == "--full" ]]; then
+    # Full snapshot backup (dated folder)
+    DEST_PATH="$RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/$TIMESTAMP"
+    echo ""
+    echo "Creating full snapshot: $DEST_PATH"
+    
+    rclone sync "$RCLONE_SOURCE:$SOURCE_BUCKET" "$DEST_PATH" \
+        --progress \
+        --stats 30s \
+        --transfers 8 \
+        --checkers 16
+    
+    # Cleanup old snapshots
+    echo ""
+    echo "Cleaning up old snapshots (keeping last $BACKUP_RETENTION)..."
+    
+    SNAPSHOTS=$(rclone lsf "$RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/" --dirs-only 2>/dev/null | sort -r)
+    SNAPSHOT_COUNT=$(echo "$SNAPSHOTS" | grep -c . || true)
+    
+    if [[ $SNAPSHOT_COUNT -gt $BACKUP_RETENTION ]]; then
+        TO_DELETE=$(echo "$SNAPSHOTS" | tail -n +$((BACKUP_RETENTION + 1)))
+        while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            echo "  Deleting snapshot: $dir"
+            rclone purge "$RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/$dir"
+        done <<< "$TO_DELETE"
+    else
+        echo "  No old snapshots to delete ($SNAPSHOT_COUNT exist)"
+    fi
+else
+    # Incremental sync to "latest" folder
+    DEST_PATH="$RCLONE_BACKUP:$BACKUP_BUCKET/r2-latest"
+    echo ""
+    echo "Incremental sync to: $DEST_PATH"
+    
+    rclone sync "$RCLONE_SOURCE:$SOURCE_BUCKET" "$DEST_PATH" \
+        --progress \
+        --stats 30s \
+        --transfers 8 \
+        --checkers 16
+fi
+
+echo ""
+echo "=== R2 Backup Complete ==="
+echo "Destination: $DEST_PATH"
+
+# Show backup size
+BACKUP_SIZE=$(rclone size "$DEST_PATH" --json 2>/dev/null | jq -r '.bytes // 0' | numfmt --to=iec 2>/dev/null || echo "unknown")
+echo "Backup size: $BACKUP_SIZE"

--- a/backend/scripts/backup/restore-db.sh
+++ b/backend/scripts/backup/restore-db.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Restore database from backup
+# Usage: ./restore-db.sh <backup-name>
+#        ./restore-db.sh --list           # List available backups
+#        ./restore-db.sh --latest         # Restore most recent backup
+#
+# Environment variables:
+#   DATABASE_PATH - SQLite database path (default: /app/data/unheard.db)
+#   BACKUP_BUCKET - R2 backup bucket name (default: unheard-backups)
+#   RCLONE_REMOTE - rclone remote name (default: r2-backup)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+DB_PATH="${DATABASE_PATH:-/app/data/unheard.db}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-unheard-backups}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-r2-backup}"
+
+ACTION="${1:-}"
+
+echo "=== Database Restore ==="
+echo ""
+
+if ! command -v rclone &> /dev/null; then
+    echo "Error: rclone is not installed"
+    exit 1
+fi
+
+list_backups() {
+    echo "Available backups in $RCLONE_REMOTE:$BACKUP_BUCKET/db/:"
+    echo ""
+    rclone lsf "$RCLONE_REMOTE:$BACKUP_BUCKET/db/" --files-only | sort -r | head -20
+    echo ""
+    echo "(Showing most recent 20)"
+}
+
+if [[ -z "$ACTION" ]]; then
+    echo "Usage: $0 <backup-name>"
+    echo "       $0 --list"
+    echo "       $0 --latest"
+    echo ""
+    list_backups
+    exit 1
+fi
+
+if [[ "$ACTION" == "--list" ]]; then
+    list_backups
+    exit 0
+fi
+
+if [[ "$ACTION" == "--latest" ]]; then
+    BACKUP_NAME=$(rclone lsf "$RCLONE_REMOTE:$BACKUP_BUCKET/db/" --files-only | sort -r | head -1)
+    if [[ -z "$BACKUP_NAME" ]]; then
+        echo "Error: No backups found"
+        exit 1
+    fi
+    echo "Latest backup: $BACKUP_NAME"
+else
+    BACKUP_NAME="$ACTION"
+fi
+
+echo "Restoring: $BACKUP_NAME"
+echo "Target: $DB_PATH"
+echo ""
+
+# Confirm with user
+read -p "⚠ This will REPLACE the current database. Continue? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Aborted"
+    exit 1
+fi
+
+# Create temp directory
+TEMP_DIR="/tmp/db-restore-$$"
+mkdir -p "$TEMP_DIR"
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download backup
+echo ""
+echo "Downloading backup..."
+rclone copy "$RCLONE_REMOTE:$BACKUP_BUCKET/db/$BACKUP_NAME" "$TEMP_DIR/" --progress
+
+# Decompress if gzipped
+DOWNLOADED_FILE="$TEMP_DIR/$BACKUP_NAME"
+if [[ "$BACKUP_NAME" == *.gz ]]; then
+    echo "Decompressing..."
+    gunzip "$DOWNLOADED_FILE"
+    DOWNLOADED_FILE="${DOWNLOADED_FILE%.gz}"
+fi
+
+# Verify it's a valid SQLite database
+echo "Verifying backup integrity..."
+if ! sqlite3 "$DOWNLOADED_FILE" "PRAGMA integrity_check;" | grep -q "ok"; then
+    echo "Error: Backup file is not a valid SQLite database"
+    exit 1
+fi
+
+# Create backup of current database
+if [[ -f "$DB_PATH" ]]; then
+    CURRENT_BACKUP="${DB_PATH}.pre-restore-$(date +%Y%m%d_%H%M%S)"
+    echo "Backing up current database to: $CURRENT_BACKUP"
+    cp "$DB_PATH" "$CURRENT_BACKUP"
+fi
+
+# Stop the service if running (optional - warn user)
+echo ""
+echo "⚠ Make sure the backend service is STOPPED before proceeding!"
+read -p "Is the service stopped? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Please stop the service first: docker compose down"
+    exit 1
+fi
+
+# Restore
+echo ""
+echo "Restoring database..."
+cp "$DOWNLOADED_FILE" "$DB_PATH"
+
+echo ""
+echo "=== Restore Complete ==="
+echo "Restored: $BACKUP_NAME -> $DB_PATH"
+echo ""
+echo "Remember to restart the backend service: docker compose up -d"

--- a/backend/scripts/backup/restore-r2.sh
+++ b/backend/scripts/backup/restore-r2.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Restore R2 media from backup
+# Usage: ./restore-r2.sh [--list]           # List available snapshots
+#        ./restore-r2.sh <snapshot-date>    # Restore from dated snapshot
+#        ./restore-r2.sh --latest           # Restore from r2-latest
+#
+# Environment variables:
+#   R2_BUCKET_NAME - Target bucket name (default: unheard-artists-prod)
+#   BACKUP_BUCKET  - Source backup bucket (default: unheard-backups)
+#   RCLONE_SOURCE  - rclone remote for target bucket (default: r2-prod)
+#   RCLONE_REMOTE  - rclone remote for backup bucket (default: r2-backup)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+TARGET_BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-unheard-backups}"
+RCLONE_TARGET="${RCLONE_SOURCE:-r2-prod}"
+RCLONE_BACKUP="${RCLONE_REMOTE:-r2-backup}"
+
+ACTION="${1:-}"
+
+echo "=== R2 Media Restore ==="
+echo ""
+
+if ! command -v rclone &> /dev/null; then
+    echo "Error: rclone is not installed"
+    exit 1
+fi
+
+list_snapshots() {
+    echo "Available snapshots in $RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/:"
+    echo ""
+    rclone lsf "$RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/" --dirs-only | sort -r
+    echo ""
+    echo "Also available: r2-latest (incremental sync backup)"
+}
+
+if [[ -z "$ACTION" ]]; then
+    echo "Usage: $0 <snapshot-date>  (e.g., 2025-01-11)"
+    echo "       $0 --latest"
+    echo "       $0 --list"
+    echo ""
+    list_snapshots
+    exit 1
+fi
+
+if [[ "$ACTION" == "--list" ]]; then
+    list_snapshots
+    exit 0
+fi
+
+if [[ "$ACTION" == "--latest" ]]; then
+    SOURCE_PATH="$RCLONE_BACKUP:$BACKUP_BUCKET/r2-latest"
+    echo "Restoring from: r2-latest"
+else
+    SOURCE_PATH="$RCLONE_BACKUP:$BACKUP_BUCKET/r2-snapshots/$ACTION"
+    echo "Restoring from: snapshot $ACTION"
+fi
+
+echo "Target: $RCLONE_TARGET:$TARGET_BUCKET"
+echo ""
+
+# Check source exists
+if ! rclone lsd "$SOURCE_PATH" &>/dev/null && ! rclone lsf "$SOURCE_PATH" --files-only &>/dev/null; then
+    echo "Error: Backup source not found: $SOURCE_PATH"
+    echo ""
+    list_snapshots
+    exit 1
+fi
+
+# Show sizes
+SOURCE_SIZE=$(rclone size "$SOURCE_PATH" --json 2>/dev/null | jq -r '.bytes // 0' | numfmt --to=iec 2>/dev/null || echo "unknown")
+SOURCE_COUNT=$(rclone size "$SOURCE_PATH" --json 2>/dev/null | jq -r '.count // 0')
+echo "Backup contains $SOURCE_COUNT objects ($SOURCE_SIZE)"
+
+TARGET_SIZE=$(rclone size "$RCLONE_TARGET:$TARGET_BUCKET" --json 2>/dev/null | jq -r '.bytes // 0' | numfmt --to=iec 2>/dev/null || echo "unknown")
+TARGET_COUNT=$(rclone size "$RCLONE_TARGET:$TARGET_BUCKET" --json 2>/dev/null | jq -r '.count // 0')
+echo "Target contains $TARGET_COUNT objects ($TARGET_SIZE)"
+echo ""
+
+# Confirm
+echo "⚠ This will SYNC the backup to the target bucket."
+echo "  Files in target not in backup will be DELETED!"
+read -p "Continue? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Aborted"
+    exit 1
+fi
+
+# Perform restore
+echo ""
+echo "Restoring R2 media..."
+rclone sync "$SOURCE_PATH" "$RCLONE_TARGET:$TARGET_BUCKET" \
+    --progress \
+    --stats 30s \
+    --transfers 8 \
+    --checkers 16
+
+echo ""
+echo "=== Restore Complete ==="
+echo "Restored: $SOURCE_PATH -> $RCLONE_TARGET:$TARGET_BUCKET"

--- a/backend/scripts/backup/setup_rclone.sh
+++ b/backend/scripts/backup/setup_rclone.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Setup rclone on Lightsail for R2 backups
+# Run this on the Lightsail instance after initial provisioning
+#
+# Usage: ./setup_rclone.sh
+#
+# Required environment variables (from .env or passed directly):
+#   R2_ACCOUNT_ID        - Cloudflare account ID
+#   R2_ACCESS_KEY_ID     - R2 access key
+#   R2_SECRET_ACCESS_KEY - R2 secret key
+#   R2_BUCKET_NAME       - Production bucket name (default: unheard-artists-prod)
+#   BACKUP_BUCKET        - Backup bucket name (default: unheard-backups)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+# Required variables
+R2_ACCOUNT_ID="${R2_ACCOUNT_ID:-}"
+R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID:-}"
+R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY:-}"
+R2_BUCKET_NAME="${R2_BUCKET_NAME:-unheard-artists-prod}"
+BACKUP_BUCKET="${BACKUP_BUCKET:-unheard-backups}"
+
+if [[ -z "$R2_ACCOUNT_ID" || -z "$R2_ACCESS_KEY_ID" || -z "$R2_SECRET_ACCESS_KEY" ]]; then
+    echo "Error: R2 credentials not set"
+    echo "Required: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+    echo ""
+    echo "These can be set in .env or passed as environment variables"
+    exit 1
+fi
+
+R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+echo "=== rclone Setup for R2 Backups ==="
+echo ""
+echo "R2 Account: $R2_ACCOUNT_ID"
+echo "R2 Endpoint: $R2_ENDPOINT"
+echo "Production bucket: $R2_BUCKET_NAME"
+echo "Backup bucket: $BACKUP_BUCKET"
+echo ""
+
+# Install rclone if not present
+if ! command -v rclone &> /dev/null; then
+    echo "Installing rclone..."
+    curl https://rclone.org/install.sh | sudo bash
+    echo ""
+fi
+
+echo "rclone version: $(rclone version --check | head -1)"
+echo ""
+
+# Create rclone config directory
+RCLONE_CONFIG_DIR="$HOME/.config/rclone"
+mkdir -p "$RCLONE_CONFIG_DIR"
+
+RCLONE_CONFIG="$RCLONE_CONFIG_DIR/rclone.conf"
+
+echo "Creating rclone configuration at $RCLONE_CONFIG..."
+
+# Generate rclone config with two remotes:
+# - r2-prod: For accessing the production bucket
+# - r2-backup: For accessing the backup bucket (could be same credentials, different bucket)
+cat > "$RCLONE_CONFIG" << EOF
+# R2 Production bucket remote
+[r2-prod]
+type = s3
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY_ID}
+secret_access_key = ${R2_SECRET_ACCESS_KEY}
+endpoint = ${R2_ENDPOINT}
+acl = private
+
+# R2 Backup bucket remote (uses same credentials)
+[r2-backup]
+type = s3
+provider = Cloudflare
+access_key_id = ${R2_ACCESS_KEY_ID}
+secret_access_key = ${R2_SECRET_ACCESS_KEY}
+endpoint = ${R2_ENDPOINT}
+acl = private
+EOF
+
+chmod 600 "$RCLONE_CONFIG"
+echo "  Created $RCLONE_CONFIG"
+
+# Test connectivity
+echo ""
+echo "Testing R2 connectivity..."
+
+echo -n "  r2-prod:$R2_BUCKET_NAME ... "
+if rclone lsd "r2-prod:$R2_BUCKET_NAME" &>/dev/null; then
+    echo "✓ OK"
+else
+    echo "✗ FAILED (bucket may not exist yet)"
+fi
+
+echo -n "  r2-backup:$BACKUP_BUCKET ... "
+if rclone lsd "r2-backup:$BACKUP_BUCKET" &>/dev/null; then
+    echo "✓ OK"
+else
+    echo "✗ FAILED (bucket may not exist yet)"
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "Configured remotes:"
+echo "  r2-prod   - Production R2 bucket ($R2_BUCKET_NAME)"
+echo "  r2-backup - Backup R2 bucket ($BACKUP_BUCKET)"
+echo ""
+echo "Usage examples:"
+echo "  rclone ls r2-prod:$R2_BUCKET_NAME"
+echo "  rclone ls r2-backup:$BACKUP_BUCKET"
+echo "  rclone sync r2-prod:$R2_BUCKET_NAME r2-backup:$BACKUP_BUCKET/r2-latest"
+echo ""
+echo "Run backups with:"
+echo "  ./scripts/backup/backup-db.sh"
+echo "  ./scripts/backup/backup-r2.sh"
+echo "  ./scripts/backup/backup-all.sh"

--- a/backend/scripts/r2/delete.sh
+++ b/backend/scripts/r2/delete.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Delete objects from R2 bucket
+# Usage: ./delete.sh <key> [key2] [key3] ...
+#        ./delete.sh --prefix <prefix>  # Delete all objects with prefix
+#        ./delete.sh --stdin            # Read keys from stdin (one per line)
+#
+# Environment variables:
+#   R2_BUCKET_NAME - Bucket name (default: from .env or 'unheard-artists-prod')
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+
+delete_object() {
+    local key="$1"
+    echo "Deleting: $key"
+    if wrangler r2 object delete "$BUCKET/$key" 2>/dev/null; then
+        echo "  ✓ Deleted"
+    else
+        echo "  ✗ Failed to delete"
+        return 1
+    fi
+}
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <key> [key2] [key3] ..."
+    echo "       $0 --prefix <prefix>"
+    echo "       $0 --stdin"
+    exit 1
+fi
+
+echo "Bucket: $BUCKET"
+echo "---"
+
+if [[ "$1" == "--prefix" ]]; then
+    PREFIX="${2:-}"
+    if [[ -z "$PREFIX" ]]; then
+        echo "Error: --prefix requires a prefix argument"
+        exit 1
+    fi
+    
+    echo "Deleting all objects with prefix: $PREFIX"
+    echo "Fetching object list..."
+    
+    # Get list of objects and delete each
+    KEYS=$(wrangler r2 object list "$BUCKET" --prefix "$PREFIX" --json 2>/dev/null | jq -r '.[].key // empty')
+    
+    if [[ -z "$KEYS" ]]; then
+        echo "No objects found with prefix: $PREFIX"
+        exit 0
+    fi
+    
+    COUNT=0
+    FAILED=0
+    while IFS= read -r key; do
+        if delete_object "$key"; then
+            ((COUNT++))
+        else
+            ((FAILED++))
+        fi
+    done <<< "$KEYS"
+    
+    echo "---"
+    echo "Deleted: $COUNT, Failed: $FAILED"
+
+elif [[ "$1" == "--stdin" ]]; then
+    echo "Reading keys from stdin..."
+    COUNT=0
+    FAILED=0
+    while IFS= read -r key; do
+        [[ -z "$key" ]] && continue
+        if delete_object "$key"; then
+            ((COUNT++))
+        else
+            ((FAILED++))
+        fi
+    done
+    
+    echo "---"
+    echo "Deleted: $COUNT, Failed: $FAILED"
+
+else
+    # Delete specified keys
+    COUNT=0
+    FAILED=0
+    for key in "$@"; do
+        if delete_object "$key"; then
+            ((COUNT++))
+        else
+            ((FAILED++))
+        fi
+    done
+    
+    echo "---"
+    echo "Deleted: $COUNT, Failed: $FAILED"
+fi

--- a/backend/scripts/r2/list.sh
+++ b/backend/scripts/r2/list.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# List objects in R2 bucket
+# Usage: ./list.sh [prefix] [--json]
+#
+# Environment variables:
+#   R2_BUCKET_NAME - Bucket name (default: from .env or 'unheard-artists-prod')
+#   R2_ACCOUNT_ID  - Cloudflare account ID
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+PREFIX="${1:-}"
+OUTPUT_FORMAT="${2:-}"
+
+echo "Listing objects in bucket: $BUCKET"
+[[ -n "$PREFIX" ]] && echo "Prefix filter: $PREFIX"
+echo "---"
+
+if [[ "$OUTPUT_FORMAT" == "--json" ]]; then
+    wrangler r2 object list "$BUCKET" ${PREFIX:+--prefix "$PREFIX"} --json
+else
+    wrangler r2 object list "$BUCKET" ${PREFIX:+--prefix "$PREFIX"}
+fi

--- a/backend/scripts/r2/move.sh
+++ b/backend/scripts/r2/move.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Move/rename objects in R2 bucket (copy + delete)
+# Usage: ./move.sh <source-key> <dest-key>
+#        ./move.sh --prefix <old-prefix> <new-prefix>  # Bulk rename prefix
+#
+# Environment variables:
+#   R2_BUCKET_NAME - Bucket name (default: from .env or 'unheard-artists-prod')
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+TEMP_DIR="/tmp/r2-move-$$"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+move_object() {
+    local src="$1"
+    local dst="$2"
+    
+    echo "Moving: $src -> $dst"
+    
+    mkdir -p "$TEMP_DIR"
+    local temp_file="$TEMP_DIR/$(basename "$src")"
+    
+    # Download
+    if ! wrangler r2 object get "$BUCKET/$src" --file "$temp_file" 2>/dev/null; then
+        echo "  ✗ Failed to download source"
+        return 1
+    fi
+    
+    # Upload to new location
+    if ! wrangler r2 object put "$BUCKET/$dst" --file "$temp_file" 2>/dev/null; then
+        echo "  ✗ Failed to upload to destination"
+        return 1
+    fi
+    
+    # Delete original
+    if ! wrangler r2 object delete "$BUCKET/$src" 2>/dev/null; then
+        echo "  ⚠ Copied but failed to delete source (duplicate exists)"
+        return 1
+    fi
+    
+    rm -f "$temp_file"
+    echo "  ✓ Moved"
+    return 0
+}
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <source-key> <dest-key>"
+    echo "       $0 --prefix <old-prefix> <new-prefix>"
+    exit 1
+fi
+
+echo "Bucket: $BUCKET"
+echo "---"
+
+if [[ "$1" == "--prefix" ]]; then
+    OLD_PREFIX="${2:-}"
+    NEW_PREFIX="${3:-}"
+    
+    if [[ -z "$OLD_PREFIX" || -z "$NEW_PREFIX" ]]; then
+        echo "Error: --prefix requires old-prefix and new-prefix arguments"
+        exit 1
+    fi
+    
+    echo "Renaming prefix: $OLD_PREFIX -> $NEW_PREFIX"
+    echo "Fetching object list..."
+    
+    KEYS=$(wrangler r2 object list "$BUCKET" --prefix "$OLD_PREFIX" --json 2>/dev/null | jq -r '.[].key // empty')
+    
+    if [[ -z "$KEYS" ]]; then
+        echo "No objects found with prefix: $OLD_PREFIX"
+        exit 0
+    fi
+    
+    COUNT=0
+    FAILED=0
+    while IFS= read -r key; do
+        new_key="${NEW_PREFIX}${key#$OLD_PREFIX}"
+        if move_object "$key" "$new_key"; then
+            ((COUNT++))
+        else
+            ((FAILED++))
+        fi
+    done <<< "$KEYS"
+    
+    echo "---"
+    echo "Moved: $COUNT, Failed: $FAILED"
+
+else
+    SRC="$1"
+    DST="$2"
+    
+    if move_object "$SRC" "$DST"; then
+        echo "---"
+        echo "Success"
+    else
+        echo "---"
+        echo "Failed"
+        exit 1
+    fi
+fi

--- a/backend/scripts/r2/sync-check.sh
+++ b/backend/scripts/r2/sync-check.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Check synchronization between database and R2 storage
+# Reports orphaned R2 objects (not in DB) and missing R2 objects (in DB but not in R2)
+#
+# Usage: ./sync-check.sh [--fix-orphans]
+#
+# Environment variables:
+#   R2_BUCKET_NAME - Bucket name (default: from .env or 'unheard-artists-prod')
+#   DATABASE_PATH  - SQLite database path (default: ../data/unheard.db)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+# Load .env if exists
+if [[ -f "$BACKEND_DIR/.env" ]]; then
+    set -a
+    source "$BACKEND_DIR/.env"
+    set +a
+fi
+
+BUCKET="${R2_BUCKET_NAME:-unheard-artists-prod}"
+DB_PATH="${DATABASE_PATH:-$BACKEND_DIR/data/unheard.db}"
+FIX_ORPHANS="${1:-}"
+
+TEMP_DIR="/tmp/r2-sync-check-$$"
+mkdir -p "$TEMP_DIR"
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+echo "=== R2 <-> Database Sync Check ==="
+echo "Bucket: $BUCKET"
+echo "Database: $DB_PATH"
+echo ""
+
+if [[ ! -f "$DB_PATH" ]]; then
+    echo "Error: Database not found at $DB_PATH"
+    exit 1
+fi
+
+# Get all keys from database
+echo "Fetching keys from database..."
+DB_KEYS_FILE="$TEMP_DIR/db_keys.txt"
+
+sqlite3 "$DB_PATH" <<EOF | sort -u > "$DB_KEYS_FILE"
+SELECT pic_key FROM artists WHERE pic_key IS NOT NULL AND pic_key != '';
+SELECT pic_cropped_key FROM artists WHERE pic_cropped_key IS NOT NULL AND pic_cropped_key != '';
+SELECT pic_overlay_key FROM artists WHERE pic_overlay_key IS NOT NULL AND pic_overlay_key != '';
+SELECT voice_message_key FROM artists WHERE voice_message_key IS NOT NULL AND voice_message_key != '';
+SELECT track1_key FROM artists WHERE track1_key IS NOT NULL AND track1_key != '';
+SELECT track2_key FROM artists WHERE track2_key IS NOT NULL AND track2_key != '';
+SELECT track1_original_key FROM artists WHERE track1_original_key IS NOT NULL AND track1_original_key != '';
+SELECT track2_original_key FROM artists WHERE track2_original_key IS NOT NULL AND track2_original_key != '';
+SELECT voice_original_key FROM artists WHERE voice_original_key IS NOT NULL AND voice_original_key != '';
+SELECT recording_key FROM shows WHERE recording_key IS NOT NULL AND recording_key != '';
+SELECT pic_key FROM pending_submissions WHERE pic_key IS NOT NULL AND pic_key != '';
+SELECT pic_cropped_key FROM pending_submissions WHERE pic_cropped_key IS NOT NULL AND pic_cropped_key != '';
+SELECT pic_overlay_key FROM pending_submissions WHERE pic_overlay_key IS NOT NULL AND pic_overlay_key != '';
+SELECT track1_key FROM pending_submissions WHERE track1_key IS NOT NULL AND track1_key != '';
+SELECT track2_key FROM pending_submissions WHERE track2_key IS NOT NULL AND track2_key != '';
+SELECT voice_key FROM pending_submissions WHERE voice_key IS NOT NULL AND voice_key != '';
+SELECT track1_original_key FROM pending_submissions WHERE track1_original_key IS NOT NULL AND track1_original_key != '';
+SELECT track2_original_key FROM pending_submissions WHERE track2_original_key IS NOT NULL AND track2_original_key != '';
+SELECT voice_original_key FROM pending_submissions WHERE voice_original_key IS NOT NULL AND voice_original_key != '';
+EOF
+
+DB_COUNT=$(wc -l < "$DB_KEYS_FILE" | tr -d ' ')
+echo "  Found $DB_COUNT keys in database"
+
+# Get all keys from R2
+echo "Fetching keys from R2..."
+R2_KEYS_FILE="$TEMP_DIR/r2_keys.txt"
+
+wrangler r2 object list "$BUCKET" --json 2>/dev/null | jq -r '.[].key // empty' | sort -u > "$R2_KEYS_FILE"
+
+R2_COUNT=$(wc -l < "$R2_KEYS_FILE" | tr -d ' ')
+echo "  Found $R2_COUNT objects in R2"
+echo ""
+
+# Find orphans (in R2 but not in DB)
+echo "=== Orphaned Objects (in R2, not in DB) ==="
+ORPHANS_FILE="$TEMP_DIR/orphans.txt"
+comm -23 "$R2_KEYS_FILE" "$DB_KEYS_FILE" > "$ORPHANS_FILE"
+ORPHAN_COUNT=$(wc -l < "$ORPHANS_FILE" | tr -d ' ')
+
+if [[ $ORPHAN_COUNT -eq 0 ]]; then
+    echo "  None found ✓"
+else
+    echo "  Found $ORPHAN_COUNT orphaned objects:"
+    head -20 "$ORPHANS_FILE" | sed 's/^/    /'
+    if [[ $ORPHAN_COUNT -gt 20 ]]; then
+        echo "    ... and $((ORPHAN_COUNT - 20)) more"
+    fi
+    
+    if [[ "$FIX_ORPHANS" == "--fix-orphans" ]]; then
+        echo ""
+        echo "  Deleting orphaned objects..."
+        DELETED=0
+        while IFS= read -r key; do
+            if wrangler r2 object delete "$BUCKET/$key" 2>/dev/null; then
+                echo "    ✓ Deleted: $key"
+                ((DELETED++))
+            else
+                echo "    ✗ Failed: $key"
+            fi
+        done < "$ORPHANS_FILE"
+        echo "  Deleted $DELETED orphaned objects"
+    fi
+fi
+echo ""
+
+# Find missing (in DB but not in R2)
+echo "=== Missing Objects (in DB, not in R2) ==="
+MISSING_FILE="$TEMP_DIR/missing.txt"
+comm -13 "$R2_KEYS_FILE" "$DB_KEYS_FILE" > "$MISSING_FILE"
+MISSING_COUNT=$(wc -l < "$MISSING_FILE" | tr -d ' ')
+
+if [[ $MISSING_COUNT -eq 0 ]]; then
+    echo "  None found ✓"
+else
+    echo "  ⚠ Found $MISSING_COUNT missing objects (data integrity issue!):"
+    head -20 "$MISSING_FILE" | sed 's/^/    /'
+    if [[ $MISSING_COUNT -gt 20 ]]; then
+        echo "    ... and $((MISSING_COUNT - 20)) more"
+    fi
+fi
+echo ""
+
+# Summary
+echo "=== Summary ==="
+echo "  Database keys: $DB_COUNT"
+echo "  R2 objects: $R2_COUNT"
+echo "  Orphaned (R2 only): $ORPHAN_COUNT"
+echo "  Missing (DB only): $MISSING_COUNT"
+
+if [[ $MISSING_COUNT -gt 0 ]]; then
+    echo ""
+    echo "⚠ WARNING: Missing objects indicate data integrity issues!"
+    echo "  These files are referenced in the database but do not exist in R2."
+    echo "  Check if they were accidentally deleted or never uploaded."
+    exit 1
+fi
+
+if [[ $ORPHAN_COUNT -gt 0 && "$FIX_ORPHANS" != "--fix-orphans" ]]; then
+    echo ""
+    echo "Tip: Run with --fix-orphans to delete orphaned R2 objects"
+fi

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -51,6 +51,12 @@ pub struct Config {
     pub ffmpeg_mp3_bitrate: String,
     #[serde(default = "default_ffmpeg_sample_rate")]
     pub ffmpeg_mp3_sample_rate: u32,
+
+    // GitHub Actions backup trigger (optional)
+    // If set, a GitHub repository_dispatch event will be triggered after artist submission
+    pub github_dispatch_token: Option<String>,
+    #[serde(default = "default_github_repo")]
+    pub github_repo: String,
 }
 
 fn default_host() -> String {
@@ -95,6 +101,10 @@ fn default_ffmpeg_bitrate() -> String {
 
 fn default_ffmpeg_sample_rate() -> u32 {
     44100
+}
+
+fn default_github_repo() -> String {
+    "phaabe/live.moafunk.de".to_string()
 }
 
 impl Config {

--- a/backend/src/handlers/backup_trigger.rs
+++ b/backend/src/handlers/backup_trigger.rs
@@ -1,0 +1,78 @@
+//! GitHub Actions backup trigger
+//!
+//! Triggers a `repository_dispatch` event to run backup workflow after artist submission.
+//! This is fire-and-forget - submission success is not dependent on backup trigger success.
+
+use crate::config::Config;
+
+/// Trigger a GitHub Actions backup workflow via repository_dispatch
+///
+/// This is non-blocking and failure-tolerant - we don't want backup trigger failures
+/// to affect the user's submission experience.
+pub fn trigger_backup_on_submission(config: &Config, artist_id: i64) {
+    // Only trigger if GitHub dispatch token is configured
+    let Some(token) = &config.github_dispatch_token else {
+        tracing::debug!("GitHub dispatch token not configured, skipping backup trigger");
+        return;
+    };
+
+    let repo = &config.github_repo;
+    let url = format!("https://api.github.com/repos/{}/dispatches", repo);
+
+    tracing::info!(
+        "Triggering backup workflow for artist_id={} via {}",
+        artist_id,
+        url
+    );
+
+    // Spawn a detached task so we don't block the response
+    let token = token.clone();
+    tokio::spawn(async move {
+        match send_dispatch_event(&url, &token, artist_id).await {
+            Ok(()) => {
+                tracing::info!(
+                    "Successfully triggered backup workflow for artist_id={}",
+                    artist_id
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to trigger backup workflow for artist_id={}: {}",
+                    artist_id,
+                    e
+                );
+            }
+        }
+    });
+}
+
+async fn send_dispatch_event(url: &str, token: &str, artist_id: i64) -> Result<(), String> {
+    let client = reqwest::Client::new();
+
+    let payload = serde_json::json!({
+        "event_type": "backup-on-submission",
+        "client_payload": {
+            "artist_id": artist_id,
+            "trigger": "artist-submission"
+        }
+    });
+
+    let response = client
+        .post(url)
+        .header("Accept", "application/vnd.github+json")
+        .header("Authorization", format!("Bearer {}", token))
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "unheard-backend")
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    let status = response.status();
+    if status.is_success() {
+        Ok(())
+    } else {
+        let body = response.text().await.unwrap_or_default();
+        Err(format!("GitHub API returned {}: {}", status, body))
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod backup_trigger;
 pub mod download;
 pub mod stream_ws;
 pub mod submit;

--- a/backend/src/handlers/submit.rs
+++ b/backend/src/handlers/submit.rs
@@ -504,6 +504,9 @@ pub async fn submit_form(
     .execute(&state.db)
     .await?;
 
+    // Trigger backup workflow (fire-and-forget)
+    super::backup_trigger::trigger_backup_on_submission(&state.config, artist_id);
+
     Ok(Json(SubmitResponse {
         success: true,
         message: "Thank you for your submission! We'll be in touch soon.".to_string(),

--- a/backend/src/handlers/submit_chunked.rs
+++ b/backend/src/handlers/submit_chunked.rs
@@ -886,6 +886,9 @@ async fn finalize_artist_files_background(
                 .execute(&state.db)
                 .await?;
 
+            // Trigger backup workflow (fire-and-forget)
+            super::backup_trigger::trigger_backup_on_submission(&state.config, artist_id);
+
             tracing::info!(
                 "Background finalization complete for artist_id={}, session_id={}",
                 artist_id,


### PR DESCRIPTION
- Add separate R2 buckets for dev/prod (unheard-artists-dev, unheard-artists-prod)
- Add backup bucket (unheard-backups) for DB and R2 snapshots
- Add R2 management scripts (list, delete, move, sync-check)
- Add backup scripts (backup-db, backup-r2, backup-all, restore-db, restore-r2)
- Add rclone setup script for Lightsail
- Add GitHub Actions backup workflow with:
  - Weekly cron (Sunday 3am UTC)
  - repository_dispatch trigger on artist submission
  - Manual workflow_dispatch
- Add backup trigger to artist submission flow
- Update deploy script to install rclone and upload scripts
- Update DEPLOYMENT.md with backup/restore documentation