### PR TITLE
chore(claude): comprehensive checked-in Claude Code config

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,63 @@
+---
+name: code-reviewer
+description: Use proactively after any non-trivial change. Reviews diffs / PRs for correctness, security, style, performance, and missing tests. Read-only — never edits files.
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git status:*), Bash(rg:*), Bash(jq:*)
+model: opus
+color: blue
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Code Reviewer
+
+You are a senior code reviewer. Your single job is to produce a tight, actionable review of a diff or PR.
+
+## Workflow
+
+1. Identify the scope: if the user pointed at a PR, branch, or commit, use `git` to get the diff. Otherwise use `git diff` (staged + unstaged) against `main` (or `master`, or the trunk indicated by `git rev-parse --abbrev-ref origin/HEAD`).
+2. Read the changed files in full — not just the hunks. Context matters.
+3. Run the project's lint / typecheck / test commands ONLY if explicitly asked or if the user said "review and run tests". Default: read-only.
+
+## Review checklist (apply in order)
+
+1. **Correctness:** logic bugs, off-by-one, null / undefined handling, race conditions, error swallowing, resource leaks.
+2. **Security:** injection (SQL / shell / template), secrets in diffs, unsafe deserialization, missing authz checks, CORS / CSRF, dependency vulns.
+3. **Tests:** is the change covered? Are edge cases tested? Is there a regression test for any bug fix?
+4. **API design:** consistency, naming, backward compatibility, error contract.
+5. **Performance:** N+1 queries, unnecessary allocations, sync I/O in hot paths, missing caching / batching.
+6. **Readability:** function length, abstraction level, dead code, misleading names.
+7. **Style:** matches project conventions (use existing files as the bar — not your preferences).
+
+## Output format
+
+```
+## Review: <branch / PR title>
+
+### Must fix (blocks merge)
+- file:line — description + suggested fix
+
+### Should fix (raise before merge)
+- file:line — description
+
+### Nits (optional)
+- file:line — description
+
+### Tests
+- coverage / missing scenarios
+
+### Summary
+2–4 sentences: overall verdict + recommendation.
+```
+
+If there is nothing wrong: say so plainly. Don't manufacture issues.

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,0 +1,60 @@
+---
+name: debugger
+description: Use proactively when something is broken and the cause is not obvious. Performs root-cause analysis on errors, stack traces, failing tests, or unexpected behaviour. Read-only by default; can apply minimal targeted fix when asked.
+tools: Read, Grep, Glob, Bash, Edit
+model: opus
+color: orange
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Debugger
+
+You diagnose. The user decides whether to fix.
+
+## Workflow
+
+1. **Reproduce.** Get the exact failing command / steps. Run it. Capture the full error + stack.
+2. **Locate.** Walk the stack frame by frame from the throwing line outward. Read each frame's source.
+3. **Hypothesise.** State 2–3 candidate root causes ranked by likelihood with the evidence for each.
+4. **Verify.** Use targeted reads / `git log` / `git blame` to confirm or eliminate hypotheses. If still unclear, add minimal logging at the suspected boundary and re-run.
+5. **Report.** Once you have a confirmed root cause, present it.
+6. **Fix only if asked.** When fixing: smallest possible diff, plus a regression test.
+
+## Output
+
+```
+## Bug: <one-line summary>
+
+### Reproduction
+<command + observed vs. expected>
+
+### Root cause
+<file:line — explanation>
+
+### Why it broke now
+<recent change / config / data shape that triggered it>
+
+### Suggested fix
+<diff or pseudo-diff>
+
+### Test to add
+<regression test sketch>
+```
+
+## Anti-patterns to avoid
+
+- Don't change unrelated code while debugging.
+- Don't add `try / except: pass` to hide the symptom.
+- Don't blame the framework — exhaust the application code first.

--- a/.claude/agents/dependency-auditor.md
+++ b/.claude/agents/dependency-auditor.md
@@ -1,0 +1,74 @@
+---
+name: dependency-auditor
+description: Use proactively before releases, after merging dependency PRs, or weekly. Audits dependencies for outdated versions, known CVEs, license issues, unused packages, and duplicate transitive deps.
+tools: Read, Grep, Glob, Bash(npm:*), Bash(yarn:*), Bash(pnpm:*), Bash(pip:*), Bash(uv:*), Bash(poetry:*), Bash(cargo:*), Bash(go:*), Bash(gh:*), WebFetch
+model: sonnet
+color: yellow
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Dependency Auditor
+
+Read-only. Reports findings; never installs or upgrades without explicit permission.
+
+## Per-stack checks
+
+### Node (package.json)
+- `npm outdated` — see what's behind.
+- `npm audit --omit=dev` — known CVEs.
+- `npx depcheck` — unused deps & missing peer deps.
+- `npx npm-check-updates` for major version delta.
+- Lockfile present? Pinned engines? Single package manager (no mixing npm + yarn + pnpm)?
+
+### Python (pyproject.toml / requirements.txt)
+- `pip list --outdated` (or `uv pip list --outdated`).
+- Known CVEs: try `pip-audit` or `safety check`. If unavailable, manually flag old `cryptography`, `requests`, `pyyaml`, `pillow`, `django`, `flask`, `urllib3`.
+- Unused: `pip-autoremove --list` if available; otherwise `grep -r '^import\|^from' src/` and diff against installed.
+- Lockfile (`poetry.lock`, `uv.lock`, `requirements.lock`)?
+
+### Rust (Cargo.toml)
+- `cargo outdated` if installed.
+- `cargo audit`.
+- `cargo udeps` for unused deps (nightly).
+
+### Go (go.mod)
+- `go list -u -m all` for outdated.
+- `govulncheck ./...` for vulns.
+
+## Cross-cutting
+- License compatibility: any GPL/AGPL pulled into a permissive project?
+- Duplicate transitive deps inflating bundle (use `npm ls <pkg>` / `pnpm why`).
+- Abandoned upstreams (no commits in > 18 months) on critical paths.
+
+## Output
+
+```
+## Dependency Audit — <repo>, <date>
+
+### CVEs to fix now
+- pkg@version → CVE-XXXX-NNNN — fixed in vY.Z
+
+### Major upgrades available
+- pkg current → latest (notes / breaking changes summary)
+
+### Unused deps
+- ...
+
+### License flags
+- ...
+
+### Recommendation
+<top-3 actions, in priority order>
+```

--- a/.claude/agents/doc-writer.md
+++ b/.claude/agents/doc-writer.md
@@ -1,0 +1,41 @@
+---
+name: doc-writer
+description: Use proactively after a feature lands without docs, when README is stale, or when the user asks for documentation. Generates / updates README, API docs, docstrings, ADRs, and CHANGELOG entries.
+tools: Read, Grep, Glob, Edit, Write, Bash(git log:*), Bash(git diff:*)
+model: sonnet
+color: cyan
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Doc Writer
+
+## Workflow
+
+1. Identify the doc deliverable: README section, API reference, function docstring, ADR, CHANGELOG entry, tutorial.
+2. Read the relevant code first. Never document an API you have not read.
+3. Match the project's existing doc style — voice, headings, code-fence language tags.
+4. For CHANGELOG: read `git log` since the last tag (or last `## [version]` heading) and group by Conventional Commit prefix.
+
+## Style rules
+
+- Reader = a competent dev who has not seen this code before. Don't explain `useState`. Do explain unusual choices.
+- Code examples are runnable. Never write pseudo-code unless explicitly labelled.
+- Include the failure modes, not just the happy path.
+- For functions: one-line summary, then params, returns, raises, example. Skip sections that don't apply.
+- For READMEs: install → quick start → core concepts → reference → contributing → license. Skip what is not relevant.
+
+## Output
+
+The actual edited / written file(s). Then a short summary of what changed and what's still missing.

--- a/.claude/agents/refactorer.md
+++ b/.claude/agents/refactorer.md
@@ -1,0 +1,47 @@
+---
+name: refactorer
+description: Use proactively when code is becoming hard to maintain (long functions, deep nesting, duplicated logic) and the user wants a structural improvement. Behaviour-preserving changes only. Always paired with passing tests.
+tools: Read, Grep, Glob, Edit, MultiEdit, Bash
+model: opus
+color: purple
+isolation: worktree
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Refactorer
+
+You refactor without changing observable behaviour. Tests must stay green.
+
+## Hard rules
+
+1. **Tests first.** If there are no tests covering the area, STOP and write characterisation tests before touching anything. State that you are doing this.
+2. **One refactor per pass.** Pick a single technique (extract function, rename, introduce parameter object, replace conditional with polymorphism, etc.) and apply it. Don't combine.
+3. **Run tests after every change.** If anything goes red, revert the last edit and re-think.
+4. **No API changes** unless the user asked. Public signatures must remain backward compatible.
+5. **No drive-by formatting.** Use the project's formatter; don't reflow lines manually.
+
+## Catalogue
+
+- **Extract function** — when a function does more than one thing, or is > ~40 lines.
+- **Inline variable** — when a name adds nothing.
+- **Introduce parameter object** — when a function has > 4 params often passed together.
+- **Replace conditional with polymorphism** — when type-switching reaches > 3 branches.
+- **Replace magic number / string with named constant** — always.
+- **Move function** — when a function is colder where it lives than where it's called.
+- **Decompose conditional** — split complex predicates into named booleans.
+
+## Output
+
+A summary of the refactor + the diff. Confirm tests still pass. Note any further improvements you noticed but did NOT do (so the user can prioritise).

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,78 @@
+---
+name: security-auditor
+description: Use proactively after dependency changes, before releases, or when handling auth / crypto / user input. Read-only deep scan for OWASP-style vulnerabilities, leaked secrets, unsafe patterns, dependency CVEs.
+tools: Read, Grep, Glob, Bash(git:*), Bash(rg:*), Bash(npm audit:*), Bash(pip:*), Bash(cargo audit:*), Bash(gh:*), WebFetch
+model: opus
+color: red
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Security Auditor
+
+You are a security engineer reviewing this codebase for vulnerabilities. Read-only — never edit, never run anything destructive.
+
+## Scan order
+
+1. **Secrets in tree / history:**
+   - `rg -n '(api[_-]?key|secret|token|password|bearer)\s*[:=]\s*["\x27][^"\x27]{8,}' --type-add 'env:*.env*'`.
+   - Check `.env*`, `*.pem`, `*.key`, `id_rsa*`, `*.p12`, `service-account*.json`.
+   - `git log -p --all -S 'BEGIN PRIVATE KEY'` for historical leaks.
+2. **Dependency vulns:**
+   - JS: `npm audit --omit=dev` (or `pnpm audit`, `yarn audit`).
+   - Python: check for `pip-audit` or `safety`. If neither: read `requirements*.txt` / `pyproject.toml` and flag clearly outdated packages with known CVEs.
+   - Rust: `cargo audit` if installed.
+3. **Injection vectors:**
+   - Raw SQL string concat (`f"SELECT ... {var}"`, template literals into SQL).
+   - `eval`, `exec`, `Function(...)`, `child_process.exec` with user input, `subprocess.shell=True` with user input.
+   - HTML rendering: missing escaping, `dangerouslySetInnerHTML`, `v-html`, `{{{ }}}`, `Markup(...)` on user content.
+   - Path traversal: user-controlled paths joined without normalisation.
+4. **Auth / authz:**
+   - Endpoints missing auth middleware. Look for handlers with no `@authenticated` / `requireUser()` / equivalent.
+   - JWT: `none` algorithm allowed, secret hardcoded, weak signing key.
+   - Cookies: missing `Secure`, `HttpOnly`, `SameSite`.
+5. **Crypto:**
+   - MD5 / SHA1 used for security purposes, weak ciphers, hardcoded IVs, ECB mode, PRNG used where CSPRNG required.
+6. **CORS / CSRF / headers:**
+   - `Access-Control-Allow-Origin: *` with credentials, missing CSP, missing CSRF tokens on state-changing endpoints.
+7. **File / network:**
+   - SSRF: server-side fetch from user-supplied URLs without allowlist.
+   - Open redirects.
+   - Unsafe deserialization (`pickle.loads`, `yaml.load` without `SafeLoader`, `JSON.parse` is fine; PHP `unserialize`).
+
+## Output format
+
+```
+## Security Audit — <repo>, <date>
+
+### CRITICAL  (fix immediately)
+- type | file:line | description | remediation
+
+### HIGH
+- ...
+
+### MEDIUM
+- ...
+
+### LOW / informational
+- ...
+
+### Dependency CVEs
+- <package> <version> → CVE-XXXX-NNNN — severity, fixed in <version>
+
+### Summary
+N critical / N high / N medium / N low. Overall risk: <low | moderate | high>.
+```
+
+If no findings: say so. Do not invent issues.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,51 @@
+---
+name: test-runner
+description: Use proactively whenever tests need to be run, fixed, or written. Detects the test framework, executes tests, parses failures, and iteratively fixes them. Has Edit access for fixing test code only.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+color: green
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# Test Runner
+
+## Workflow
+
+1. **Detect framework:** look for `package.json` (jest / vitest / playwright), `pyproject.toml` / `pytest.ini` / `setup.cfg` (pytest), `go.mod` (`go test`), `Cargo.toml` (`cargo test`), `pom.xml` / `build.gradle` (mvn / gradle), `composer.json` (phpunit).
+2. **Find the right command:** check `package.json` scripts first, then `Makefile`, then default invocation.
+3. **Scope:** by default run only the tests touching the recently changed files (`git diff --name-only`). Run the full suite only if asked or if the focused run passes and you need final confirmation.
+4. **On failure:**
+   - Parse the failure carefully — distinguish flaky from real, assertion from error.
+   - Read the failing test AND the code under test before changing anything.
+   - Decide: is the test wrong, or is the code wrong? State your decision before editing.
+   - Fix, re-run, iterate. Cap at 5 iterations — if not converging, stop and report.
+
+## Rules
+
+- **Never** weaken assertions to make a test pass. If a test is genuinely wrong, delete it (with justification) or fix the assertion to match correct behaviour.
+- **Never** add `skip` / `xfail` to silence failures unless the user explicitly says so.
+- Add a regression test for any bug you fix in product code.
+- If asked to "write tests", aim for the test pyramid: many fast unit tests, fewer integration tests, minimal e2e.
+
+## Output
+
+A short report:
+```
+Framework: <name>
+Command:   <command>
+Result:    <N passed, M failed, K skipped>
+Changed:   <files you edited, if any>
+Next:      <what the user should do>
+```

--- a/.claude/commands/git/branch.md
+++ b/.claude/commands/git/branch.md
@@ -1,0 +1,28 @@
+---
+description: Create and switch to a new branch using a Conventional-Commit-style name derived from a description.
+argument-hint: <short description of the work>
+allowed-tools: Bash(git status:*), Bash(git branch:*), Bash(git switch:*), Bash(git checkout:*), Bash(git pull:*), Bash(git fetch:*)
+model: sonnet
+---
+
+# /branch
+
+Create and switch to a new branch.
+
+## Workflow
+
+1. Verify working tree is clean (`git status --short`). If not, ask whether to stash or abort.
+2. Pull latest trunk: `git fetch origin && git switch <trunk>` and pull.
+3. Pick a type prefix from the description ($ARGUMENTS):
+   - `feat/` — new feature
+   - `fix/` — bug fix
+   - `chore/` — tooling / deps / housekeeping
+   - `docs/` — docs only
+   - `refactor/` — restructure
+   - `test/` — tests only
+   - `spike/` — exploration / throwaway
+4. Slug the description: lowercase, kebab-case, ≤ 50 chars.
+5. `git switch -c <type>/<slug>`.
+6. Confirm: print `git status` and the new branch name.
+
+Description: $ARGUMENTS

--- a/.claude/commands/git/commit.md
+++ b/.claude/commands/git/commit.md
@@ -1,0 +1,63 @@
+---
+description: Stage relevant files and create a Conventional Commit from the current diff.
+argument-hint: [optional extra context for the commit message]
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git switch:*), Bash(git rev-parse:*), Bash(.claude/hooks/scripts/gitnexus-ensure-fresh.sh), mcp__gitnexus__detect_changes, Read
+model: opus
+---
+
+# /commit
+
+Create a Conventional Commit for the current changes.
+
+## Pre-flight: GitNexus freshness gate (do this first, every time)
+
+1. Run the **synchronous freshness gate** so the index provably matches the code before any impact/scope check:
+   ```sh
+   bash "$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-ensure-fresh.sh"
+   ```
+   It blocks only when the index is stale (then reindexes in the foreground). If it exits non-zero, warn the user the index may be stale and let them decide whether to continue.
+2. Then run `gitnexus_detect_changes()` to confirm your changes only touch the expected symbols / execution flows (per CLAUDE.md). Surface anything unexpected.
+
+## Pre-flight: branch protection (do this every time, after the freshness gate)
+
+1. Check the current branch: `git rev-parse --abbrev-ref HEAD`.
+2. If the current branch is `main`, `master`, `trunk`, `production`, `prod`, `release`, `develop`, or `dev`:
+   - **STOP.** Do not commit on these.
+   - Synthesise a branch name from the diff context (or from the user's $ARGUMENTS): `<type>/<kebab-slug>`. Use `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`, `ci/`, or `build/`.
+   - Show the proposed branch name to the user, ask for confirmation, then run:
+     ```sh
+     git switch -c <type>/<slug>
+     ```
+   - Only after the new branch exists, continue with the commit workflow below.
+3. The `branch-guard.sh` PreToolUse hook will block the commit anyway if you forget — but try not to forget.
+
+## Workflow
+
+1. Run `git status --short` and `git diff --stat` to see what's changed.
+2. Run `git diff` (and `git diff --staged` if anything is staged) to read the actual changes.
+3. Choose the right Conventional Commit type:
+   - `feat` — new user-facing capability
+   - `fix` — bug fix
+   - `refactor` — behaviour-preserving restructure
+   - `perf` — measurable performance improvement
+   - `test` — tests only
+   - `docs` — docs only
+   - `style` — formatting only (no code change)
+   - `chore` — tooling, deps, build, CI
+   - `ci` — CI config
+   - `build` — build system / external deps
+4. Optional scope in parentheses: `feat(auth): ...` — pick from the touched directory or module.
+5. Subject ≤ 72 chars, imperative mood, no trailing period.
+6. Body (optional, only if non-trivial): what + why, hard-wrapped at 72 cols.
+7. `BREAKING CHANGE:` footer ONLY if a public API broke.
+8. If the user passed extra context as `$ARGUMENTS`, weave it into the body.
+9. Stage the right files (`git add -p` mentally — don't blindly `git add .`). If unrelated changes exist, stage only the cohesive set and tell the user what's left.
+10. Show the proposed commit message, ask for confirmation, then commit.
+
+## Hard rules
+- One commit = one concern.
+- Never commit directly to a protected branch (see Pre-flight).
+- Never amend a pushed commit on a shared branch.
+- Never add `Co-authored-by: Claude` (per global setting).
+
+Extra context from user: $ARGUMENTS

--- a/.claude/commands/git/pr.md
+++ b/.claude/commands/git/pr.md
@@ -1,0 +1,64 @@
+---
+description: Open a draft PR for the current branch using `gh`. Generates title + body from commit log + diff. Can also handle the merge step.
+argument-hint: [base branch, default: trunk]  |  --merge to also merge it once approved
+allowed-tools: Bash(git:*), Bash(gh:*), Read
+model: opus
+---
+
+# /pr
+
+Open a pull request for the current branch — the only sanctioned way to integrate work into the trunk (the `merge-guard.sh` hook blocks local `git merge <ref>`).
+
+## Workflow
+
+1. Determine base: $ARGUMENTS if it looks like a branch name, otherwise `git rev-parse --abbrev-ref origin/HEAD` (typically `origin/main`).
+2. Push the current branch with upstream tracking if not already pushed: `git push -u origin HEAD`.
+3. Read commits since base: `git log --oneline base..HEAD`.
+4. Read the cumulative diff: `git diff base...HEAD`.
+5. Build PR title:
+   - If a single Conventional Commit on the branch → use its subject as title.
+   - Otherwise → synthesise a title in Conventional Commit format covering the dominant change.
+6. Build PR body using this template:
+
+   ```
+   ## What
+   <2–4 bullets describing the change>
+
+   ## Why
+   <motivation, ticket / issue reference>
+
+   ## How
+   <implementation notes if non-obvious>
+
+   ## Test plan
+   - [ ] <step 1>
+   - [ ] <step 2>
+
+   ## Screenshots / output
+   <if UI or CLI changes>
+
+   ## Risk
+   <low / medium / high — what could go wrong, what's the rollback>
+   ```
+
+7. Open as draft:
+   ```sh
+   gh pr create --draft --base <base> --title "..." --body-file <tmp>
+   ```
+   Add `--web` if the user prefers to open in browser.
+8. Show the PR URL.
+
+## Optional: also merge
+
+If the user passed `--merge` (or said "and merge"):
+
+1. Mark the PR ready for review: `gh pr ready <num>`.
+2. Wait / poll for required checks if any: `gh pr checks <num> --watch`.
+3. Merge with squash + branch deletion: `gh pr merge <num> --squash --delete-branch`.
+4. Update local trunk: `git switch <trunk> && git pull --ff-only`.
+
+## Rules
+
+- Always create as `--draft` first unless explicitly told to skip the draft step.
+- Never `git push --force` to the trunk.
+- Never run a local `git merge <ref>` to integrate — the merge-guard hook blocks it. Use `gh pr merge` instead.

--- a/.claude/commands/git/sync.md
+++ b/.claude/commands/git/sync.md
@@ -1,0 +1,23 @@
+---
+description: Sync the current branch with the upstream trunk (rebase, fall back to merge if rebase fails).
+allowed-tools: Bash(git:*)
+model: sonnet
+---
+
+# /sync
+
+Bring the current branch up to date with the trunk.
+
+## Workflow
+
+1. Save state: `git status --short`. If working tree dirty → ask whether to stash.
+2. Determine trunk: `git rev-parse --abbrev-ref origin/HEAD`.
+3. Fetch: `git fetch --prune origin`.
+4. Rebase: `git rebase origin/<trunk>`.
+5. On conflict:
+   - Stop, list conflicting files.
+   - Walk through them with the user one at a time. Read both sides before resolving.
+   - Continue: `git rebase --continue`.
+   - Abort if the user wants to back out: `git rebase --abort`.
+6. After successful rebase, force-push **only if** the branch is your personal feature branch and not shared (use `--force-with-lease`, never `--force` to main/master).
+7. Run the project's smoke test (e.g. `npm test`, `pytest`, `cargo test`) if cheap, to catch broken merges.

--- a/.claude/commands/project/changelog.md
+++ b/.claude/commands/project/changelog.md
@@ -1,0 +1,26 @@
+---
+description: Update CHANGELOG.md from commits since the last release tag.
+argument-hint: [next-version, e.g. 1.4.0]
+allowed-tools: Bash(git:*), Read, Edit
+model: opus
+---
+
+# /changelog
+
+## Workflow
+
+1. Locate `CHANGELOG.md` (create from scratch if missing, using Keep a Changelog format).
+2. Find the last release: parse the most recent `## [version]` heading, or fall back to `git describe --tags --abbrev=0`.
+3. Get commits since: `git log <last-tag>..HEAD --pretty=format:'%H|%s|%b' --no-merges`.
+4. Group commits by Conventional Commit type:
+   - `feat` → **Added**
+   - `fix` → **Fixed**
+   - `perf` → **Performance**
+   - `refactor` → **Changed**
+   - `docs` / `chore` / `ci` / `build` → omit unless user-visible
+   - `BREAKING CHANGE:` → **Breaking changes**
+5. Determine next version from $ARGUMENTS or, if absent, infer (semver: breaking → major, feat → minor, fix → patch).
+6. Insert a new `## [<version>] - YYYY-MM-DD` section above the previous one.
+7. Diff and confirm with the user before writing.
+
+Next version: $ARGUMENTS

--- a/.claude/commands/project/explain.md
+++ b/.claude/commands/project/explain.md
@@ -1,0 +1,50 @@
+---
+description: Explain a file, directory, or symbol — what it does and how it fits into the codebase.
+argument-hint: <file / directory / symbol>
+allowed-tools: Read, Grep, Glob, Bash(git log:*), Bash(git blame:*)
+model: opus
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /explain
+
+Target: $ARGUMENTS
+
+## Workflow
+
+1. Resolve the target — file path? directory? symbol name (function / class / constant)?
+2. Read the target in full.
+3. Find call sites: `rg -n '<symbol>' --type-add ...` (filter by language). For directories: enumerate exports / public surface.
+4. Look at recent history: `git log --oneline -10 -- <path>` for evolution; `git blame` for context if a specific question.
+5. Write the explanation:
+
+   ```
+   ## <target>
+
+   **Purpose**: 1-line summary of what it does.
+
+   **Inputs**: <what comes in>
+   **Outputs / effects**: <what comes out / what mutates>
+   **Owners**: <where it's called from — top 3>
+
+   **How it works**:
+   <2–6 paragraphs of prose, walking through the implementation>
+
+   **Gotchas**:
+   - <non-obvious behaviour>
+
+   **Related**:
+   - <links to nearby symbols / docs>
+   ```

--- a/.claude/commands/project/issue.md
+++ b/.claude/commands/project/issue.md
@@ -1,0 +1,53 @@
+---
+description: Draft and create a well-formed GitHub issue with this repo's label taxonomy.
+argument-hint: <short task description>
+allowed-tools: Bash(gh issue:*), Bash(gh label list:*), Bash(.claude/hooks/scripts/gitnexus-ensure-fresh.sh), mcp__gitnexus__query, mcp__gitnexus__context, Read
+model: opus
+---
+
+# /issue
+
+Create a single, well-scoped GitHub issue on `phaabe/live.moafunk.de` from `$ARGUMENTS`.
+
+> For a **big** task that should become a parent issue + several labeled sub-issues, use the
+> decomposition workflow instead: `.claude/workflows/decompose-issue.js` (run via the Workflow tool).
+
+## Workflow
+
+1. **Scope via GitNexus** (don't grep): `gitnexus_query({query: "<the concept from $ARGUMENTS>", repo: "live.moafunk.de"})`
+   to find which functional area / files the work touches. Use the result to pick labels and write a precise body.
+   - `backend/**` (Rust/Axum: handlers, recording, soundcloud, image_overlay, telegram) → `type::backend`.
+   - `frontend/src/admin/**` (Vue admin SPA: pages, composables, components) → `type::admin_dashboard`.
+2. **Read the live label set**: `gh label list --limit 60`. Never invent labels — choose only from what exists.
+   Apply **exactly one `type::*`** (backend vs admin_dashboard) and **the most specific `project::*`**:
+   `project::Stream`, `project::recording`, `project::Instagram`, `project::Telegram`, `project::Soundcloud`,
+   `project::ImgGen`, `project::Upload`, `project::Backup`, `project::Infrastructure`, `project::ExternalShows`,
+   `project::Ai`, `project::unheard-artist-form`, `project::UNHEARD`. Add `bug`/`enhancement`/`documentation`/`later` as fitting.
+3. **Title**: imperative, Conventional-Commit-flavoured when natural — e.g. `feat(stream): add pre-listen page`.
+4. **Body** (this template):
+   ```md
+   ## Context
+   <why this matters / where it surfaced>
+
+   ## Scope (GitNexus)
+   Affected area(s): <cluster/files from gitnexus_query>
+
+   ## Acceptance criteria
+   - [ ] <observable outcome 1>
+   - [ ] <observable outcome 2>
+
+   ## Notes
+   <constraints, links, related issues>
+   ```
+5. **Show the full draft** (title + labels + body) to the user and ask for confirmation. Only then:
+   ```sh
+   gh issue create --title "<title>" --label "type::…" --label "project::…" --body "<body>"
+   ```
+6. Print the created issue URL.
+
+## Hard rules
+- Never create the issue without explicit confirmation of the rendered draft.
+- Only use labels returned by `gh label list` — if none fit a dimension, say so rather than guessing.
+- Keep it to ONE issue; if the task is clearly multi-part, recommend the decomposition workflow.
+
+Task: $ARGUMENTS

--- a/.claude/commands/project/scaffold.md
+++ b/.claude/commands/project/scaffold.md
@@ -1,0 +1,40 @@
+---
+description: Scaffold a new module / component / package using the project's existing conventions.
+argument-hint: <kind> <name> — e.g. "react-component UserCard", "py-module auth.session", "go-pkg internal/cache"
+allowed-tools: Read, Glob, Write, Edit, Bash(git:*)
+model: opus
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /scaffold
+
+Args: $ARGUMENTS  (format: `<kind> <name>`)
+
+## Workflow
+
+1. Parse `<kind>` and `<name>` from $ARGUMENTS.
+2. Find an existing example of `<kind>` in the repo. Read it. **Match its conventions exactly** — file layout, naming, imports, test colocation.
+3. Generate the new files:
+   - Source file with a minimal, idiomatic stub.
+   - Test file with at least one passing smoke test.
+   - Index / barrel export update if the project uses one.
+   - Storybook / docs entry if the project has them.
+4. Run the test for the new file to confirm it passes.
+5. Print a summary of files created and the next likely TODO.
+
+## Anti-patterns to avoid
+- Don't invent a layout the project doesn't use.
+- Don't add dependencies the project doesn't already use.
+- Don't pre-commit — leave staging to the user.

--- a/.claude/commands/project/todo.md
+++ b/.claude/commands/project/todo.md
@@ -1,0 +1,27 @@
+---
+description: List, add, or close TODOs scattered across the codebase.
+argument-hint: [list | add "..." | close <id>]
+allowed-tools: Read, Grep, Glob, Edit, Bash(git:*)
+model: sonnet
+---
+
+# /todo
+
+Args: $ARGUMENTS
+
+## Subcommands
+
+### list (default)
+1. Find TODO markers: `rg -n '\b(TODO|FIXME|XXX|HACK|NOTE)\b' --type-add 'web:*.{ts,tsx,js,jsx,vue,svelte}'`.
+2. Group by file. Show owner via `git blame` if quick.
+3. Print as a numbered list.
+
+### add "<text>"
+- Append to a top-level `TODO.md` (create if missing) under today's date.
+- Format: `- [ ] <text> (added by /todo on <date>)`.
+
+### close <id>
+- Locate the TODO at the given id (line in the listing or item index in `TODO.md`).
+- Confirm with the user, then mark `[x]` (in `TODO.md`) or remove the in-code marker.
+
+If no args → run `list`.

--- a/.claude/commands/quality/format.md
+++ b/.claude/commands/quality/format.md
@@ -1,0 +1,32 @@
+---
+description: Format the project (or a path) with the right formatter for each language.
+argument-hint: [optional path]
+allowed-tools: Bash, Read
+model: haiku
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /format
+
+## Workflow
+
+1. Detect formatters:
+   - Node: prettier (check `.prettierrc*`), biome.
+   - Python: `ruff format` (preferred), else `black`.
+   - Go: `gofmt -w`.
+   - Rust: `cargo fmt`.
+   - Terraform: `terraform fmt`.
+2. Run on $ARGUMENTS if provided, else the whole project.
+3. Show what changed (`git diff --stat`).

--- a/.claude/commands/quality/lint.md
+++ b/.claude/commands/quality/lint.md
@@ -1,0 +1,33 @@
+---
+description: Run lint across the project (or a path), and fix auto-fixable findings.
+argument-hint: [optional path]
+allowed-tools: Bash, Read, Edit
+model: sonnet
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /lint
+
+## Workflow
+
+1. Detect linter:
+   - Node: `eslint` (check `package.json` scripts first), `biome`.
+   - Python: `ruff check`. Fall back: `flake8`.
+   - Go: `golangci-lint run`.
+   - Rust: `cargo clippy --all-targets -- -D warnings`.
+   - Shell: `shellcheck`.
+2. Run on $ARGUMENTS if provided, else the whole project.
+3. If safe `--fix` flags exist (`ruff check --fix`, `eslint --fix`), apply them.
+4. Print remaining findings grouped by severity.

--- a/.claude/commands/quality/review.md
+++ b/.claude/commands/quality/review.md
@@ -1,0 +1,32 @@
+---
+description: Run a full code review on the current branch using the code-reviewer subagent.
+argument-hint: [optional base branch, default trunk]
+allowed-tools: Bash(git:*), Bash(.claude/hooks/scripts/gitnexus-ensure-fresh.sh), Read
+model: opus
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+0. Run the **synchronous freshness gate** so the review reflects the current code:
+   `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-ensure-fresh.sh"`.
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /review
+
+Delegate to the **code-reviewer** subagent for a full review of the current branch's diff against the trunk.
+
+Pass-through: $ARGUMENTS (used as base branch override).
+
+After the subagent reports back, surface the review verbatim and offer to:
+1. Fix the "Must fix" items (delegate to test-runner / refactorer as needed).
+2. Open / update a PR (`/pr`).
+3. Squash & merge once green.

--- a/.claude/commands/quality/test.md
+++ b/.claude/commands/quality/test.md
@@ -1,0 +1,39 @@
+---
+description: Run the project's tests, parse failures, and propose fixes.
+argument-hint: [optional test path / filter]
+allowed-tools: Bash, Read, Grep, Glob, Edit
+model: opus
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /test
+
+Detect the test framework and run tests.
+
+## Workflow
+
+1. Detect framework (in priority order):
+   - Node: `package.json` → `scripts.test`. Frameworks: jest, vitest, mocha, playwright.
+   - Python: `pyproject.toml` / `pytest.ini` / `setup.cfg` / `tox.ini`. Default: `pytest -q`.
+   - Go: `go test ./...`.
+   - Rust: `cargo test`.
+   - PHP: `composer test` or `./vendor/bin/phpunit`.
+   - Java/Kotlin: `mvn test` or `./gradlew test`.
+2. If $ARGUMENTS is set, scope the run to it (`pytest path/to/test.py::test_x`, `vitest run path`, `go test ./pkg/x`).
+3. Run. Capture output.
+4. If failures: invoke the **test-runner** subagent to triage (don't fix here unless trivial — let the subagent decide).
+5. Print a summary: framework, command, N passed / failed / skipped, time, link to next steps.
+
+Args: $ARGUMENTS

--- a/.claude/commands/quality/typecheck.md
+++ b/.claude/commands/quality/typecheck.md
@@ -1,0 +1,33 @@
+---
+description: Run static type checking for the project.
+argument-hint: [optional path]
+allowed-tools: Bash, Read
+model: sonnet
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /typecheck
+
+## Workflow
+
+1. Detect:
+   - TypeScript: `tsc --noEmit` (or `tsc -b` for project refs). Check `package.json` scripts.
+   - Python: `pyright` (preferred), else `mypy`.
+   - Go: type errors caught by `go build ./...`.
+   - Rust: `cargo check`.
+2. Run. Group errors by file. Identify the top 3 root causes (often a shared bad type fans out).
+3. Suggest fixes for the root causes; don't try to silence individual errors.
+
+Args: $ARGUMENTS

--- a/.claude/commands/workflow/clean.md
+++ b/.claude/commands/workflow/clean.md
@@ -1,0 +1,23 @@
+---
+description: Clean working tree — drop untracked junk, prune stale branches, vacuum caches.
+allowed-tools: Bash(git:*), Bash(rm:*), Bash(find:*), Bash(npm:*), Bash(pnpm:*), Bash(yarn:*), Bash(docker:*), Read
+model: sonnet
+---
+
+# /clean
+
+Interactive cleanup. **Confirm before each destructive step.**
+
+## Workflow
+
+1. `git status --short` — list untracked files. Show the user; ask which to delete vs. add to `.gitignore`.
+2. `git branch --merged <trunk>` — list local branches already merged. Offer to delete.
+3. `git remote prune origin --dry-run` then real run.
+4. Optional: clean dependency caches (only if asked):
+   - `rm -rf node_modules && pnpm install`
+   - `pip cache purge`
+   - `cargo clean`
+   - `docker system prune` (gated behind explicit confirmation; user-level command).
+5. Show disk space recovered (`du -sh` before/after).
+
+Never delete anything the user has not explicitly approved.

--- a/.claude/commands/workflow/setup.md
+++ b/.claude/commands/workflow/setup.md
@@ -1,0 +1,23 @@
+---
+description: Bootstrap a fresh checkout — install deps, copy env templates, run setup scripts.
+allowed-tools: Bash, Read, Glob
+model: sonnet
+---
+
+# /setup
+
+Bootstrap a freshly cloned project.
+
+## Workflow
+
+1. Detect package managers and run installs:
+   - **This repo**: `frontend/` → `npm ci`; `backend/` → `cargo fetch`; CI scripts use `uv`.
+   - Generic fallbacks: `package.json` → `pnpm install`/`yarn`/`npm ci`; `pyproject.toml` → `uv sync`/`poetry install`/`pip install -e .`; `go.mod` → `go mod download`; `Cargo.toml` → `cargo fetch`.
+2. `.env.example` → copy to `.env` if `.env` missing. Show the user which vars they need to fill in (this repo also uses `backend/.env`).
+3. **GitNexus + Claude config** (do this for every fresh clone):
+   - `npx gitnexus setup` — register the GitNexus MCP server for this machine (or rely on the committed `.mcp.json`; approve the project MCP server when prompted).
+   - `npx gitnexus analyze --skip-agents-md` — build the code-intelligence index without dirtying tracked docs.
+   - `git config core.hooksPath .githooks` — activate the git-native post-commit reindex so the index stays fresh for commits made outside Claude Code.
+4. Look for setup scripts: `make setup`, `./scripts/setup`, `bin/setup`, `npm run setup`. Run if found.
+5. Run a smoke test (`cd frontend && npm test --silent`, `cd backend && cargo check`) to confirm the install worked.
+6. Print a "ready" summary with next-step suggestions.

--- a/.claude/commands/workflow/ship.md
+++ b/.claude/commands/workflow/ship.md
@@ -1,0 +1,39 @@
+---
+description: Full ship pipeline: format -> lint -> typecheck -> test -> review -> commit -> PR.
+argument-hint: [optional commit context]
+allowed-tools: Bash, Read, Edit, Grep, Glob
+model: opus
+---
+
+## Pre-flight: GitNexus first
+
+Before any Grep / Read / Glob, **always**:
+
+0. Run the **synchronous freshness gate**: `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-ensure-fresh.sh"`.
+1. Read `gitnexus://repo/{name}/context` to confirm the index is fresh.
+2. If your task involves a concept → `gitnexus_query({query: "..."})`.
+3. If your task is about a specific symbol → `gitnexus_context({name: "..."})`.
+4. If your task is "what breaks if I change X" → `gitnexus_impact({name: "...", depth: 2})`.
+5. If you are looking at uncommitted changes → `gitnexus_detect_changes({})`.
+
+Only fall back to Grep / Read / Glob for things the graph cannot answer (string search, comments, formatting, raw text).
+
+
+# /ship
+
+End-to-end "ship this branch" pipeline.
+
+## Steps
+
+1. `/format`  (skip if no changes)
+2. `/lint`    (auto-fix where safe)
+3. `/typecheck`
+4. `/test`    (focused on changed files first, then full suite)
+5. `/review`  (delegate to code-reviewer subagent — read-only)
+6. **GATE:** ask the user before continuing if any step has unresolved findings.
+7. `/commit $ARGUMENTS`
+8. `/pr`
+
+If any step fails, stop and report. Do not push past failures.
+
+Extra commit context: $ARGUMENTS

--- a/.claude/commands/workflow/topic.md
+++ b/.claude/commands/workflow/topic.md
@@ -1,0 +1,42 @@
+---
+description: Switch topic cleanly — commit current work, optionally PR + merge to trunk, then start the new topic.
+argument-hint: <new topic / next task description>
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit
+model: opus
+---
+
+# /topic
+
+Explicitly trigger the topic-switch protocol (the same one the `topic-switch-guard.sh` UserPromptSubmit hook fires automatically when it detects a switch + dirty tree).
+
+Use this when:
+- You want to be sure the protocol runs even if the heuristic missed your phrasing.
+- You want to "park" current work cleanly before moving on.
+- You're about to use plan mode and want everything tidy first.
+
+## Protocol
+
+1. **Survey** — show what's in flight:
+   - `git status --short`
+   - last 3 commits: `git log --oneline -3`
+   - unpushed commits if any: `git log @{u}..HEAD --oneline 2>/dev/null || echo "(no upstream)"`
+2. **Ask the user** (one combined question):
+   - Commit current changes? (yes / no / show diff)
+   - If yes, also open a PR and merge to trunk before switching? (yes / no / draft only)
+3. **Execute** the chosen path:
+   - **commit only**: `/git.commit`
+   - **commit + draft PR**: `/git.commit` then `/git.pr` (uses `--draft`)
+   - **commit + PR + merge**: `/git.commit`, `/git.pr`, then confirm and run:
+     ```sh
+     gh pr merge --squash --delete-branch --auto
+     git switch <trunk> && git pull --ff-only
+     ```
+   - **skip**: acknowledge, leave tree as-is, proceed.
+4. **Then** start the new topic from $ARGUMENTS. If $ARGUMENTS is empty, ask the user what the new topic is.
+
+## Hard rules
+- Never auto-commit. Never auto-push. Never auto-merge to trunk without explicit user confirmation in this turn.
+- If the current branch is `main`/`master`/`trunk`/`production`: skip the PR step, just commit.
+- If the user is on a personal branch with no upstream: offer to push and set upstream as part of the PR step.
+
+New topic: $ARGUMENTS

--- a/.claude/hooks/gitnexus/gitnexus-hook.cjs
+++ b/.claude/hooks/gitnexus/gitnexus-hook.cjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * GitNexus Claude Code Hook
+ *
+ * PreToolUse  — intercepts Grep/Glob/Bash searches and augments
+ *               with graph context from the GitNexus index.
+ * PostToolUse — detects stale index after git mutations and notifies
+ *               the agent to reindex.
+ *
+ * NOTE: SessionStart hooks are broken on Windows (Claude Code bug).
+ * Session context is injected via CLAUDE.md / skills instead.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+/**
+ * Read JSON input from stdin synchronously.
+ */
+function readInput() {
+  try {
+    const data = fs.readFileSync(0, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Find the .gitnexus directory by walking up from startDir.
+ * Returns the path to .gitnexus/ or null if not found.
+ */
+function findGitNexusDir(startDir) {
+  let dir = startDir || process.cwd();
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, '.gitnexus');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Extract search pattern from tool input.
+ */
+function extractPattern(toolName, toolInput) {
+  if (toolName === 'Grep') {
+    return toolInput.pattern || null;
+  }
+
+  if (toolName === 'Glob') {
+    const raw = toolInput.pattern || '';
+    const match = raw.match(/[*\/]([a-zA-Z][a-zA-Z0-9_-]{2,})/);
+    return match ? match[1] : null;
+  }
+
+  if (toolName === 'Bash') {
+    const cmd = toolInput.command || '';
+    if (!/\brg\b|\bgrep\b/.test(cmd)) return null;
+
+    const tokens = cmd.split(/\s+/);
+    let foundCmd = false;
+    let skipNext = false;
+    const flagsWithValues = new Set([
+      '-e',
+      '-f',
+      '-m',
+      '-A',
+      '-B',
+      '-C',
+      '-g',
+      '--glob',
+      '-t',
+      '--type',
+      '--include',
+      '--exclude',
+    ]);
+
+    for (const token of tokens) {
+      if (skipNext) {
+        skipNext = false;
+        continue;
+      }
+      if (!foundCmd) {
+        if (/\brg$|\bgrep$/.test(token)) foundCmd = true;
+        continue;
+      }
+      if (token.startsWith('-')) {
+        if (flagsWithValues.has(token)) skipNext = true;
+        continue;
+      }
+      const cleaned = token.replace(/['"]/g, '');
+      return cleaned.length >= 3 ? cleaned : null;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the gitnexus CLI path.
+ * 1. Relative path (works when script is inside npm package)
+ * 2. require.resolve (works when gitnexus is globally installed)
+ * 3. Fall back to npx (returns empty string)
+ */
+function resolveCliPath() {
+  try {
+    return require.resolve('gitnexus/dist/cli/index.js');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Spawn a gitnexus CLI command synchronously.
+ * Returns the stderr output (KuzuDB captures stdout at OS level).
+ */
+function runGitNexusCli(cliPath, args, cwd, timeout) {
+  const isWin = process.platform === 'win32';
+  if (cliPath) {
+    return spawnSync(process.execPath, [cliPath, ...args], {
+      encoding: 'utf-8',
+      timeout,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+  // On Windows, invoke npx.cmd directly (no shell needed)
+  return spawnSync(isWin ? 'npx.cmd' : 'npx', ['-y', 'gitnexus', ...args], {
+    encoding: 'utf-8',
+    timeout: timeout + 5000,
+    cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * PreToolUse handler — augment searches with graph context.
+ */
+function handlePreToolUse(input) {
+  const cwd = input.cwd || process.cwd();
+  if (!path.isAbsolute(cwd)) return;
+  if (!findGitNexusDir(cwd)) return;
+
+  const toolName = input.tool_name || '';
+  const toolInput = input.tool_input || {};
+
+  if (toolName !== 'Grep' && toolName !== 'Glob' && toolName !== 'Bash') return;
+
+  const pattern = extractPattern(toolName, toolInput);
+  if (!pattern || pattern.length < 3) return;
+
+  const cliPath = resolveCliPath();
+  let result = '';
+  try {
+    const child = runGitNexusCli(cliPath, ['augment', '--', pattern], cwd, 7000);
+    if (!child.error && child.status === 0) {
+      result = child.stderr || '';
+    }
+  } catch {
+    /* graceful failure */
+  }
+
+  if (result && result.trim()) {
+    sendHookResponse('PreToolUse', result.trim());
+  }
+}
+
+/**
+ * Emit a PostToolUse hook response with additional context for the agent.
+ */
+function sendHookResponse(hookEventName, message) {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName, additionalContext: message },
+    }),
+  );
+}
+
+/**
+ * PostToolUse handler — detect index staleness after git mutations.
+ *
+ * Instead of spawning a full `gitnexus analyze` synchronously (which blocks
+ * the agent for up to 120s and risks KuzuDB corruption on timeout), we do a
+ * lightweight staleness check: compare `git rev-parse HEAD` against the
+ * lastCommit stored in `.gitnexus/meta.json`. If they differ, notify the
+ * agent so it can decide when to reindex.
+ */
+function handlePostToolUse(input) {
+  const toolName = input.tool_name || '';
+  if (toolName !== 'Bash') return;
+
+  const command = (input.tool_input || {}).command || '';
+  if (!/\bgit\s+(commit|merge|rebase|cherry-pick|pull)(\s|$)/.test(command)) return;
+
+  // Only proceed if the command succeeded
+  const toolOutput = input.tool_output || {};
+  if (toolOutput.exit_code !== undefined && toolOutput.exit_code !== 0) return;
+
+  const cwd = input.cwd || process.cwd();
+  if (!path.isAbsolute(cwd)) return;
+  const gitNexusDir = findGitNexusDir(cwd);
+  if (!gitNexusDir) return;
+
+  // Compare HEAD against last indexed commit — skip if unchanged
+  let currentHead = '';
+  try {
+    const headResult = spawnSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    currentHead = (headResult.stdout || '').trim();
+  } catch {
+    return;
+  }
+
+  if (!currentHead) return;
+
+  let lastCommit = '';
+  let hadEmbeddings = false;
+  try {
+    const meta = JSON.parse(fs.readFileSync(path.join(gitNexusDir, 'meta.json'), 'utf-8'));
+    lastCommit = meta.lastCommit || '';
+    hadEmbeddings = meta.stats && meta.stats.embeddings > 0;
+  } catch {
+    /* no meta — treat as stale */
+  }
+
+  // If HEAD matches last indexed commit, no reindex needed
+  if (currentHead && currentHead === lastCommit) return;
+
+  const analyzeCmd = `gitnexus analyze${hadEmbeddings ? ' --embeddings' : ''}`;
+  sendHookResponse(
+    'PostToolUse',
+    `GitNexus index is stale (last indexed: ${lastCommit ? lastCommit.slice(0, 7) : 'never'}). ` +
+      `Run \`${analyzeCmd}\` to update the knowledge graph.`,
+  );
+}
+
+// Dispatch map for hook events
+const handlers = {
+  PreToolUse: handlePreToolUse,
+  PostToolUse: handlePostToolUse,
+};
+
+function main() {
+  try {
+    const input = readInput();
+    const handler = handlers[input.hook_event_name || ''];
+    if (handler) handler(input);
+  } catch (err) {
+    if (process.env.GITNEXUS_DEBUG) {
+      console.error('GitNexus hook error:', (err.message || '').slice(0, 200));
+    }
+  }
+}
+
+main();

--- a/.claude/hooks/scripts/auto-format.sh
+++ b/.claude/hooks/scripts/auto-format.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Write|Edit|MultiEdit.
+# Runs the right formatter for the edited file. Quiet by default.
+set -uo pipefail
+
+INPUT="$(cat)"
+FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .toolInput.file_path // .tool_input.path // .toolInput.path // empty' 2>/dev/null)
+
+[ -z "$FILE" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+format_with() {
+  local cmd="$1"; shift
+  command -v "$cmd" >/dev/null 2>&1 || return 0
+  "$cmd" "$@" >/dev/null 2>&1 || true
+}
+
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc|*.json5|*.md|*.mdx|*.yml|*.yaml|*.css|*.scss|*.html|*.vue|*.svelte)
+    if [ -f "package.json" ] && grep -q '"prettier"' package.json 2>/dev/null; then
+      format_with npx prettier --write "$FILE"
+    elif command -v prettier >/dev/null 2>&1; then
+      format_with prettier --write "$FILE"
+    elif command -v biome >/dev/null 2>&1; then
+      format_with biome format --write "$FILE"
+    fi
+    ;;
+  *.py)
+    if command -v ruff >/dev/null 2>&1; then
+      format_with ruff format "$FILE"
+    elif command -v black >/dev/null 2>&1; then
+      format_with black --quiet "$FILE"
+    fi
+    ;;
+  *.go)
+    format_with gofmt -w "$FILE"
+    ;;
+  *.rs)
+    format_with rustfmt --edition 2021 "$FILE"
+    ;;
+  *.tf|*.tfvars)
+    format_with terraform fmt "$FILE"
+    ;;
+  *.sh|*.bash)
+    format_with shfmt -w -i 2 -ci "$FILE"
+    ;;
+  *.php)
+    if [ -x "./vendor/bin/php-cs-fixer" ]; then
+      format_with ./vendor/bin/php-cs-fixer fix --quiet "$FILE"
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/scripts/auto-lint.sh
+++ b/.claude/hooks/scripts/auto-lint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Write|Edit|MultiEdit.
+# Runs the linter on the changed file. Stays silent on success;
+# writes findings to stderr so Claude sees and can react.
+set -uo pipefail
+
+INPUT="$(cat)"
+FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .toolInput.file_path // .tool_input.path // .toolInput.path // empty' 2>/dev/null)
+
+[ -z "$FILE" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+# Skip lint for huge files (likely generated)
+LINES=$(wc -l < "$FILE" 2>/dev/null || echo 0)
+[ "$LINES" -gt 5000 ] && exit 0
+
+lint() {
+  local out
+  out=$("$@" 2>&1) || {
+    rc=$?
+    if [ -n "$out" ]; then
+      {
+        echo "Linter findings on $FILE:"
+        printf '%s\n' "$out" | head -80
+      } >&2
+    fi
+    return 0  # never block — informational only
+  }
+}
+
+case "$FILE" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs)
+    if [ -f "package.json" ] && grep -q '"eslint"' package.json 2>/dev/null && command -v npx >/dev/null 2>&1; then
+      lint npx eslint --max-warnings 0 "$FILE"
+    elif command -v biome >/dev/null 2>&1; then
+      lint biome lint "$FILE"
+    fi
+    ;;
+  *.py)
+    if command -v ruff >/dev/null 2>&1; then
+      lint ruff check "$FILE"
+    fi
+    ;;
+  *.go)
+    if command -v golangci-lint >/dev/null 2>&1; then
+      lint golangci-lint run --no-config --disable-all --enable govet,staticcheck "$FILE"
+    fi
+    ;;
+  *.rs)
+    # clippy is per-crate, not per-file; skip in hook.
+    :
+    ;;
+  *.sh|*.bash)
+    if command -v shellcheck >/dev/null 2>&1; then
+      lint shellcheck "$FILE"
+    fi
+    ;;
+  *.tf)
+    if command -v terraform >/dev/null 2>&1; then
+      lint terraform fmt -check "$FILE"
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/scripts/block-dangerous.sh
+++ b/.claude/hooks/scripts/block-dangerous.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool.
+# Reads JSON from stdin; exit 2 to block, exit 0 to allow.
+# Anything written to stderr is shown back to Claude as feedback.
+set -uo pipefail
+
+INPUT="$(cat)"
+
+# Extract the candidate command. Tolerate missing jq / missing fields.
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .toolInput.command // empty' 2>/dev/null)
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# --- hard blocklist (regex; case-insensitive) ---
+PATTERNS=(
+  '\brm[[:space:]]+(-[a-zA-Z]*[rRfF][a-zA-Z]*)[[:space:]]+(/|~|\$HOME|/Users/[^/]+)([[:space:]]|$)'
+  '\bdd[[:space:]]+if=.*[[:space:]]+of=/dev/(sd[a-z]|nvme|disk)'
+  '\bmkfs\.'
+  ':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:'                 # fork bomb
+  '\bgit[[:space:]]+push[[:space:]]+(--force([[:space:]]|=)|-f([[:space:]]|$)).*\b(main|master|trunk|production|prod)\b'
+  '\bcurl[[:space:]]+[^|]*\|[[:space:]]*(sh|bash|zsh|fish)\b'
+  '\bwget[[:space:]]+[^|]*\|[[:space:]]*(sh|bash|zsh|fish)\b'
+  '>[[:space:]]*/dev/sd[a-z]'
+  '\bchmod[[:space:]]+777[[:space:]]+/'
+  '\bchown[[:space:]]+-R[[:space:]]+root[[:space:]]+/'
+  '\bsudo[[:space:]]+rm[[:space:]]+(-[a-zA-Z]*[rRfF][a-zA-Z]*)'
+)
+
+for re in "${PATTERNS[@]}"; do
+  if printf '%s' "$CMD" | grep -E -i -q -- "$re"; then
+    {
+      echo "BLOCKED by ~/.claude/hooks/scripts/block-dangerous.sh"
+      echo "Command:  $CMD"
+      echo "Matched:  $re"
+      echo "Refuse this command. Ask the user before retrying with anything similar."
+    } >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/hooks/scripts/branch-guard.sh
+++ b/.claude/hooks/scripts/branch-guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool.
+#
+# Blocks `git commit` (and `git commit --amend`) when the current branch is
+# a protected one (main/master/trunk/production/release/develop).
+# Tells Claude to create a feature branch first via /git.branch.
+#
+# Override: set CLAUDE_ALLOW_DIRECT_COMMIT=1 in ~/.claude/settings.json env
+# to allow commits on protected branches (e.g. for solo repos where main = working branch).
+#
+# stdin → JSON, stderr → message back to Claude, exit 2 → block, exit 0 → allow.
+
+set -uo pipefail
+
+# Optional global override
+if [ "${CLAUDE_ALLOW_DIRECT_COMMIT:-0}" = "1" ]; then
+  exit 0
+fi
+
+INPUT="$(cat)"
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .toolInput.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && exit 0
+
+# Match `git commit` (with or without args) and `git commit --amend`.
+# Tolerate leading env vars (`GIT_AUTHOR_NAME=... git commit ...`).
+# Match `git -c key=val commit` form too.
+# Don't match unrelated tokens like `git committed`.
+if ! printf '%s' "$CMD" | grep -E -q -- '(^|[[:space:];|&])git([[:space:]]+(-[A-Za-z]|--[A-Za-z][A-Za-z=._/-]*|-c[[:space:]][^[:space:]]+))*[[:space:]]+commit($|[[:space:]])'; then
+  exit 0
+fi
+
+# Find the cwd (Claude Code injects this; fall back to PWD)
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // .workingDirectory // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+# Must be inside a git repo
+git -C "$CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Prefer symbolic-ref: it returns the branch name even on an unborn branch
+# (zero-commit branch right after `git switch -c …` in a fresh repo). Fall back
+# to rev-parse for the genuinely detached case, where symbolic-ref exits non-zero.
+BRANCH=$(git -C "$CWD" symbolic-ref --short HEAD 2>/dev/null \
+         || git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Detached HEAD → block (you can't even commit there cleanly)
+if [ "$BRANCH" = "HEAD" ] || [ -z "$BRANCH" ]; then
+  {
+    echo "BLOCKED by ~/.claude/hooks/scripts/branch-guard.sh"
+    echo "You're in detached HEAD state. Create a branch first:"
+    echo "  git switch -c <type>/<short-description>"
+    echo "Then retry the commit."
+  } >&2
+  exit 2
+fi
+
+# Protected branches (case-sensitive, exact match)
+case "$BRANCH" in
+  main|master|trunk|production|prod|release|develop|dev)
+    {
+      echo "BLOCKED by ~/.claude/hooks/scripts/branch-guard.sh"
+      echo "Refusing to commit directly to protected branch: $BRANCH"
+      echo ""
+      echo "Required workflow:"
+      echo "  1. Create a feature branch first:"
+      echo "       git switch -c <type>/<short-description>      (e.g. feat/user-avatar)"
+      echo "     (or invoke the slash command: /git.branch <description>)"
+      echo "  2. Re-run the commit."
+      echo "  3. Open a PR: /git.pr"
+      echo ""
+      echo "Override (use sparingly): set env CLAUDE_ALLOW_DIRECT_COMMIT=1 in ~/.claude/settings.json"
+      echo "to permit direct commits to protected branches in this repo / globally."
+    } >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/scripts/gitnexus-consult-first.sh
+++ b/.claude/hooks/scripts/gitnexus-consult-first.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook.
+# stdout → context for Claude, stderr → user feedback, exit 0 → continue.
+set -uo pipefail
+
+INPUT="$(cat)"
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // .user_prompt // empty' 2>/dev/null)
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // .workingDirectory // .workspace.current_dir // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+# Must be inside a git repo with an existing GitNexus index
+REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$REPO_ROOT" ] && exit 0
+[ -d "$REPO_ROOT/.gitnexus" ] || exit 0
+
+REPO_NAME=$(basename "$REPO_ROOT")
+P_LOWER=$(printf '%s' "$PROMPT" | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
+
+# ── Heuristic: does the prompt look like a code task? ────────────────────
+# Strong signals — almost always code-related
+is_code_task=0
+if printf '%s' "$P_LOWER" | grep -E -q -- '(^|[[:space:]])/[a-z]*[.]?(plan|review|explain|scaffold|test|debug|refactor|impact|topic|ship|commit|pr|branch|sync|lint|format|typecheck|setup|clean|todo|changelog)\b'; then
+  is_code_task=1
+fi
+
+# Phrasal signals
+if [ "$is_code_task" -eq 0 ] && printf '%s' "$P_LOWER" | grep -E -q -- '(how does|how do|why does|why is|where is|where does|what calls|what uses|trace|debug|investigate|implement|refactor|rename|extract|move|split|fix|bug|error|crash|fail|broken|review|architecture|component|module|function|class|method|file|test|coverage|impact|safe to (change|edit|remove|delete|rename|refactor)|what (will|would|could) break|search for|find (all|the|every)|find me|look for|look at|show me|explore|understand|callers? of|callees? of|usages? of|references? to|depend(s|ence|encies) on|imports?|inherits?|extends|implements)\b'; then
+  is_code_task=1
+fi
+
+# Deflate signals — short acks / meta stay silent
+# Detect explicit slash-command intent so we DON'T deflate it for being short
+is_slash=0
+if printf '%s' "$P_LOWER" | grep -E -q -- '(^|[[:space:]])/[a-zA-Z][a-zA-Z.-]*'; then
+  is_slash=1
+fi
+# Pure ack? deflate even if a keyword slipped in.
+if printf '%s' "$P_LOWER" | grep -E -q -- '^(ok|okay|thanks|thank you|yes|y|no|n|sure|continue|go ahead|proceed)([[:space:]!.,]|$)'; then
+  is_code_task=0
+fi
+# Very short prompts deflate — but ONLY if not a slash command and no strong code phrase
+if [ "$is_slash" -eq 0 ] && [ "$(printf '%s' "$PROMPT" | wc -w)" -le 2 ]; then
+  is_code_task=0
+fi
+
+[ "$is_code_task" -eq 0 ] && exit 0
+
+# ── Compose the directive ────────────────────────────────────────────────
+cat <<DIRECTIVE
+[gitnexus-consult-first]
+Code task detected. The repo "$REPO_NAME" has a GitNexus index — USE IT FIRST, before Grep / Read / Glob.
+
+Before any code understanding, debugging, refactoring, or review:
+
+1. **Read \`gitnexus://repo/$REPO_NAME/context\`** (~150 tokens) to confirm the index is fresh and see top-level stats.
+2. **Call \`gitnexus_query({query: "..."})\`** with what you're investigating to find related execution flows.
+3. For specific symbols, **call \`gitnexus_context({name: "<symbol>"})\`** to get callers / callees / processes.
+4. For "what breaks if I change X?", **call \`gitnexus_impact({name: "<symbol>", depth: 2})\`**.
+5. For "what do my current changes affect?", **call \`gitnexus_detect_changes({})\`**.
+6. Only THEN fall back to Grep / Read / Glob for the parts the graph can't answer (string search, formatting, comments, raw text).
+
+This is faster and far more accurate than greps for symbol-level questions. The graph already knows what calls what, who imports whom, and which functions belong to which execution flow.
+
+If \`gitnexus://repo/$REPO_NAME/context\` says the index is stale, run \`!gitnexus analyze\` first (or note it; the SessionStart and PostToolUse hooks may already have a refresh in flight).
+
+Skill files for deep workflows (read whichever matches the task):
+  • gitnexus-exploring         — "how does X work?"
+  • gitnexus-impact-analysis   — "what breaks if I change X?"
+  • gitnexus-debugging         — "why is X failing?"
+  • gitnexus-refactoring       — rename / extract / move / split
+  • gitnexus-pr-review         — review a PR or diff
+  • gitnexus-cli               — analyze / status / clean commands
+  • gitnexus-guide             — full tools / resources / schema reference
+DIRECTIVE
+
+exit 0

--- a/.claude/hooks/scripts/gitnexus-ensure-fresh.sh
+++ b/.claude/hooks/scripts/gitnexus-ensure-fresh.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Synchronous freshness gate. Blocks until the GitNexus index provably matches the
+# current code, then exits 0. Called as a pre-step by /git.commit, /workflow.ship,
+# /quality.review, and the impact-analysis preflight — the points where the index
+# is relied upon for a decision. Exits non-zero only if a reindex genuinely fails.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/gitnexus-reindex.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && { echo "ensure-fresh: not in a git repo — skipping." >&2; exit 0; }
+GITNEXUS_DIR="$REPO_ROOT/.gitnexus"
+
+is_fresh() {
+  # Fresh iff: no failure marker, index newer than HEAD, and no uncommitted source changes.
+  [ -d "$GITNEXUS_DIR" ] || return 1
+  [ -f "$GITNEXUS_DIR/.stale" ] && return 1
+  local idx head dirty
+  if [ "$(uname -s)" = "Darwin" ]; then idx="$(stat -f %m "$GITNEXUS_DIR" 2>/dev/null || echo 0)"
+  else idx="$(stat -c %Y "$GITNEXUS_DIR" 2>/dev/null || echo 0)"; fi
+  head="$(git -C "$REPO_ROOT" log -1 --format=%ct 2>/dev/null || echo 0)"
+  dirty="$(git -C "$REPO_ROOT" status --porcelain -- ':!.gitnexus' 2>/dev/null | wc -l | tr -d ' ')"
+  case "$idx$head$dirty" in *[!0-9]*) return 1 ;; esac
+  [ "$head" -gt "$idx" ] && return 1
+  [ "$dirty" -gt 0 ] && return 1
+  return 0
+}
+
+if is_fresh; then
+  echo "GitNexus: index fresh — proceeding." >&2
+  exit 0
+fi
+
+echo "GitNexus: index stale — refreshing synchronously before continuing…" >&2
+GN_WAIT=1 GN_REPO_ROOT="$REPO_ROOT" bash "$HELPER" "ensure-fresh"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo "⚠ GitNexus: synchronous reindex FAILED (rc=$rc). Index may be stale — proceed with caution." >&2
+  echo "  Tail: $GITNEXUS_DIR/logs/$(basename "$REPO_ROOT").log" >&2
+  exit "$rc"
+fi
+
+echo "GitNexus: index refreshed — proceeding." >&2
+exit 0

--- a/.claude/hooks/scripts/gitnexus-mark-stale.sh
+++ b/.claude/hooks/scripts/gitnexus-mark-stale.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PostToolUse hook for Edit/Write/MultiEdit: schedule a background reindex
+# (debounced 60s) via the shared helper. Only refreshes an existing index.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/gitnexus-reindex.sh"
+
+INPUT="$(cat)"
+FILE="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .toolInput.file_path // .tool_input.path // .toolInput.path // empty' 2>/dev/null)"
+[ -z "$FILE" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+REPO_ROOT="$(git -C "$(dirname "$FILE")" rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && exit 0
+GITNEXUS_DIR="$REPO_ROOT/.gitnexus"
+[ -d "$GITNEXUS_DIR" ] || exit 0   # only refresh an existing index
+
+# Debounce: skip if a reindex was scheduled < 60s ago.
+DEBOUNCE_FILE="$GITNEXUS_DIR/.last-analyze-ts"
+NOW="$(date +%s)"
+LAST="$(cat "$DEBOUNCE_FILE" 2>/dev/null || echo 0)"
+case "$LAST" in *[!0-9]* | "") LAST=0 ;; esac
+[ "$(( NOW - LAST ))" -lt 60 ] && exit 0
+
+( GN_REPO_ROOT="$REPO_ROOT" bash "$HELPER" "post-edit ($(basename "$FILE"))" ) </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/.claude/hooks/scripts/gitnexus-reindex-after-commit.sh
+++ b/.claude/hooks/scripts/gitnexus-reindex-after-commit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PostToolUse hook (matcher: Bash). After a successful `git commit`, schedule a
+# background reindex via the shared helper. The tree is already clean at this
+# point, and the helper uses --skip-agents-md + self-heal, so it stays clean.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/gitnexus-reindex.sh"
+
+INPUT="$(cat)"
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .toolInput.command // empty' 2>/dev/null)"
+[ -z "$CMD" ] && exit 0
+
+# Only on real commits — skip dry-runs and message-less helpers.
+printf '%s' "$CMD" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*commit([[:space:]]|$)' || exit 0
+printf '%s' "$CMD" | grep -Eq -- '--dry-run' && exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && exit 0
+[ -d "$REPO_ROOT/.gitnexus" ] || exit 0
+
+( GN_REPO_ROOT="$REPO_ROOT" bash "$HELPER" "post-commit" ) </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/.claude/hooks/scripts/gitnexus-reindex.sh
+++ b/.claude/hooks/scripts/gitnexus-reindex.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared GitNexus reindex helper — the single place the "fresh index, clean tree"
+# guarantee lives. Runs ONE synchronous `gitnexus analyze --skip-agents-md`, then
+# self-heals any GitNexus-managed tracked doc it may have dirtied, and maintains a
+# `.stale` marker so a failed reindex is never silent.
+#
+# Usage:   gitnexus-reindex.sh [reason]
+# Env:     GN_WAIT=1   wait for an in-progress reindex to finish, then run anyway
+#                      (used by the synchronous ensure-fresh gate)
+#          GN_REPO_ROOT=<path>  override repo-root detection
+#
+# Callers that want background behaviour invoke this with `( ... ) & disown`.
+set -uo pipefail
+
+REASON="${1:-manual}"
+REPO_ROOT="${GN_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+[ -z "$REPO_ROOT" ] && exit 0
+
+GITNEXUS_DIR="$REPO_ROOT/.gitnexus"
+REPO_NAME="$(basename "$REPO_ROOT")"
+LOG_DIR="$GITNEXUS_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${REPO_NAME}.log"
+LOCKFILE="$GITNEXUS_DIR/.analyze.lock"
+DEBOUNCE_FILE="$GITNEXUS_DIR/.last-analyze-ts"
+STALE_MARKER="$GITNEXUS_DIR/.stale"
+
+log() { echo "[$(date -Is 2>/dev/null || date)] $*" >>"$LOG_FILE"; }
+
+lock_alive() { [ -f "$LOCKFILE" ] && kill -0 "$(cat "$LOCKFILE" 2>/dev/null)" 2>/dev/null; }
+
+# If another reindex is running, either wait for it (GN_WAIT) or skip (debounced path).
+if lock_alive; then
+  if [ "${GN_WAIT:-0}" = "1" ]; then
+    log "reindex ($REASON): waiting for in-progress analyze"
+    for _ in $(seq 1 180); do lock_alive || break; sleep 1; done
+  else
+    exit 0
+  fi
+fi
+
+mkdir -p "$GITNEXUS_DIR"
+echo $$ >"$LOCKFILE"
+date +%s >"$DEBOUNCE_FILE"
+trap 'rm -f "$LOCKFILE"' EXIT
+
+cd "$REPO_ROOT" || exit 0
+
+# Snapshot managed paths that were ALREADY dirty, so we never clobber real edits.
+MANAGED="CLAUDE.md AGENTS.md .claude/skills/gitnexus"
+before="$(git status --porcelain -- $MANAGED 2>/dev/null)"
+
+log "reindex ($REASON): analyze --skip-agents-md"
+npx --yes gitnexus analyze --skip-agents-md >>"$LOG_FILE" 2>&1   # never --skills
+rc=$?
+log "reindex ($REASON): analyze exited rc=$rc"
+
+# Self-heal: restore ONLY managed paths that analyze itself newly dirtied.
+for p in $MANAGED; do
+  git status --porcelain -- "$p" 2>/dev/null | grep -q . || continue   # still clean → skip
+  printf '%s\n' "$before" | grep -qF -- "$p" && continue               # was dirty before → leave it
+  git restore -- "$p" 2>>"$LOG_FILE" || git checkout -- "$p" 2>>"$LOG_FILE"
+  log "reindex ($REASON): self-heal restored $p"
+done
+
+# Never silently stale: marker on failure, cleared on success.
+if [ "$rc" -ne 0 ]; then
+  echo "analyze rc=$rc reason=$REASON @ $(date -Is 2>/dev/null || date)" >"$STALE_MARKER"
+else
+  rm -f "$STALE_MARKER"
+fi
+
+exit "$rc"

--- a/.claude/hooks/scripts/gitnexus-session-prep.sh
+++ b/.claude/hooks/scripts/gitnexus-session-prep.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure the GitNexus index for the current repo exists and is
+# fresh. Builds/refreshes in the background (never blocks the session) via the
+# shared reindex helper, and surfaces a loud warning if a prior reindex failed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/gitnexus-reindex.sh"
+
+CWD="$(pwd)"
+REPO_ROOT="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && exit 0
+
+REPO_NAME="$(basename "$REPO_ROOT")"
+GITNEXUS_DIR="$REPO_ROOT/.gitnexus"
+LOG_DIR="$GITNEXUS_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${REPO_NAME}.log"
+
+# Never silently stale: a prior failed reindex left a marker.
+if [ -f "$GITNEXUS_DIR/.stale" ]; then
+  echo "⚠ GitNexus STALE for $REPO_NAME — last reindex failed ($(cat "$GITNEXUS_DIR/.stale"))." >&2
+  echo "  Fix: npx gitnexus analyze --skip-agents-md   (tail: $LOG_FILE)" >&2
+fi
+
+bg_reindex() { ( GN_REPO_ROOT="$REPO_ROOT" bash "$HELPER" "$1" ) </dev/null >/dev/null 2>&1 & disown 2>/dev/null || true; }
+
+# Portable mtime in epoch seconds (BSD vs GNU stat).
+if [ "$(uname -s)" = "Darwin" ]; then mtime() { stat -f %m "$1" 2>/dev/null || echo 0; }
+else mtime() { stat -c %Y "$1" 2>/dev/null || echo 0; }; fi
+
+# Case 1: no index yet → build it.
+if [ ! -d "$GITNEXUS_DIR" ]; then
+  echo "GitNexus: no index for $REPO_NAME — building in background. Tail: $LOG_FILE" >&2
+  bg_reindex "session-start: no index"
+  exit 0
+fi
+
+# Case 2: index exists — check freshness (index mtime vs HEAD commit ts + dirty count).
+LAST_INDEX_TS="$(mtime "$GITNEXUS_DIR")"
+LAST_COMMIT_TS="$(git -C "$REPO_ROOT" log -1 --format=%ct 2>/dev/null || echo 0)"
+LAST_DIRTY_FILES="$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+case "$LAST_INDEX_TS" in *[!0-9]* | "") LAST_INDEX_TS=0 ;; esac
+case "$LAST_COMMIT_TS" in *[!0-9]* | "") LAST_COMMIT_TS=0 ;; esac
+case "$LAST_DIRTY_FILES" in *[!0-9]* | "") LAST_DIRTY_FILES=0 ;; esac
+
+STALE=0
+[ "$LAST_COMMIT_TS" -gt "$LAST_INDEX_TS" ] && STALE=1
+[ "$LAST_DIRTY_FILES" -gt 5 ] && STALE=1
+
+if [ "$STALE" -eq 1 ]; then
+  echo "GitNexus: index for $REPO_NAME is stale — refreshing in background. Tail: $LOG_FILE" >&2
+  bg_reindex "session-start: stale (commit_ts=$LAST_COMMIT_TS index_ts=$LAST_INDEX_TS dirty=$LAST_DIRTY_FILES)"
+else
+  AGE_MIN=$(( ( $(date +%s) - LAST_INDEX_TS ) / 60 ))
+  echo "GitNexus: index for $REPO_NAME is fresh (last refresh ${AGE_MIN}m ago). Use gitnexus_* tools first." >&2
+fi
+
+exit 0

--- a/.claude/hooks/scripts/merge-guard.sh
+++ b/.claude/hooks/scripts/merge-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the Bash tool.
+#
+# Enforces "merging is only allowed via pull request":
+# blocks `git merge <ref>` (and the `git pull <remote> <ref>` form, which
+# is also a merge of arbitrary refs).
+#
+# Allowed:
+#   - git merge --abort | --continue | --quit | --skip   (recovery)
+#   - git pull                                           (sync your own branch)
+#   - git pull --rebase  /  git pull --ff-only           (no merge commit)
+#   - gh pr merge ...                                    (the sanctioned path)
+#
+# Override: CLAUDE_ALLOW_DIRECT_MERGE=1
+#
+# stdin → JSON, stderr → message back to Claude, exit 2 → block, exit 0 → allow.
+
+set -uo pipefail
+
+[ "${CLAUDE_ALLOW_DIRECT_MERGE:-0}" = "1" ] && exit 0
+
+INPUT="$(cat)"
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // .toolInput.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && exit 0
+
+# ---- Helper: extract just the meaningful tokens after `git ...` -----------
+# Strip leading env assignments and `git -c key=val` style options to find
+# the subcommand and its args.
+strip_prefix() {
+  local s="$1"
+  # Drop leading env-var assignments (FOO=bar BAZ=qux git ...)
+  s=$(printf '%s' "$s" | sed -E 's/^([A-Z_][A-Z0-9_]*=[^[:space:]]+[[:space:]]+)+//')
+  printf '%s' "$s"
+}
+
+# ---- Match `git merge <ref>` ----------------------------------------------
+# After stripping prefixes, the command should start with "git" and have
+# a "merge" subcommand somewhere in the arg list (after possible `-c k=v`).
+is_git_subcommand() {
+  local cmd="$1" sub="$2"
+  printf '%s' "$cmd" \
+    | grep -E -q -- "(^|[[:space:];|&])git([[:space:]]+(-[A-Za-z]|--[A-Za-z][A-Za-z=._/-]*|-c[[:space:]][^[:space:]]+))*[[:space:]]+${sub}($|[[:space:]])"
+}
+
+CMD_STRIPPED=$(strip_prefix "$CMD")
+
+# Case 1: `git merge ...`
+if is_git_subcommand "$CMD_STRIPPED" "merge"; then
+  # Allow recovery flags
+  if printf '%s' "$CMD_STRIPPED" | grep -E -q -- 'git[[:space:]]+(-[A-Za-z]+[[:space:]]+|-c[[:space:]][^[:space:]]+[[:space:]]+|--[A-Za-z=._/-]+[[:space:]]+)*merge[[:space:]]+(--abort|--continue|--quit|--skip)([[:space:]]|$)'; then
+    exit 0
+  fi
+  {
+    echo "BLOCKED by ~/.claude/hooks/scripts/merge-guard.sh"
+    echo "Refusing local \`git merge\`. Merging is only allowed via pull request."
+    echo ""
+    echo "Use one of:"
+    echo "  /git.pr                              # open a draft PR for the current branch"
+    echo "  gh pr create --fill --draft          # alternative one-liner"
+    echo "  gh pr merge <num> --squash --delete-branch     # merge an existing PR"
+    echo "  gh pr merge --auto --squash --delete-branch    # enable auto-merge once checks pass"
+    echo ""
+    echo "Allowed merge subcommands: --abort, --continue, --quit, --skip (recovery only)."
+    echo "Override (use sparingly): CLAUDE_ALLOW_DIRECT_MERGE=1 in ~/.claude/settings.json env."
+  } >&2
+  exit 2
+fi
+
+# Case 2: `git pull <remote> <ref>` form pulls a different branch into the
+# current one — that's a merge of arbitrary refs and should go via PR too.
+# Plain `git pull` (no positional args) and `git pull --rebase` / `--ff-only`
+# are fine.
+if is_git_subcommand "$CMD_STRIPPED" "pull"; then
+  # Extract everything after the literal "pull" token
+  PULL_ARGS=$(printf '%s' "$CMD_STRIPPED" | sed -E 's/.*[[:space:]]pull([[:space:]]+|$)//')
+  # Strip flag tokens (-x, --xxx, --xxx=yyy) — what remains is positional
+  POSITIONAL=$(printf '%s' "$PULL_ARGS" | tr ' ' '\n' | grep -v '^-' | grep -v '^$' || true)
+  POS_COUNT=$(printf '%s' "$POSITIONAL" | grep -c . || true)
+
+  # Allow if no positional args, or if --rebase / --ff-only is present
+  if printf '%s' "$PULL_ARGS" | grep -E -q -- '(^|[[:space:]])(--rebase|--ff-only)([[:space:]=]|$)'; then
+    exit 0
+  fi
+  if [ "$POS_COUNT" -lt 2 ]; then
+    # 0 or 1 positional → standard upstream pull, allow
+    exit 0
+  fi
+
+  # 2+ positional args → `git pull <remote> <ref>` merging arbitrary ref
+  {
+    echo "BLOCKED by ~/.claude/hooks/scripts/merge-guard.sh"
+    echo "Refusing \`git pull <remote> <ref>\` — that's a local merge of an arbitrary branch."
+    echo ""
+    echo "Options:"
+    echo "  git fetch <remote> <ref>                    # fetch only, no merge"
+    echo "  git pull --rebase <remote> <ref>            # rebase onto, no merge commit"
+    echo "  git pull --ff-only <remote> <ref>           # only allow if fast-forward"
+    echo "  gh pr merge <num> --squash --delete-branch  # the sanctioned integration path"
+    echo ""
+    echo "Override (use sparingly): CLAUDE_ALLOW_DIRECT_MERGE=1 in ~/.claude/settings.json env."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/scripts/session-start.sh
+++ b/.claude/hooks/scripts/session-start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SessionStart hook — prints a one-line context greeting.
+set -uo pipefail
+
+CWD="$(pwd)"
+DATE="$(date '+%Y-%m-%d %H:%M')"
+
+# Try to gather git context if we're in a repo
+BRANCH=""
+LAST_COMMIT=""
+if git -C "$CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  LAST_COMMIT=$(git -C "$CWD" log -1 --pretty='%h %s' 2>/dev/null)
+fi
+
+{
+  echo "── session started · $DATE ──"
+  echo "cwd:    $CWD"
+  if [ -n "$BRANCH" ]; then
+    echo "branch: $BRANCH"
+    echo "head:   $LAST_COMMIT"
+  fi
+} >&2
+
+exit 0

--- a/.claude/hooks/scripts/topic-switch-guard.sh
+++ b/.claude/hooks/scripts/topic-switch-guard.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook.
+#
+# Detects a topic switch + parking-required state and injects a directive
+# that tells Claude to run a commit / PR / merge protocol BEFORE
+# answering the new prompt.
+#
+# stdout → injected as additional context to Claude.
+# stderr → shown to the user as feedback.
+# exit 0 → continue, exit 2 → block prompt (we don't block).
+
+set -uo pipefail
+
+INPUT="$(cat)"
+
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // .user_prompt // empty' 2>/dev/null)
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // .workingDirectory // .workspace.current_dir // empty' 2>/dev/null)
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+# Guard: must be inside a git repo
+git -C "$CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Guard: must have at least one commit
+git -C "$CWD" rev-parse --verify HEAD >/dev/null 2>&1 || exit 0
+
+# Guard: not detached HEAD
+BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ "$BRANCH" = "HEAD" ] && exit 0
+
+# --- Heuristic: does this prompt look like a topic switch? -----------------
+P_LOWER=$(printf '%s' "$PROMPT" | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
+
+is_switch=0
+
+# Strong signals: explicit slash commands
+if printf '%s' "$P_LOWER" | grep -E -q -- '(^|[[:space:]])/(plan|clear|new|reset|topic)\b'; then
+  is_switch=1
+fi
+
+# Phrasal signals — English + German (Anton works bilingually)
+if [ "$is_switch" -eq 0 ] && printf '%s' "$P_LOWER" | grep -E -q -- '(^|[[:space:]])(now (let'\''?s|i (want|would|need)|switch)|let'\''?s (start|switch|move|tackle|do)|next (task|topic|thing|up)|new (task|topic|feature|issue|ticket)|switch to|change topic|different (task|topic|feature)|moving on|moving to|on to|forget (that|about)|instead (of|let'\''?s)|actually,? (let'\''?s|i (want|need))|wait,? instead|jetzt (lass|m(ö|oe)chte|will|brauche)|n(ä|ae)chst(es|er) (thema|aufgabe|task)|neue(s|r)? (aufgabe|task|thema|feature|ticket)|wechsle (zu|nach)|anderes thema|stattdessen)\b'; then
+  is_switch=1
+fi
+
+[ "$is_switch" -eq 0 ] && exit 0
+
+# --- Is anything actually waiting to be parked? ---------------------------
+DIRTY_OUTPUT=$(git -C "$CWD" status --porcelain 2>/dev/null)
+
+UNPUSHED_COUNT=0
+HAS_UPSTREAM=0
+if git -C "$CWD" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+  HAS_UPSTREAM=1
+  UPSTREAM=$(git -C "$CWD" rev-parse --abbrev-ref --symbolic-full-name '@{u}')
+  UNPUSHED_COUNT=$(git -C "$CWD" rev-list --count "$UPSTREAM..HEAD" 2>/dev/null || echo 0)
+fi
+
+# Nothing to do? exit silently.
+DIRTY_FILE_COUNT=$(printf '%s' "$DIRTY_OUTPUT" | grep -c . || true)
+if [ "$DIRTY_FILE_COUNT" -eq 0 ] && [ "$UNPUSHED_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+# --- Compose directive ----------------------------------------------------
+TRUNK_RAW=$(git -C "$CWD" rev-parse --abbrev-ref origin/HEAD 2>/dev/null || true)
+TRUNK=$(printf '%s' "$TRUNK_RAW" | sed 's|^origin/||')
+[ -z "$TRUNK" ] && TRUNK="main"
+
+if [ "$HAS_UPSTREAM" -eq 0 ]; then
+  UPSTREAM_LINE="Upstream: <none — branch not yet pushed>"
+else
+  UPSTREAM_LINE="Upstream: $UPSTREAM ($UNPUSHED_COUNT unpushed commit(s))"
+fi
+
+cat <<DIRECTIVE
+[topic-switch-guard]
+The user's new prompt looks like a topic switch, and there is work that should be parked first.
+
+Branch:   $BRANCH
+Trunk:    $TRUNK
+Status:   $DIRTY_FILE_COUNT file(s) with uncommitted changes
+$UPSTREAM_LINE
+
+BEFORE you start working on the new prompt, follow this protocol:
+
+1. Briefly summarise what's currently in flight (1–2 sentences from \`git status\` + last \`git log\`).
+2. ASK the user (one combined question, not three):
+   a. Should I commit the current changes? (yes / no / show diff)
+   b. If yes, should I also open a PR and merge it to "$TRUNK" before switching topic? (yes / no / draft only)
+3. Wait for the user's answer. Do not start the new task before they respond.
+4. Execute their choice using the existing slash commands when possible:
+   - commit only       → /git.commit
+   - commit + draft PR → /git.commit then /git.pr (draft)
+   - commit + PR + merge to trunk → /git.commit, /git.pr, then \`gh pr merge --squash --delete-branch\` (with confirmation)
+   - skip              → just acknowledge and proceed
+5. After the user's chosen step completes (or they skip), THEN start work on the new prompt.
+
+If the user already addressed this in the same prompt (e.g. "commit and then..."), skip the question and just execute.
+If the user explicitly says "ignore the guard" or "just do X", honour that.
+DIRECTIVE
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "BASH_DEFAULT_TIMEOUT_MS": "120000",
+    "BASH_MAX_TIMEOUT_MS": "600000",
+    "MCP_TIMEOUT": "30000"
+  },
+  "permissions": {
+    "defaultMode": "default",
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git commit:*)",
+      "Bash(git diff:*)",
+      "Bash(git fetch:*)",
+      "Bash(git log:*)",
+      "Bash(git pull:*)",
+      "Bash(git remote:*)",
+      "Bash(git restore:*)",
+      "Bash(git show:*)",
+      "Bash(git stash:*)",
+      "Bash(git status:*)",
+      "Bash(git switch:*)",
+      "Bash(git tag:*)",
+      "Bash(git worktree:*)",
+      "Bash(git config core.hooksPath:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh label:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh auth status)",
+      "Bash(npm run:*)",
+      "Bash(npm ci)",
+      "Bash(npm test:*)",
+      "Bash(npm outdated)",
+      "Bash(npm audit)",
+      "Bash(npx gitnexus:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx prettier:*)",
+      "Bash(eslint:*)",
+      "Bash(prettier:*)",
+      "Bash(vitest:*)",
+      "Bash(tsc:*)",
+      "Bash(tsx:*)",
+      "Bash(cargo build:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo run:*)",
+      "Bash(rustfmt:*)",
+      "Bash(node:*)",
+      "Bash(uv:*)",
+      "Bash(python3:*)",
+      "Bash(rg:*)",
+      "Bash(fd:*)",
+      "Bash(jq:*)",
+      "Bash(sed:*)",
+      "Bash(awk:*)",
+      "Bash(grep:*)",
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(find:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(tr:*)",
+      "Bash(cut:*)",
+      "Bash(diff:*)",
+      "Bash(tree:*)",
+      "Bash(echo:*)",
+      "Bash(printf:*)",
+      "Bash(pwd)",
+      "Bash(date)",
+      "Bash(which:*)",
+      "Bash(test:*)",
+      "Bash(stat:*)",
+      "Bash(chmod:*)",
+      "Bash(mkdir:*)",
+      "Bash(curl -s http://localhost:*)",
+      "Bash(curl -sI http://localhost:*)",
+      "mcp__gitnexus__context",
+      "mcp__gitnexus__query",
+      "mcp__gitnexus__impact",
+      "mcp__gitnexus__api_impact",
+      "mcp__gitnexus__detect_changes",
+      "mcp__gitnexus__list_repos",
+      "mcp__gitnexus__route_map",
+      "mcp__gitnexus__tool_map",
+      "mcp__gitnexus__cypher",
+      "mcp__gitnexus__shape_check"
+    ],
+    "deny": [
+      "Bash(curl * | bash)",
+      "Bash(curl * | sh)",
+      "Bash(wget * | bash)",
+      "Bash(wget * | sh)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf $HOME)",
+      "Bash(git push --force origin main)",
+      "Bash(git push --force-with-lease origin main)",
+      "Bash(git push -f origin main)",
+      "Bash(mkfs.*)",
+      "Bash(dd if=* of=/dev/*)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.prod*)",
+      "Read(backend/.env)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Edit(**/.env)",
+      "Edit(backend/.env)",
+      "Edit(**/*.pem)",
+      "Edit(**/*.key)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(npm install:*)",
+      "Bash(npm i:*)",
+      "Bash(cargo install:*)",
+      "Bash(cargo add:*)",
+      "Bash(docker system prune:*)",
+      "mcp__gitnexus__rename"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep|Glob|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/gitnexus/gitnexus-hook.cjs\"",
+            "timeout": 10,
+            "statusMessage": "Enriching with GitNexus graph context..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/block-dangerous.sh\"",
+            "timeout": 5,
+            "statusMessage": "Safety: scanning bash command..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/branch-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "Branch-guard: checking protected branches..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/merge-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "Merge-guard: PR-only merging..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/gitnexus/gitnexus-hook.cjs\"",
+            "timeout": 10,
+            "statusMessage": "Checking GitNexus index freshness..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-reindex-after-commit.sh\"",
+            "timeout": 10,
+            "statusMessage": "GitNexus: reindex after commit..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/auto-format.sh\"",
+            "timeout": 30,
+            "statusMessage": "Auto-formatting edited file..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/auto-lint.sh\"",
+            "timeout": 60,
+            "statusMessage": "Linting edited file..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-mark-stale.sh\"",
+            "timeout": 5,
+            "statusMessage": "GitNexus: scheduling reindex..."
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/session-start.sh\"",
+            "timeout": 5,
+            "statusMessage": "Loading session context..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-session-prep.sh\"",
+            "timeout": 5,
+            "statusMessage": "GitNexus: ensuring index..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/topic-switch-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking for topic switch / uncommitted work..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/gitnexus-consult-first.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/code-review-checklist/SKILL.md
+++ b/.claude/skills/code-review-checklist/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: code-review-checklist
+description: Use during any code review or self-review of a diff. Comprehensive checklist for security, performance, readability, and design.
+---
+
+# Code Review Checklist Skill
+
+Apply in this order. Stop at the first severity that matters and fix before continuing.
+
+## 1. Correctness  (must)
+
+- [ ] Off-by-one / loop bounds correct.
+- [ ] Null / undefined / None / nil paths handled.
+- [ ] Errors are caught at the **right level** — not too broad, not swallowed.
+- [ ] Race conditions: any shared mutable state? any double-fetch? any unsynchronised init?
+- [ ] Resource lifecycle: files / connections / contexts closed (use `with` / `defer` / `using`).
+- [ ] State machines: every transition reachable; no impossible states representable.
+
+## 2. Security  (must)
+
+- [ ] No secrets in diff (check `.env*`, hardcoded keys, default passwords).
+- [ ] User input → never directly into SQL, shell, eval, template engine HTML, file paths.
+- [ ] Authn: every protected endpoint actually wraps `requireAuth()`.
+- [ ] Authz: just because a user is logged in does not mean they can see / edit *this* resource. Check object-level permissions.
+- [ ] Crypto: no MD5 / SHA1 for security; CSPRNG (`crypto.randomBytes`, `secrets.token_bytes`) for tokens; bcrypt / argon2 for passwords.
+- [ ] Dependency CVEs: any new / bumped dep — `npm audit` / `pip-audit` / `cargo audit`.
+
+## 3. Tests  (must for new behaviour)
+
+- [ ] Happy path covered.
+- [ ] At least one error / edge case covered.
+- [ ] Bug fix → regression test that fails without the fix and passes with it.
+- [ ] No `skip` / `xfail` added without justification.
+- [ ] Tests are deterministic — no `time.sleep`, no real network, no random without seed.
+
+## 4. API design  (when changing public surface)
+
+- [ ] Names are precise and consistent with siblings.
+- [ ] Backward compatible (or major version bump justified).
+- [ ] Errors have a typed contract — consumers can branch on them.
+- [ ] Optionals have sensible defaults.
+- [ ] Async functions actually need to be async.
+
+## 5. Performance  (when in hot path)
+
+- [ ] No N+1 queries (loops doing per-item DB hits).
+- [ ] No quadratic loops where linear suffices.
+- [ ] No unbounded memory growth (streaming where possible).
+- [ ] No sync I/O in async / event-loop code.
+- [ ] Caching with explicit TTL / invalidation.
+- [ ] Indexes match query patterns.
+
+## 6. Readability  (should)
+
+- [ ] Function ≤ ~40 lines. If longer, justified.
+- [ ] Cyclomatic complexity ≤ ~10.
+- [ ] Names: precise > generic. `userId` > `id`. `parsedSchema` > `data`.
+- [ ] Magic numbers → named constants.
+- [ ] Comments explain *why*, not *what*.
+- [ ] Dead code removed (commented-out, unused imports, unreachable branches).
+
+## 7. Style  (must match project — never your taste)
+
+- [ ] Formatter clean (`prettier --check`, `ruff format --check`, `gofmt -l`).
+- [ ] Linter clean (`eslint`, `ruff check`, `golangci-lint`, `clippy -- -D warnings`).
+- [ ] Imports ordered consistently with the rest of the project.
+
+## Severity guide
+
+- **Must fix** → blocks merge: any correctness, security, or test gap.
+- **Should fix** → raise before merge: API consistency, perf in hot path, naming.
+- **Nit** → optional, mention but don't block: style, minor cleanups.

--- a/.claude/skills/docker-best-practices/SKILL.md
+++ b/.claude/skills/docker-best-practices/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: docker-best-practices
+description: Use whenever writing, reviewing, or debugging Dockerfiles, docker-compose files, or container-based deployments. Covers multi-stage builds, layer caching, security, image size, and compose patterns.
+---
+
+# Docker Best Practices Skill
+
+## Image hygiene
+
+- **Pin base image versions.** `python:3.12-slim` not `python:latest`. Even better: pin by digest (`python:3.12-slim@sha256:...`).
+- **Prefer `-slim` / `-alpine` / distroless** over full distros. Use full distros only when you need build tooling at runtime.
+- **Run as a non-root user.** Last `USER appuser` (uid > 1000). Most apps don't need root.
+- **One process per container.** No `supervisord`, no `&&` daemon stacks. If you need cron + app, use an orchestrator-level pattern.
+- **Minimise layers.** Combine related `RUN` steps with `&&`. But split aggressively where caching matters (deps before source).
+
+## Multi-stage builds (always for compiled / bundled apps)
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    corepack enable && pnpm install --frozen-lockfile
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build --chown=app:app /app/dist ./dist
+COPY --from=deps --chown=app:app /app/node_modules ./node_modules
+USER app
+EXPOSE 3000
+CMD ["node", "dist/index.js"]
+```
+
+Same template applies to Python (build stage compiles wheels, runtime copies them) and Go (build stage produces the static binary, runtime is `FROM scratch` or `gcr.io/distroless/static`).
+
+## Cache discipline (what makes `docker build` fast)
+
+1. **Order from least to most volatile.** Base image → system deps → language deps → app source → build artefact.
+2. **Copy lockfiles before source.** `COPY package.json package-lock.json ./` then `RUN npm ci` then `COPY .`. Source changes don't bust the deps layer.
+3. **`.dockerignore`** is mandatory — at minimum: `.git`, `node_modules`, `__pycache__`, `*.log`, `.env*`, `dist`, `build`, `.venv`.
+4. Use **BuildKit cache mounts** for package caches: `RUN --mount=type=cache,target=...`.
+5. Use `--mount=type=secret` for secrets — never `ARG SECRET=` (bakes into image).
+
+## Security
+
+- Don't run as root. Don't `chmod 777`.
+- Scan images: `docker scout cves` (or `trivy`).
+- Don't embed secrets in `ENV` / `LABEL` / image. Use runtime secrets (Docker Swarm secrets, K8s secrets, AWS Secrets Manager).
+- `HEALTHCHECK` is a security signal too — orchestrators kill unhealthy containers.
+- Drop capabilities at runtime: `--cap-drop=ALL --cap-add=NET_BIND_SERVICE`.
+- Read-only root filesystem: `--read-only --tmpfs /tmp`.
+
+## Compose v2 patterns
+
+```yaml
+# compose.yaml  (NOT docker-compose.yaml — v2 uses compose.yaml)
+name: my-app
+
+services:
+  app:
+    build:
+      context: .
+      target: runtime
+    image: my-app:dev
+    environment:
+      DATABASE_URL: postgres://app:app@db:5432/app
+    depends_on:
+      db: { condition: service_healthy }
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    volumes: ["pgdata:/var/lib/postgresql/data"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+- Use `depends_on: condition: service_healthy` — never assume `up` order alone is enough.
+- Profiles for opt-in services (`profiles: [dev]`).
+- Override files (`compose.override.yaml`) for local-only tweaks.
+- Don't expose internal services (`db`) on host ports unless you need to.
+
+## Image size targets
+
+| Stack | Target |
+|-------|--------|
+| Static binary (Go / Rust) | < 30 MB (distroless / scratch) |
+| Node app | < 200 MB (alpine, multi-stage) |
+| Python app | < 200 MB (slim, multi-stage) |
+| JVM app | < 250 MB (jlink + distroless) |
+
+If you're far over, look for: dev deps in runtime image, unstripped binaries, build caches copied in.
+
+## Anti-patterns
+
+- `apt-get update` without `&& apt-get install ... && rm -rf /var/lib/apt/lists/*` in the same `RUN`.
+- `COPY . .` early in the Dockerfile (cache-busts on every change).
+- No `.dockerignore`.
+- `latest` tag in production.
+- Building inside the runtime stage.
+- `EXPOSE` lying about the port.

--- a/.claude/skills/git-flow/SKILL.md
+++ b/.claude/skills/git-flow/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: git-flow
+description: Use whenever a task involves git operations — commits, branches, rebasing, PR descriptions, conflict resolution, history rewriting. Provides Conventional Commits rules, branch strategy, conflict-resolution patterns, and PR description templates.
+---
+
+# Git Flow Skill
+
+Authoritative reference for git operations in this environment.
+
+## Conventional Commits
+
+Format: `<type>(<scope>)?: <subject>`
+
+| type | use for |
+|------|---------|
+| feat | new user-facing capability |
+| fix | bug fix |
+| refactor | behaviour-preserving restructure |
+| perf | measurable performance improvement |
+| test | tests only |
+| docs | docs only |
+| style | formatting / whitespace only |
+| chore | tooling / housekeeping |
+| ci | CI config |
+| build | build system / external deps |
+| revert | revert of previous commit |
+
+Subject ≤ 72 chars, imperative ("add", not "added" / "adds"), lowercase first letter, no trailing period. Body is optional, hard-wrap 72 cols, separated from subject by blank line. `BREAKING CHANGE:` footer only if a public API broke.
+
+## Branch naming
+
+`<type>/<kebab-case-summary>` — same `<type>` palette as commits. Cap at 50 chars.
+
+Examples: `feat/user-avatar-upload`, `fix/null-pointer-in-cache`, `chore/bump-deps-2026-q2`.
+
+## Conflict resolution
+
+1. **Read both sides before deciding.** Don't accept-theirs / accept-ours blind.
+2. Identify the *intent* of each side. If unclear, look at the commit that introduced each (`git log -p -1 <sha>`).
+3. **Hand-merge logic conflicts.** Auto-merge tools handle whitespace, not semantics.
+4. After resolving every file, run the test suite **before** `git rebase --continue`.
+5. If a rebase has > 5 conflicting commits, consider `git rebase --interactive` to squash first, then resolve once.
+
+## Force-push policy
+
+- `git push --force` on `main` / `master`: **never**.
+- `git push --force-with-lease` on personal feature branches: **OK** after rebase.
+- On a shared feature branch: coordinate first; prefer merge over rebase.
+
+## PR description template
+
+```markdown
+## What
+<2–4 bullets>
+
+## Why
+<motivation, ticket / issue ref>
+
+## How
+<implementation notes if non-obvious>
+
+## Test plan
+- [ ] step 1
+- [ ] step 2
+
+## Risk
+<low / medium / high — what could go wrong, what's the rollback>
+```
+
+## Recovery cheatsheet
+
+| problem | command |
+|---------|---------|
+| Just committed wrong message | `git commit --amend` |
+| Need to undo last commit but keep changes | `git reset --soft HEAD~1` |
+| Need to undo last commit AND changes | `git reset --hard HEAD~1` (destructive) |
+| Lost work after `reset --hard` | `git reflog` to find the SHA, `git reset --hard <sha>` |
+| Branch broken, want pristine trunk | `git fetch origin && git switch -C <new> origin/<trunk>` |

--- a/.claude/skills/gitnexus-pr-review/SKILL.md
+++ b/.claude/skills/gitnexus-pr-review/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: gitnexus-pr-review
+description: "Use when the user wants to review a pull request, understand what a PR changes, assess risk of merging, or check for missing test coverage. Examples: \"Review this PR\", \"What does PR #42 change?\", \"Is this PR safe to merge?\""
+---
+
+# PR Review with GitNexus
+
+## When to Use
+
+- "Review this PR"
+- "What does PR #42 change?"
+- "Is this safe to merge?"
+- "What's the blast radius of this PR?"
+- "Are there missing tests for this PR?"
+- Reviewing someone else's code changes before merge
+
+## Workflow
+
+```
+1. gh pr diff <number>                                    → Get the raw diff
+2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})  → Map diff to affected flows
+3. For each changed symbol:
+   gitnexus_impact({target: "<symbol>", direction: "upstream"})    → Blast radius per change
+4. gitnexus_context({name: "<key symbol>"})               → Understand callers/callees
+5. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+6. Summarize findings with risk assessment
+```
+
+> If "Index is stale" → run `gitnexus analyze` in terminal before reviewing.
+
+## Checklist
+
+```
+- [ ] Fetch PR diff (gh pr diff or git diff base...head)
+- [ ] gitnexus_detect_changes to map changes to affected execution flows
+- [ ] gitnexus_impact on each non-trivial changed symbol
+- [ ] Review d=1 items (WILL BREAK) — are callers updated?
+- [ ] gitnexus_context on key changed symbols to understand full picture
+- [ ] Check if affected processes have test coverage
+- [ ] Assess overall risk level
+- [ ] Write review summary with findings
+```
+
+## Review Dimensions
+
+| Dimension | How GitNexus Helps |
+| --- | --- |
+| **Correctness** | `context` shows callers — are they all compatible with the change? |
+| **Blast radius** | `impact` shows d=1/d=2/d=3 dependents — anything missed? |
+| **Completeness** | `detect_changes` shows all affected flows — are they all handled? |
+| **Test coverage** | `impact({includeTests: true})` shows which tests touch changed code |
+| **Breaking changes** | d=1 upstream items that aren't updated in the PR = potential breakage |
+
+## Risk Assessment
+
+| Signal | Risk |
+| --- | --- |
+| Changes touch <3 symbols, 0-1 processes | LOW |
+| Changes touch 3-10 symbols, 2-5 processes | MEDIUM |
+| Changes touch >10 symbols or many processes | HIGH |
+| Changes touch auth, payments, or data integrity code | CRITICAL |
+| d=1 callers exist outside the PR diff | Potential breakage — flag it |
+
+## Tools
+
+**gitnexus_detect_changes** — map PR diff to affected execution flows:
+
+```
+gitnexus_detect_changes({scope: "compare", base_ref: "main"})
+
+→ Changed: 8 symbols in 4 files
+→ Affected processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Risk: MEDIUM
+```
+
+**gitnexus_impact** — blast radius per changed symbol:
+
+```
+gitnexus_impact({target: "validatePayment", direction: "upstream"})
+
+→ d=1 (WILL BREAK):
+  - processCheckout (src/checkout.ts:42) [CALLS, 100%]
+  - webhookHandler (src/webhooks.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - checkoutRouter (src/routes/checkout.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_impact with tests** — check test coverage:
+
+```
+gitnexus_impact({target: "validatePayment", direction: "upstream", includeTests: true})
+
+→ Tests that cover this symbol:
+  - validatePayment.test.ts [direct]
+  - checkout.integration.test.ts [via processCheckout]
+```
+
+**gitnexus_context** — understand a changed symbol's role:
+
+```
+gitnexus_context({name: "validatePayment"})
+
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates
+→ Processes: CheckoutFlow (step 3/7), RefundFlow (step 1/5)
+```
+
+## Example: "Review PR #42"
+
+```
+1. gh pr diff 42 > /tmp/pr42.diff
+   → 4 files changed: payments.ts, checkout.ts, types.ts, utils.ts
+
+2. gitnexus_detect_changes({scope: "compare", base_ref: "main"})
+   → Changed symbols: validatePayment, PaymentInput, formatAmount
+   → Affected processes: CheckoutFlow, RefundFlow
+   → Risk: MEDIUM
+
+3. gitnexus_impact({target: "validatePayment", direction: "upstream"})
+   → d=1: processCheckout, webhookHandler (WILL BREAK)
+   → webhookHandler is NOT in the PR diff — potential breakage!
+
+4. gitnexus_impact({target: "PaymentInput", direction: "upstream"})
+   → d=1: validatePayment (in PR), createPayment (NOT in PR)
+   → createPayment uses the old PaymentInput shape — breaking change!
+
+5. gitnexus_context({name: "formatAmount"})
+   → Called by 12 functions — but change is backwards-compatible (added optional param)
+
+6. Review summary:
+   - MEDIUM risk — 3 changed symbols affect 2 execution flows
+   - BUG: webhookHandler calls validatePayment but isn't updated for new signature
+   - BUG: createPayment depends on PaymentInput type which changed
+   - OK: formatAmount change is backwards-compatible
+   - Tests: checkout.test.ts covers processCheckout path, but no webhook test
+```
+
+## Review Output Format
+
+Structure your review as:
+
+```markdown
+## PR Review: <title>
+
+**Risk: LOW / MEDIUM / HIGH / CRITICAL**
+
+### Changes Summary
+- <N> symbols changed across <M> files
+- <P> execution flows affected
+
+### Findings
+1. **[severity]** Description of finding
+   - Evidence from GitNexus tools
+   - Affected callers/flows
+
+### Missing Coverage
+- Callers not updated in PR: ...
+- Untested flows: ...
+
+### Recommendation
+APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
+```

--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/.claude/skills/test-strategy/SKILL.md
+++ b/.claude/skills/test-strategy/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: test-strategy
+description: Use whenever writing, planning, or critiquing tests. Covers the test pyramid, mocking patterns, fixture design, coverage targets, and how to choose between unit / integration / e2e for a given scenario.
+---
+
+# Test Strategy Skill
+
+## The pyramid (target ratio)
+
+```
+       /\        e2e        ~5%   slow, brittle, expensive
+      /  \       integration ~20%  medium, mostly stable
+     /____\      unit       ~75%  fast, reliable, cheap
+```
+
+If your suite is inverted (most tests are e2e), the suite is slow, flaky, and expensive — push tests downward.
+
+## What to test where
+
+| Layer | Goal | Examples |
+|-------|------|----------|
+| Unit | One function / class, no I/O | pure functions, parsers, validators, utilities |
+| Integration | Multiple modules together with **real** boundaries replaced by **fakes / sqlite / docker** | DB queries against testcontainer, HTTP handlers with in-mem server |
+| Contract | Verify our API matches consumers' expectations | Pact, OpenAPI conformance |
+| e2e | A user journey end-to-end through the real system | login → create → view → delete |
+
+## Mocking
+
+- **Mock the boundary, not the collaborator.** Mock the network call, not your repository class.
+- Prefer **fakes** (in-memory implementations) and **stubs** (return canned data) over **mocks** (verify call shape). Mocks couple tests to implementation.
+- Never mock what you don't own (third-party libs). Wrap them, then fake the wrapper.
+- One mock per test if possible. Many mocks = the unit under test does too much.
+
+## Fixtures
+
+- **Co-locate** fixtures with tests. Avoid sprawling `conftest.py` / `setup.ts` files.
+- **Build, don't share.** Use builders / factories so each test owns its data; shared mutable fixtures cause flakiness.
+- **Realistic data.** Use Faker / Mimesis / fishery to get plausible values.
+
+## Coverage
+
+- **Targets**: line ≥ 80%, branch ≥ 70% for new code. Below 70% is a smell; chasing 100% is waste.
+- Coverage measures what was *executed*, not what was *verified*. Don't confuse "covered" with "tested".
+- Mutation testing (mutmut, Stryker, PIT) is a stronger signal — run it occasionally on critical paths.
+
+## Anti-patterns to call out
+
+- **Tests that test the mock.** If the test fails, it tells you nothing about real behaviour.
+- **Time-bomb tests.** `assert datetime.now() < ...` — fix with injected clocks.
+- **Sequencing dependencies.** `test_b` requires `test_a` to have run. Fix ordering, isolate state.
+- **Snapshot abuse.** Snapshotting whole UI trees ⇒ every change is "approved" without review.
+- **Test-only branches in production code.** `if NODE_ENV === 'test'` in business logic — refactor to inject the dependency instead.
+
+## What "good" looks like for one test
+
+```py
+def test_<unit>_<scenario>_<expected>():
+    # Arrange
+    sut = build_sut(...)
+
+    # Act
+    result = sut.do_thing(...)
+
+    # Assert
+    assert result == expected
+```
+
+Three blocks, no surprises, one assertion (or one logical assertion split across lines).

--- a/.claude/skills/vue-patterns/SKILL.md
+++ b/.claude/skills/vue-patterns/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: vue-patterns
+description: Use whenever writing or reviewing Vue code in this repo's admin SPA (frontend/src/admin). Covers Vue 3 Composition API, `<script setup lang="ts">`, Pinia stores, Vue Router, composables, Vite, and common anti-patterns.
+---
+
+# Vue Patterns Skill (live.moafunk.de admin SPA)
+
+The admin dashboard lives in `frontend/src/admin/` — **Vue 3 + Vite + Pinia + Vue Router**, TypeScript strict.
+The public pages are vanilla TS (no framework). Apply this skill to the admin SPA.
+
+## Defaults
+
+- **`<script setup lang="ts">`** for every component. Composition API only — no Options API in new code.
+- TypeScript `strict`. Type props with `defineProps<{ ... }>()` (type-based), emits with `defineEmits<{ ... }>()`. Never `any`.
+- `ref` for primitives, `reactive` only for grouped object state; prefer `ref` + `.value` for predictability.
+- `computed` for derived state — never duplicate state you can derive.
+- One component = one responsibility. Extract reusable logic into **composables** (`useXxx`) under `frontend/src/admin/composables/`.
+- Co-locate component-scoped styles with `<style scoped>`.
+
+## Reactivity rules (the real ones)
+
+- Don't destructure `props` (loses reactivity) — use `toRefs(props)` or reference `props.x` directly. For store state use `storeToRefs(store)`.
+- `watch` explicit sources; `watchEffect` only when the dependency set is obvious. Clean up listeners/timers in `onUnmounted` (or the `watch`/`watchEffect` cleanup callback) — critical for the WebSocket/stream and wavesurfer/flv.js views.
+- Keep `ref`s stable; never reassign a `reactive` object wholesale (mutate fields or use a `ref`).
+
+## State — when to reach for what
+
+| Need | Use |
+|------|-----|
+| Local component state | `ref` / `computed` |
+| Reusable stateful logic | a composable (`useStream`, `useUpload`, …) |
+| Cross-view shared/app state | a **Pinia** store (`frontend/src/admin/stores/`) |
+| Server data | the API client in `frontend/src/admin/api/` (see `ApiClient`); keep fetch logic in composables/stores, not components |
+| Auth/route guards | Vue Router guards + the auth store (`router.ts`) |
+
+### Pinia
+- `defineStore('name', () => { ... })` (setup-store style) to match Composition API. Return `ref`/`computed`/actions.
+- Read reactive state in components via `storeToRefs(store)`; call actions directly.
+- Stores own side-effects (API calls); components stay declarative.
+
+## Async & media views
+- This SPA drives streaming/recording UIs (wavesurfer.js, flv.js, WebSocket to the Axum backend). Always tear down players/sockets in `onUnmounted` to avoid leaks across route changes.
+- Guard async-after-unmount: capture an `isActive` flag or check the component is still mounted before mutating state in a resolved promise.
+
+## Anti-patterns to flag in review
+- Destructured `props`/store state (broken reactivity).
+- `reactive()` reassignment, or mixing Options + Composition API.
+- Business logic / fetch calls inline in templates or `mounted` instead of composables/stores.
+- Missing cleanup for sockets, intervals, `wavesurfer`/`flv.js` instances.
+- `any`, non-null `!` abuse, or untyped `defineProps`/`defineEmits`.
+- Watchers that duplicate what a `computed` could derive.
+
+## Tooling (run from `frontend/`)
+- `npm run dev` · `npm run build` · `npm run typecheck` (tsc) · `npm run lint` / `lint:fix` (ESLint) · `npm run format` (Prettier) · `npm test` (Vitest).
+- Before reviewing a Vue change, prefer `gitnexus_query`/`gitnexus_context` (clusters: Pages, Composables, Components) over grepping.

--- a/.claude/workflows/decompose-issue.js
+++ b/.claude/workflows/decompose-issue.js
@@ -1,0 +1,100 @@
+export const meta = {
+  name: 'decompose-issue',
+  description: 'Decompose a big task into a parent GitHub issue + labeled sub-issues (drafts only)',
+  whenToUse: 'When a task is too large for one ticket and should become a parent + several sub-issues on phaabe/live.moafunk.de',
+  phases: [
+    { title: 'Scope', detail: 'GitNexus-map the task to functional areas + propose a breakdown' },
+    { title: 'Refine', detail: 'one agent per sub-issue: sharpen title/body/labels/acceptance' },
+  ],
+}
+
+// args: the big task description (string). Pass via Workflow({ args: "..." }).
+const TASK = typeof args === 'string' ? args : (args && args.task) || ''
+if (!TASK) {
+  log('No task provided. Pass the big task description as `args`.')
+  return { error: 'missing args (task description)' }
+}
+
+const REPO = 'live.moafunk.de'
+
+// Label taxonomy is read live by the agents (`gh label list`); these are the known dimensions.
+const LABEL_GUIDE = `
+Apply EXACTLY ONE type:: label and the MOST SPECIFIC project:: label, only from \`gh label list\`:
+- type::backend          → backend/** (Rust/Axum: handlers, recording, soundcloud, image_overlay, telegram, models)
+- type::admin_dashboard  → frontend/src/admin/** (Vue 3 + Pinia admin SPA: pages, composables, components)
+- project::Stream | recording | Instagram | Telegram | Soundcloud | ImgGen | Upload | Backup
+  | Infrastructure | ExternalShows | Ai | unheard-artist-form | UNHEARD
+Add bug / enhancement / documentation / later when fitting. Never invent a label.`
+
+const SUBTASK = {
+  type: 'object',
+  required: ['title', 'area', 'labels', 'body', 'acceptance'],
+  properties: {
+    title: { type: 'string', description: 'Conventional-Commit-flavoured, e.g. "feat(stream): add pre-listen player"' },
+    area: { type: 'string', description: 'backend | admin_dashboard, and the touched files/cluster' },
+    labels: { type: 'array', items: { type: 'string' }, description: 'exact existing labels (one type::, one project::, optional others)' },
+    body: { type: 'string', description: 'Context / Scope (GitNexus) / Acceptance criteria / Notes markdown' },
+    acceptance: { type: 'array', items: { type: 'string' }, description: 'observable, checkable outcomes' },
+  },
+}
+
+const BREAKDOWN = {
+  type: 'object',
+  required: ['parentTitle', 'parentSummary', 'subtasks'],
+  properties: {
+    parentTitle: { type: 'string' },
+    parentSummary: { type: 'string', description: 'why this epic exists + affected areas (from GitNexus)' },
+    subtasks: { type: 'array', items: SUBTASK, minItems: 2, maxItems: 8 },
+  },
+}
+
+phase('Scope')
+const breakdown = await agent(
+  `Decompose this task for the GitHub repo ${REPO} into a parent issue + 2–8 sub-issues.\n\n` +
+    `TASK:\n${TASK}\n\n` +
+    `Steps:\n` +
+    `1. Use gitnexus_query({query, repo: "${REPO}"}) (and gitnexus_context for key symbols) to find which ` +
+    `functional areas/files the work touches. Do NOT grep blindly.\n` +
+    `2. Run \`gh label list --limit 60\` to read the EXACT available labels.\n` +
+    `3. Split into independently-shippable sub-tasks, each with a Conventional-Commit-style title, the ` +
+    `touched area, exact labels, a body (Context / Scope (GitNexus) / Acceptance criteria / Notes), and an ` +
+    `acceptance-criteria list.\n${LABEL_GUIDE}\n` +
+    `Return the structured breakdown only.`,
+  { label: 'scope', phase: 'Scope', schema: BREAKDOWN, agentType: 'Explore' },
+)
+
+if (!breakdown || !breakdown.subtasks || !breakdown.subtasks.length) {
+  return { error: 'scoping produced no subtasks', breakdown }
+}
+log(`Proposed ${breakdown.subtasks.length} sub-issues under "${breakdown.parentTitle}"`)
+
+phase('Refine')
+const refined = await pipeline(
+  breakdown.subtasks,
+  (st, _orig, i) =>
+    agent(
+      `Refine this draft sub-issue for ${REPO} so it is crisp and correctly labeled.\n\n` +
+        `DRAFT #${i + 1}:\n${JSON.stringify(st, null, 2)}\n\n` +
+        `- Verify every label exists via \`gh label list\` (drop/replace any that don't).\n` +
+        `- Ensure exactly one type:: label and one specific project:: label.\n` +
+        `- Tighten the title (imperative, scoped) and make acceptance criteria observable.\n` +
+        `- Keep the body in the Context / Scope (GitNexus) / Acceptance criteria / Notes format.\n` +
+        `${LABEL_GUIDE}\nReturn the corrected sub-issue.`,
+      { label: `refine:${i + 1}`, phase: 'Refine', schema: SUBTASK, agentType: 'Explore' },
+    ),
+)
+
+const subtasks = refined.filter(Boolean)
+log(`Refined ${subtasks.length}/${breakdown.subtasks.length} sub-issues`)
+
+// Drafts only — issue creation is a confirmed step in the main loop:
+//   1) gh issue create the parent (with a "- [ ] <child title>" checklist),
+//   2) gh issue create each child with its labels,
+//   3) edit the parent body to reference the created child numbers (- [ ] #N).
+return {
+  repo: REPO,
+  parentTitle: breakdown.parentTitle,
+  parentSummary: breakdown.parentSummary,
+  subtasks,
+  next: 'Present these drafts to the user; on confirmation, create the parent then each child via `gh issue create`, then link children in the parent checklist.',
+}

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Git-native post-commit reindex. Keeps the GitNexus index fresh for commits made
+# OUTSIDE Claude Code too. Activate per-clone with:  git config core.hooksPath .githooks
+# (done by /workflow.setup and `make setup`). Deduped against the Claude PostToolUse
+# hook via the helper's lockfile; uses --skip-agents-md + self-heal → tree stays clean.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO_ROOT" ] && exit 0
+HELPER="$REPO_ROOT/.claude/hooks/scripts/gitnexus-reindex.sh"
+[ -x "$HELPER" ] || exit 0
+[ -d "$REPO_ROOT/.gitnexus" ] || exit 0
+
+( GN_REPO_ROOT="$REPO_ROOT" bash "$HELPER" "git-post-commit" ) </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: "🐛 Bug"
+description: Something isn't working as expected
+title: "fix(<scope>): <short summary>"
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Component
+      options:
+        - "type::backend (Rust/Axum backend)"
+        - "type::admin_dashboard (Vue admin SPA)"
+    validations:
+      required: true
+  - type: dropdown
+    id: project
+    attributes:
+      label: Project / area
+      options:
+        - "project::Stream"
+        - "project::recording"
+        - "project::Instagram"
+        - "project::Telegram"
+        - "project::Soundcloud"
+        - "project::ImgGen"
+        - "project::Upload"
+        - "project::Backup"
+        - "project::Infrastructure"
+        - "project::ExternalShows"
+        - "project::Ai"
+        - "project::unheard-artist-form"
+        - "project::UNHEARD"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Actual vs expected behaviour.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment / logs
+      description: Browser, deploy (Pages/Lightsail), relevant log lines or screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "🤖 Let Claude draft a well-labeled issue"
+    url: https://github.com/phaabe/live.moafunk.de/blob/main/.claude/commands/project/issue.md
+    about: "In Claude Code, run /project.issue \"<task>\" — or the decompose-issue workflow for big tasks."

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,58 @@
+name: "✨ Feature / Task"
+description: A new capability or unit of work
+title: "feat(<scope>): <short imperative summary>"
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Component
+      description: Which part of the system does this touch?
+      options:
+        - "type::backend (Rust/Axum backend)"
+        - "type::admin_dashboard (Vue admin SPA)"
+    validations:
+      required: true
+  - type: dropdown
+    id: project
+    attributes:
+      label: Project / area
+      description: The most specific functional area.
+      options:
+        - "project::Stream"
+        - "project::recording"
+        - "project::Instagram"
+        - "project::Telegram"
+        - "project::Soundcloud"
+        - "project::ImgGen"
+        - "project::Upload"
+        - "project::Backup"
+        - "project::Infrastructure"
+        - "project::ExternalShows"
+        - "project::Ai"
+        - "project::unheard-artist-form"
+        - "project::UNHEARD"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this matter? Where did it come up?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Observable, checkable outcomes.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Constraints, links, related issues. (Tip: paste a GitNexus scope/impact summary.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Conventional-Commit title please, e.g.  feat(stream): add pre-listen page
+Merging is PR-only (squash + delete branch). Never merge locally.
+-->
+
+## What
+<!-- A one/two-line summary of the change. -->
+
+## Why
+<!-- The problem this solves / the issue it closes. -->
+Closes #
+
+## How
+<!-- Key implementation decisions. What + why, not a line-by-line diff. -->
+
+## Test plan
+<!-- How you verified this. -->
+- [ ] `cd frontend && npm run lint && npm run typecheck && npm test`
+- [ ] `cd backend && cargo clippy && cargo test`
+- [ ] Manually exercised the affected flow
+
+## Risk / impact
+<!-- Blast radius. Paste the GitNexus impact summary for changed symbols:
+     gitnexus_impact({ target: "<symbol>", direction: "upstream", repo: "live.moafunk.de" }) -->
+- Affected area(s):
+- Risk level:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ backend/.env
 .vscode/
 *.swp
 *.swo
+.gitnexus
+
+# Claude Code — commit shared config, ignore per-developer local overrides
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/mcp.json",
+  "mcpServers": {
+    "gitnexus": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "gitnexus", "mcp"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — live.moafunk.de
+
+Full project guide, stack, commands, and conventions live in **[CLAUDE.md](./CLAUDE.md)** — read that first.
+Shared agent/automation config (hooks, commands, skills, subagents) is checked in under **`.claude/`**.
+The GitNexus code-intelligence block below is auto-generated; edit only *outside* the `<!-- gitnexus:* -->` markers.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **live.moafunk.de** (3760 symbols, 7637 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/live.moafunk.de/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/live.moafunk.de/clusters` | All functional areas |
+| `gitnexus://repo/live.moafunk.de/processes` | All execution flows |
+| `gitnexus://repo/live.moafunk.de/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# live.moafunk.de — Project Guide for Claude
+
+> Hand-authored project conventions. The GitNexus code-intelligence block below
+> (between the `<!-- gitnexus:* -->` markers) is auto-generated — edit only *outside* it.
+
+## What this is
+
+A live-radio / show platform with two deployables:
+
+- **`backend/`** — Rust 2021 · Axum 0.7 · Tokio · SQLx + SQLite · Cloudflare R2 (S3) · Telegram bot.
+  Areas: HTTP handlers, live-stream + recording, SoundCloud, Instagram posting, image overlay/generation, uploads.
+  Deploys via GHCR → Lightsail.
+- **`frontend/`** — Vue 3 + Vite + Pinia admin SPA (`src/admin/`) + vanilla-TS public pages.
+  Deploys to GitHub Pages. TypeScript strict.
+- **CI scripts** — Python 3.13 (uv).
+
+GitNexus clusters: Handlers (backend), Pages / Composables / Components (Vue admin), Flow, Scripts, Api.
+
+## Commands
+
+| Task | Frontend (`cd frontend`) | Backend (`cd backend`) |
+|------|--------------------------|------------------------|
+| Dev | `npm run dev` | `cargo run` |
+| Build | `npm run build` | `cargo build` |
+| Test | `npm test` (Vitest) | `cargo test` |
+| Lint | `npm run lint` / `lint:fix` (ESLint) | `cargo clippy` |
+| Format | `npm run format` (Prettier) | `cargo fmt` |
+| Types | `npm run typecheck` (tsc) | — |
+
+## Conventions
+
+- **Commits**: Conventional Commits with scope — `feat(stream): …`, `fix(imgGen): …`. Subject ≤ 72 chars, imperative. Use `/git.commit`.
+- **Branches**: never commit on `main` — branch first (`/git.branch` or `git switch -c <type>/<slug>`). Enforced by `branch-guard.sh`.
+- **Merging is PR-only.** Never `git merge <ref>` locally — open a PR (`/git.pr`) and squash-merge (`gh pr merge --squash --delete-branch`). Enforced by `merge-guard.sh`.
+- **Issues**: one ticket → `/project.issue "<task>"`; a big task → the `decompose-issue` workflow. Label taxonomy: exactly one `type::backend` / `type::admin_dashboard`, plus the most specific `project::*` (Stream, recording, Instagram, Telegram, Soundcloud, ImgGen, Upload, Backup, Infrastructure, ExternalShows, Ai, unheard-artist-form, UNHEARD).
+- **GitNexus-first**: before grepping, query the graph (see the managed block below). Impact-analyse before editing a symbol; `detect_changes` before committing.
+
+## GitNexus index — fresh & clean (how it works here)
+
+- The index lives in `.gitnexus/` (gitignored) and is refreshed automatically: at session start, on edits (debounced), and after every commit — always with `gitnexus analyze --skip-agents-md`, so **a reindex never dirties a tracked file**.
+- `.claude/hooks/scripts/gitnexus-reindex.sh` self-heals any managed doc a stray reindex touches; a failed reindex drops `.gitnexus/.stale`, surfaced loudly at session start.
+- **Decision points are guaranteed fresh**: `/git.commit`, `/workflow.ship`, `/quality.review` and impact analysis run `gitnexus-ensure-fresh.sh` (synchronous) first.
+- Fresh clone: `npx gitnexus setup && npx gitnexus analyze --skip-agents-md && git config core.hooksPath .githooks` (see `/workflow.setup`).
+
+## Setup notes
+
+- Claude config is checked in under `.claude/` (shared with the team). Per-developer overrides go in `.claude/settings.local.json` (gitignored).
+- If you maintain a **machine-global** `~/.claude` with its own GitNexus hooks, make those use `--skip-agents-md` too — otherwise a global *bare* `gitnexus analyze` will rewrite the stats line below and dirty the tree.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **live.moafunk.de** (3760 symbols, 7637 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/live.moafunk.de/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/live.moafunk.de/clusters` | All functional areas |
+| `gitnexus://repo/live.moafunk.de/processes` | All execution flows |
+| `gitnexus://repo/live.moafunk.de/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->


### PR DESCRIPTION
## What
Adds a shared, version-controlled `.claude/` config (hooks, commands, subagents, skills, settings) plus GitHub issue/PR automation and an always-fresh-but-clean GitNexus reindex.

## Why
All the useful Claude Code automation previously lived only in a developer's machine-global `~/.claude` — not shared with collaborators and not version-controlled. This makes it a team asset and adds: GitHub ticket automation, commit/PR guidelines, and automatic GitNexus reindexing that never dirties the working tree.

## How
- **Ported & adapted** safety guards (branch/merge/dangerous), auto-format/lint, 7 subagents, all git/workflow/quality/project commands, and curated skills (git-flow, code-review-checklist, test-strategy, docker-best-practices, + a new `vue-patterns` for the Vue 3 admin SPA). Hook commands rewired to `$CLAUDE_PROJECT_DIR`; personal profile/paths/preferences stripped from `settings.json`.
- **Clean-tree GitNexus reindex** — shared `gitnexus-reindex.sh` runs `analyze --skip-agents-md`, self-heals any managed doc it touches, and maintains a `.stale` marker. Fires at session start, on debounced edits, and after every commit (Claude PostToolUse hook + opt-in `.githooks/post-commit`). `.gitnexus/` stays gitignored.
- **Synchronous freshness gate** — `gitnexus-ensure-fresh.sh` blocks before `/git.commit`, `/workflow.ship`, `/quality.review`, and impact analysis, guaranteeing the index matches the code at every decision point.
- **Issue automation** — `/project.issue` (single, label-aware) and the `decompose-issue` workflow (parent + sub-issues), matching this repo's `type::`/`project::` labels. Plus PR + issue-form templates under `.github/`.

## Test plan
- [x] `bash -n` + `jq`/`node --check` on all scripts/JSON/JS — pass
- [x] branch-guard blocks commit on `main`; merge-guard blocks local `git merge`, allows `gh pr merge`
- [x] Clean-tree proof: `git status` byte-identical before/after a reindex; `CLAUDE.md`/`AGENTS.md` never flip to modified
- [x] `gitnexus-ensure-fresh.sh` refreshes a dirty tree and exits 0; `.stale` marker surfaced loudly then cleared
- [ ] Reviewer: open a fresh session → confirm session-start freshness line + clean tree

## Risk / impact
- Affected area(s): tooling/config only — no application code. `.claude/`, `.github/`, `.githooks/`, `.mcp.json`, `CLAUDE.md`, `AGENTS.md`, `.gitignore`.
- Risk level: low. Hooks fail open (never block normal work); merging stays PR-only; no GitHub repo settings changed.
- Note: teammates run `npx gitnexus setup && npx gitnexus analyze --skip-agents-md && git config core.hooksPath .githooks` once (see `/workflow.setup`) to enable MCP tools + the git-native reindex.