### PR TITLE
fix(backend): superadmin login fails locally (env var name + dotenvy $-expansion)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,9 +3,10 @@ HOST=0.0.0.0
 PORT=8000
 SECRET_KEY=change-this-to-a-random-secret-key
 
-# Admin password hash (Argon2)
+# Superadmin password hash (Argon2)
 # Generate with: cargo run --bin hash_password -- "your-password"
-ADMIN_PASSWORD_HASH=
+# Must be single-quoted: the hash contains '$', which dotenvy expands otherwise.
+SUPERADMIN_PASSWORD_HASH=''
 
 # Cloudflare R2 settings
 R2_ACCOUNT_ID=your-account-id

--- a/backend/src/bin/hash_password.rs
+++ b/backend/src/bin/hash_password.rs
@@ -21,8 +21,9 @@ fn main() {
             println!("Password hash:");
             println!("{}", hash.to_string());
             println!();
-            println!("Add this to your .env file:");
-            println!("ADMIN_PASSWORD_HASH={}", hash.to_string());
+            println!("Add this to your .env file (single quotes are required —");
+            println!("the hash contains '$' which dotenvy would otherwise expand):");
+            println!("SUPERADMIN_PASSWORD_HASH='{}'", hash.to_string());
         }
         Err(e) => {
             eprintln!("Error hashing password: {}", e);


### PR DESCRIPTION
Closes #144

## Problem
A fresh local backend can never log in as superadmin — `POST /api/auth/login` returns `401` even with the right password.

Two combined bugs:
1. **Wrong env var name** — `.env.example` and `hash_password.rs` use `ADMIN_PASSWORD_HASH`, but `Config` expects `SUPERADMIN_PASSWORD_HASH` (envy field `superadmin_password_hash`).
2. **dotenvy `$`-expansion** — `dotenvy::dotenv()` interpolates `$VAR` in values. An Argon2 PHC hash is full of `$` (`$argon2id$v=19$m=...$salt$hash`), so each segment expanded to empty and a 97-char hash was stored as a ~56-char mangled string → `verify_password` never matches.

## Fix
- Rename `ADMIN_PASSWORD_HASH` → `SUPERADMIN_PASSWORD_HASH` in `.env.example` and `hash_password.rs`.
- Single-quote the hash so dotenvy stores it literally; `.env.example` documents the requirement and `hash_password` now prints a quoted line.

## Verification
With a single-quoted hash, the seeded hash is the full 97 chars and `POST /api/auth/login` (`superadmin`) returns `200` with a session cookie.

No code-symbol/process impact (`gitnexus detect_changes`: 0 symbols, risk low) — string/config only.