### PR TITLE
feat(shows): host show management — create + all-shows overview

### DIFF
--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -2026,6 +2026,82 @@ pub struct ShowsListResponse {
     artists: Vec<ArtistBrief>,
 }
 
+/// Read-only schedule entry returned to any authenticated user (hosts included).
+#[derive(Debug, Serialize)]
+pub struct ShowOverviewItem {
+    id: i64,
+    title: String,
+    date: String,
+    start_time: Option<String>,
+    end_time: Option<String>,
+    description: Option<String>,
+    status: String,
+    show_type: String,
+    /// Username of the assigned host (external/brunchtime shows), if any.
+    host_username: Option<String>,
+    artists: Vec<ArtistBrief>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ShowsOverviewResponse {
+    shows: Vec<ShowOverviewItem>,
+}
+
+/// GET /api/shows-overview — read-only list of **all** shows for any authenticated
+/// user. Lets hosts see the full schedule (including other users' shows) without
+/// the admin-only assignment data exposed by [`api_shows_list`].
+pub async fn api_shows_overview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse> {
+    let token = auth::get_session_from_headers(&headers);
+    auth::get_current_user(&state, token.as_deref())
+        .await
+        .ok_or_else(|| AppError::Unauthorized("Not authenticated".to_string()))?;
+
+    let shows: Vec<models::Show> =
+        sqlx::query_as("SELECT * FROM shows ORDER BY date DESC, id DESC")
+            .fetch_all(&state.db)
+            .await?;
+
+    let mut items = Vec::new();
+    for show in shows {
+        let artists: Vec<ArtistBrief> = sqlx::query_as(
+            "SELECT a.id, a.name FROM artists a \
+             INNER JOIN artist_show_assignments asa ON a.id = asa.artist_id \
+             WHERE asa.show_id = ? \
+             ORDER BY asa.sort_order, a.name",
+        )
+        .bind(show.id)
+        .fetch_all(&state.db)
+        .await?;
+
+        let host_username: Option<String> = if let Some(hid) = show.host_user_id {
+            sqlx::query_scalar("SELECT username FROM users WHERE id = ?")
+                .bind(hid)
+                .fetch_optional(&state.db)
+                .await?
+        } else {
+            None
+        };
+
+        items.push(ShowOverviewItem {
+            id: show.id,
+            title: show.title,
+            date: show.date,
+            start_time: show.start_time,
+            end_time: show.end_time,
+            description: show.description,
+            status: show.status,
+            show_type: show.show_type,
+            host_username,
+            artists,
+        });
+    }
+
+    Ok(Json(ShowsOverviewResponse { shows: items }))
+}
+
 pub async fn api_shows_list(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -2590,35 +2590,57 @@ pub struct CreateShowRequest {
     date: String,
     description: Option<String>,
     show_type: Option<String>,
-    start_time: String,
-    end_time: String,
+    start_time: Option<String>,
+    end_time: Option<String>,
 }
+
+/// Default show type for host-created shows. Hosts can't pick a type, and host
+/// assignment is reserved for non-UNHEARD shows (see `api_show_assign_host`).
+const HOST_DEFAULT_SHOW_TYPE: &str = "external";
 
 pub async fn api_create_show(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(req): Json<CreateShowRequest>,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    let user = require_show_creator(&state, &headers).await?;
+    let is_admin = user.role_enum().can_access_admin();
 
-    // Validate show_type if provided
-    let show_type = req.show_type.as_deref().unwrap_or("unheard");
-    if !matches!(show_type, "unheard" | "brunchtime" | "external") {
-        return Err(AppError::BadRequest(format!(
-            "Invalid show_type: '{}'. Must be 'unheard', 'brunchtime', or 'external'",
-            show_type
-        )));
-    }
+    // Hosts get a constrained show: forced type, self-assigned, no description /
+    // end time. Admins get full control over every field.
+    let (show_type, description, end_time, host_user_id) = if is_admin {
+        let show_type = req.show_type.as_deref().unwrap_or("unheard");
+        if !matches!(show_type, "unheard" | "brunchtime" | "external") {
+            return Err(AppError::BadRequest(format!(
+                "Invalid show_type: '{}'. Must be 'unheard', 'brunchtime', or 'external'",
+                show_type
+            )));
+        }
+        (
+            show_type.to_string(),
+            req.description.clone(),
+            req.end_time.clone(),
+            None::<i64>,
+        )
+    } else {
+        (
+            HOST_DEFAULT_SHOW_TYPE.to_string(),
+            None,
+            None,
+            Some(user.id),
+        )
+    };
 
     let result = sqlx::query(
-        "INSERT INTO shows (title, date, description, status, show_type, start_time, end_time) VALUES (?, ?, ?, 'scheduled', ?, ?, ?)",
+        "INSERT INTO shows (title, date, description, status, show_type, start_time, end_time, host_user_id) VALUES (?, ?, ?, 'scheduled', ?, ?, ?, ?)",
     )
     .bind(&req.title)
     .bind(&req.date)
-    .bind(&req.description)
-    .bind(show_type)
+    .bind(&description)
+    .bind(&show_type)
     .bind(&req.start_time)
-    .bind(&req.end_time)
+    .bind(&end_time)
+    .bind(host_user_id)
     .execute(&state.db)
     .await?;
 
@@ -2645,11 +2667,12 @@ pub async fn api_create_show(
             "id": show_id,
             "title": req.title,
             "date": req.date,
-            "description": req.description,
+            "description": description,
             "status": "scheduled",
             "show_type": show_type,
             "start_time": req.start_time,
-            "end_time": req.end_time,
+            "end_time": end_time,
+            "host_user_id": host_user_id,
             "cover_url": cover_url,
             "cover_generated_at": cover_generated_at,
         })),
@@ -4827,6 +4850,28 @@ pub async fn require_admin(state: &Arc<AppState>, headers: &HeaderMap) -> Result
 
     if !user.role_enum().can_access_admin() {
         return Err(AppError::Forbidden("Admin access required".to_string()));
+    }
+
+    Ok(user)
+}
+
+/// Require an authenticated user allowed to create shows (host or admin).
+///
+/// Unlike [`require_admin`], hosts pass this check — they create a constrained,
+/// self-assigned show (see [`api_create_show`]).
+pub async fn require_show_creator(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+) -> Result<models::User> {
+    let token = auth::get_session_from_headers(headers);
+    let user = auth::get_current_user(state, token.as_deref())
+        .await
+        .ok_or_else(|| AppError::Unauthorized("Not authenticated".to_string()))?;
+
+    if !user.role_enum().can_create_show() {
+        return Err(AppError::Forbidden(
+            "Host or admin access required to create shows".to_string(),
+        ));
     }
 
     Ok(user)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -437,6 +437,12 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/shows", get(handlers::api::api_shows_list))
         .route("/api/shows", post(handlers::api::api_create_show))
+        // Note: distinct literal (not /api/shows/overview) to avoid a matchit
+        // 0.7 static-vs-:id sibling conflict with the route below.
+        .route(
+            "/api/shows-overview",
+            get(handlers::api::api_shows_overview),
+        )
         .route("/api/shows/:id", get(handlers::api::api_show_detail))
         .route(
             "/api/shows/:id/image-proxy",

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -160,6 +160,18 @@ impl UserRole {
             UserRole::Superadmin | UserRole::Admin | UserRole::Host
         )
     }
+
+    /// Check if this role may create shows.
+    ///
+    /// Hosts may create shows too, but get a constrained form: the show is
+    /// self-assigned (`host_user_id`) with a forced show type and no
+    /// description/end time. Admins get the full form.
+    pub fn can_create_show(&self) -> bool {
+        matches!(
+            self,
+            UserRole::Superadmin | UserRole::Admin | UserRole::Host
+        )
+    }
 }
 
 impl std::fmt::Display for UserRole {
@@ -233,4 +245,32 @@ pub struct OverlayPreset {
     pub updated_at: String,
     /// 'artist' or 'show'
     pub preset_type: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_parsing_round_trips() {
+        for role in [UserRole::Superadmin, UserRole::Admin, UserRole::Host] {
+            assert_eq!(UserRole::from_str(role.as_str()), Some(role.clone()));
+        }
+        assert_eq!(UserRole::from_str("ADMIN"), Some(UserRole::Admin));
+        assert_eq!(UserRole::from_str("nope"), None);
+    }
+
+    #[test]
+    fn only_admins_can_access_admin() {
+        assert!(UserRole::Superadmin.can_access_admin());
+        assert!(UserRole::Admin.can_access_admin());
+        assert!(!UserRole::Host.can_access_admin());
+    }
+
+    #[test]
+    fn hosts_and_admins_can_create_shows() {
+        assert!(UserRole::Superadmin.can_create_show());
+        assert!(UserRole::Admin.can_create_show());
+        assert!(UserRole::Host.can_create_show());
+    }
 }

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -398,7 +398,7 @@ export interface Show {
   artists: { id: number; name: string }[];
 }
 
-/** Read-only schedule entry returned by GET /api/shows/overview. */
+/** Read-only schedule entry returned by GET /api/shows-overview. */
 export interface ShowOverviewItem {
   id: number;
   title: string;

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -398,6 +398,20 @@ export interface Show {
   artists: { id: number; name: string }[];
 }
 
+/** Read-only schedule entry returned by GET /api/shows/overview. */
+export interface ShowOverviewItem {
+  id: number;
+  title: string;
+  date: string;
+  start_time?: string;
+  end_time?: string;
+  description?: string;
+  status: string;
+  show_type: string;
+  host_username?: string;
+  artists: { id: number; name: string }[];
+}
+
 export interface AssignedArtist {
   id: number;
   name: string;
@@ -450,6 +464,9 @@ export interface ShowDetail {
 
 export const showsApi = {
   list: () => api.get<{ shows: Show[]; artists: Artist[] }>('/api/shows'),
+
+  /** Read-only list of all shows (incl. other users') for any authenticated user. */
+  overview: () => api.get<{ shows: ShowOverviewItem[] }>('/api/shows-overview'),
 
   /** List all shows assigned to the authenticated user (host or artist) */
   myShows: () => api.get<{ shows: Show[] }>('/api/my-shows'),

--- a/frontend/src/admin/components/ShowCreateModal.vue
+++ b/frontend/src/admin/components/ShowCreateModal.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useAuthStore } from '../stores/auth';
+import { showsApi, type Show } from '../api';
+import { BaseButton, BaseModal, FormInput } from '@shared/components';
+import { useFlash } from '../composables/useFlash';
+import { useDateTimeRange } from '../composables/useDateTimeRange';
+import { buildShowCreatePayload, validateShowCreate } from '../showCreatePayload';
+import { VueDatePicker } from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
+
+defineProps<{ open: boolean }>();
+const emit = defineEmits<{ close: []; created: [show: Show] }>();
+
+const auth = useAuthStore();
+const flash = useFlash();
+
+/** Admins get the full form; hosts get the constrained one (issue #146). */
+const isAdmin = computed(
+  () => auth.user?.role === 'admin' || auth.user?.role === 'superadmin'
+);
+
+const creating = ref(false);
+const title = ref('');
+const description = ref('');
+const showType = ref('unheard');
+
+const {
+  startDateTime,
+  endDateTime,
+  isValid: rangeValid,
+  validationError: rangeError,
+  apiDate,
+  apiStartTime,
+  apiEndTime,
+  reset: resetRange,
+} = useDateTimeRange();
+
+function resetForm() {
+  title.value = '';
+  description.value = '';
+  showType.value = 'unheard';
+  resetRange();
+}
+
+function close() {
+  emit('close');
+}
+
+async function submit() {
+  const validationError = validateShowCreate(isAdmin.value, {
+    title: title.value,
+    startTime: apiStartTime.value,
+    endTime: apiEndTime.value,
+    startBeforeEnd: rangeValid.value,
+  });
+  if (validationError) {
+    flash.error(validationError);
+    return;
+  }
+
+  creating.value = true;
+  try {
+    const created = await showsApi.create(
+      buildShowCreatePayload(isAdmin.value, {
+        title: title.value,
+        description: description.value,
+        showType: showType.value,
+        date: apiDate.value,
+        startTime: apiStartTime.value,
+        endTime: apiEndTime.value,
+      })
+    );
+    flash.success('Show created successfully');
+    resetForm();
+    emit('created', created);
+  } catch (e) {
+    flash.error(e instanceof Error ? e.message : 'Failed to create show');
+  } finally {
+    creating.value = false;
+  }
+}
+</script>
+
+<template>
+  <BaseModal :open="open" title="Create New Show" @close="close">
+    <form class="create-form" @submit.prevent="submit">
+      <div v-if="isAdmin" class="form-group">
+        <label class="form-label">Show Type</label>
+        <select v-model="showType" class="type-select">
+          <option value="unheard">UNHEARD</option>
+          <option value="brunchtime">Brunchtime</option>
+          <option value="external">External</option>
+        </select>
+      </div>
+
+      <FormInput v-model="title" label="Title" required />
+
+      <div class="form-group">
+        <label class="form-label">Start <span class="form-required">*</span></label>
+        <VueDatePicker
+          v-model="startDateTime"
+          :enable-time-picker="true"
+          :dark="true"
+          :minutes-increment="5"
+          :max-date="isAdmin ? endDateTime || undefined : undefined"
+          :flow="{ steps: ['calendar', 'time'] }"
+          :action-row="{ showCancel: false, showPreview: false, selectBtnLabel: 'Confirm' }"
+          placeholder="Start date & time"
+          text-input
+          teleport="body"
+        />
+      </div>
+
+      <template v-if="isAdmin">
+        <div class="form-group">
+          <label class="form-label">End <span class="form-required">*</span></label>
+          <VueDatePicker
+            v-model="endDateTime"
+            :enable-time-picker="true"
+            :dark="true"
+            :minutes-increment="5"
+            :min-date="startDateTime || undefined"
+            :flow="{ steps: ['calendar', 'time'] }"
+            :action-row="{ showCancel: false, showPreview: false, selectBtnLabel: 'Confirm' }"
+            placeholder="End date & time"
+            text-input
+            teleport="body"
+          />
+        </div>
+        <p v-if="startDateTime && endDateTime && !rangeValid" class="field-error">
+          {{ rangeError }}
+        </p>
+        <FormInput v-model="description" label="Description" />
+      </template>
+    </form>
+    <template #footer>
+      <BaseButton variant="ghost" @click="close">Cancel</BaseButton>
+      <BaseButton variant="primary" :loading="creating" @click="submit">Create Show</BaseButton>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.form-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-medium);
+}
+
+.form-required {
+  color: var(--color-error);
+}
+
+.field-error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.type-select {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+</style>

--- a/frontend/src/admin/pages/ShowsPage.vue
+++ b/frontend/src/admin/pages/ShowsPage.vue
@@ -2,15 +2,11 @@
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { showsApi, type Show } from '../api';
-import { BaseButton, BaseModal, FormInput } from '@shared/components';
-import { useFlash } from '../composables/useFlash';
-import { useDateTimeRange } from '../composables/useDateTimeRange';
+import { BaseButton } from '@shared/components';
 import ShowList from '../components/ShowList.vue';
-import { VueDatePicker } from '@vuepic/vue-datepicker';
-import '@vuepic/vue-datepicker/dist/main.css';
+import ShowCreateModal from '../components/ShowCreateModal.vue';
 
 const router = useRouter();
-const flash = useFlash();
 const shows = ref<Show[]>([]);
 const loading = ref(true);
 const error = ref<string | null>(null);
@@ -38,22 +34,6 @@ const showCount = computed(() => {
 });
 
 const showCreateModal = ref(false);
-const creating = ref(false);
-const newShow = ref({
-  title: '',
-  description: '',
-  show_type: 'unheard',
-});
-const {
-  startDateTime: createStart,
-  endDateTime: createEnd,
-  isValid: createTimeValid,
-  validationError: createTimeError,
-  apiDate: createDate,
-  apiStartTime: createStartTime,
-  apiEndTime: createEndTime,
-  reset: resetCreateRange,
-} = useDateTimeRange();
 
 function goToShow(show: Show) {
   router.push(`/shows/${show.id}`);
@@ -72,31 +52,11 @@ async function loadShows() {
   }
 }
 
-async function createShow() {
-  if (!createTimeValid.value) {
-    flash.error(createTimeError.value || 'Invalid date/time');
-    return;
-  }
-  creating.value = true;
-  try {
-    const created = await showsApi.create({
-      ...newShow.value,
-      date: createDate.value,
-      start_time: createStartTime.value,
-      end_time: createEndTime.value,
-    });
-    flash.success('Show created successfully');
-    showCreateModal.value = false;
-    newShow.value = { title: '', description: '', show_type: 'unheard' };
-    resetCreateRange();
-    await loadShows();
-    if (created?.id) {
-      router.push(`/shows/${created.id}`);
-    }
-  } catch (e) {
-    flash.error(e instanceof Error ? e.message : 'Failed to create show');
-  } finally {
-    creating.value = false;
+async function onShowCreated(show: Show) {
+  showCreateModal.value = false;
+  await loadShows();
+  if (show?.id) {
+    router.push(`/shows/${show.id}`);
   }
 }
 
@@ -129,57 +89,11 @@ onMounted(loadShows);
       <ShowList :shows="shows" :filter="listFilter" @show-click="goToShow" />
     </template>
 
-    <BaseModal :open="showCreateModal" title="Create New Show" @close="showCreateModal = false">
-      <form class="create-form" @submit.prevent="createShow">
-        <div class="form-group">
-          <label class="form-label">Show Type</label>
-          <select v-model="newShow.show_type" class="type-select">
-            <option value="unheard">UNHEARD</option>
-            <option value="brunchtime">Brunchtime</option>
-            <option value="external">External</option>
-          </select>
-        </div>
-        <FormInput v-model="newShow.title" label="Title" required />
-        <div class="form-group">
-          <label class="form-label">Start <span class="form-required">*</span></label>
-          <VueDatePicker
-            v-model="createStart"
-            :enable-time-picker="true"
-            :dark="true"
-            :minutes-increment="5"
-            :max-date="createEnd || undefined"
-            :flow="{ steps: ['calendar', 'time'] }"
-            :action-row="{ showCancel: false, showPreview: false, selectBtnLabel: 'Confirm' }"
-            placeholder="Start date & time"
-            text-input
-            teleport="body"
-          />
-        </div>
-        <div class="form-group">
-          <label class="form-label">End <span class="form-required">*</span></label>
-          <VueDatePicker
-            v-model="createEnd"
-            :enable-time-picker="true"
-            :dark="true"
-            :minutes-increment="5"
-            :min-date="createStart || undefined"
-            :flow="{ steps: ['calendar', 'time'] }"
-            :action-row="{ showCancel: false, showPreview: false, selectBtnLabel: 'Confirm' }"
-            placeholder="End date & time"
-            text-input
-            teleport="body"
-          />
-        </div>
-        <p v-if="createStart && createEnd && !createTimeValid" class="field-error">{{ createTimeError }}</p>
-        <FormInput v-model="newShow.description" label="Description" />
-      </form>
-      <template #footer>
-        <BaseButton variant="ghost" @click="showCreateModal = false">Cancel</BaseButton>
-        <BaseButton variant="primary" :loading="creating" @click="createShow">
-          Create Show
-        </BaseButton>
-      </template>
-    </BaseModal>
+    <ShowCreateModal
+      :open="showCreateModal"
+      @close="showCreateModal = false"
+      @created="onShowCreated"
+    />
   </div>
 </template>
 
@@ -233,42 +147,5 @@ onMounted(loadShows);
 
 .list-count {
   font-size: var(--font-size-sm);
-}
-
-.create-form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-}
-
-.form-label {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  font-weight: var(--font-weight-medium);
-}
-
-.form-required {
-  color: var(--color-error);
-}
-
-.field-error {
-  color: var(--color-error);
-  font-size: var(--font-size-sm);
-  margin: 0;
-}
-
-.type-select {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text);
-  font-family: var(--font-family);
-  padding: var(--spacing-sm) var(--spacing-md);
 }
 </style>

--- a/frontend/src/admin/pages/flow/FlowNotAssigned.vue
+++ b/frontend/src/admin/pages/flow/FlowNotAssigned.vue
@@ -1,16 +1,40 @@
 <script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useHostFlow } from '@admin/composables';
+import { BaseButton } from '@shared/components';
+import ShowCreateModal from '@admin/components/ShowCreateModal.vue';
+
+const router = useRouter();
+const flow = useHostFlow();
+
+const showCreateModal = ref(false);
+
+/** Reset the cached flow so the new show is picked up, then re-enter /stream. */
+async function onShowCreated() {
+  showCreateModal.value = false;
+  flow.reset();
+  await router.push('/stream');
+}
 </script>
 
 <template>
   <div class="flow-not-assigned">
     <div class="not-assigned-content">
       <img src="/assets/brand/moafunk.png" alt="Moafunk" class="not-assigned-logo" />
-      <h1 class="not-assigned-title">Not Assigned</h1>
+      <h1 class="not-assigned-title">No Shows Yet</h1>
       <p class="not-assigned-message">
         You are not currently assigned to a show.<br />
-        Please wait for your assignment — we'll let you know when it's time.
+        Create your own to start streaming.
       </p>
+      <BaseButton variant="primary" class="not-assigned-cta" @click="showCreateModal = true">+ New Show</BaseButton>
     </div>
+
+    <ShowCreateModal
+      :open="showCreateModal"
+      @close="showCreateModal = false"
+      @created="onShowCreated"
+    />
   </div>
 </template>
 
@@ -45,5 +69,9 @@
   color: var(--color-text-muted);
   line-height: var(--line-height-relaxed);
   margin: 0;
+}
+
+.not-assigned-cta {
+  margin-top: var(--spacing-xl);
 }
 </style>

--- a/frontend/src/admin/pages/flow/FlowShowSelect.vue
+++ b/frontend/src/admin/pages/flow/FlowShowSelect.vue
@@ -1,14 +1,26 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useHostFlow } from '@admin/composables';
-import type { MyShowInfo } from '@admin/api';
+import type { MyShowInfo, Show } from '@admin/api';
+import { BaseButton } from '@shared/components';
+import ShowCreateModal from '@admin/components/ShowCreateModal.vue';
 
 const router = useRouter();
 const flow = useHostFlow();
 
 // Filter out shows that have already ended
 const shows = computed(() => flow.shows.value.filter(s => !flow.isShowEnded(s)));
+
+const showCreateModal = ref(false);
+
+/** After a host creates a show, reload the flow and jump straight into it. */
+async function onShowCreated(show: Show) {
+  showCreateModal.value = false;
+  await flow.fetchMyShow();
+  const created = flow.shows.value.find((s) => s.id === show.id);
+  if (created) pickShow(created);
+}
 
 /** Format a date string into a readable date */
 function fmtDate(dateStr: string): string {
@@ -71,11 +83,17 @@ function showTypeBadge(type: string): string {
 
 <template>
   <div class="flow-select">
-    <h1 class="flow-select-title">My Shows</h1>
-    <p class="flow-select-subtitle">Select a show to prepare for streaming.</p>
+    <div class="flow-select-header">
+      <div>
+        <h1 class="flow-select-title">My Shows</h1>
+        <p class="flow-select-subtitle">Select a show to prepare for streaming.</p>
+      </div>
+      <BaseButton variant="primary" @click="showCreateModal = true">+ New Show</BaseButton>
+    </div>
 
     <div v-if="shows.length === 0" class="flow-select-empty">
-      <p class="text-muted">No shows assigned.</p>
+      <p class="text-muted">No shows yet.</p>
+      <BaseButton variant="primary" @click="showCreateModal = true">+ New Show</BaseButton>
     </div>
 
     <div class="show-cards">
@@ -105,10 +123,24 @@ function showTypeBadge(type: string): string {
         </div>
       </button>
     </div>
+
+    <ShowCreateModal
+      :open="showCreateModal"
+      @close="showCreateModal = false"
+      @created="onShowCreated"
+    />
   </div>
 </template>
 
 <style scoped>
+.flow-select-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-xl);
+}
+
 .flow-select-title {
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);
@@ -118,12 +150,16 @@ function showTypeBadge(type: string): string {
 
 .flow-select-subtitle {
   color: var(--color-text-muted);
-  margin: 0 0 var(--spacing-xl);
+  margin: 0;
 }
 
 .flow-select-empty {
   text-align: center;
   padding: var(--spacing-2xl);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-lg);
 }
 
 .show-cards {

--- a/frontend/src/admin/pages/flow/FlowShowSelect.vue
+++ b/frontend/src/admin/pages/flow/FlowShowSelect.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useHostFlow } from '@admin/composables';
-import type { MyShowInfo, Show } from '@admin/api';
-import { BaseButton } from '@shared/components';
+import { showsApi, type MyShowInfo, type Show, type ShowOverviewItem } from '@admin/api';
+import { BaseButton, BaseModal } from '@shared/components';
 import ShowCreateModal from '@admin/components/ShowCreateModal.vue';
 
 const router = useRouter();
@@ -14,10 +14,32 @@ const shows = computed(() => flow.shows.value.filter(s => !flow.isShowEnded(s)))
 
 const showCreateModal = ref(false);
 
+// Read-only overview of the full schedule (incl. other users' shows).
+const allShows = ref<ShowOverviewItem[]>([]);
+const allShowsError = ref<string | null>(null);
+const detailShow = ref<ShowOverviewItem | null>(null);
+
+async function loadAllShows() {
+  allShowsError.value = null;
+  try {
+    const response = await showsApi.overview();
+    allShows.value = response.shows;
+  } catch (e) {
+    allShowsError.value = e instanceof Error ? e.message : 'Failed to load shows';
+  }
+}
+
+onMounted(loadAllShows);
+
+/** Open the read-only detail modal for any show in the overview. */
+function openDetail(s: ShowOverviewItem) {
+  detailShow.value = s;
+}
+
 /** After a host creates a show, reload the flow and jump straight into it. */
 async function onShowCreated(show: Show) {
   showCreateModal.value = false;
-  await flow.fetchMyShow();
+  await Promise.all([flow.fetchMyShow(), loadAllShows()]);
   const created = flow.shows.value.find((s) => s.id === show.id);
   if (created) pickShow(created);
 }
@@ -124,11 +146,79 @@ function showTypeBadge(type: string): string {
       </button>
     </div>
 
+    <!-- Full schedule (read-only) -->
+    <section class="all-shows">
+      <h2 class="all-shows-title">All Shows</h2>
+      <p class="all-shows-subtitle">The full schedule, including other hosts' shows.</p>
+
+      <div v-if="allShowsError" class="all-shows-error">{{ allShowsError }}</div>
+      <div v-else-if="allShows.length === 0" class="text-muted">No shows scheduled.</div>
+
+      <div v-else class="show-cards">
+        <button v-for="s in allShows" :key="s.id" class="show-card" @click="openDetail(s)">
+          <div class="show-card-header">
+            <span class="show-card-type">{{ showTypeBadge(s.show_type) }}</span>
+            <span :class="['show-card-days', daysClass(s.date)]">{{ daysLabel(s.date) }}</span>
+          </div>
+          <h3 class="show-card-title">{{ s.title }}</h3>
+          <div class="show-card-date">{{ fmtDate(s.date) }}</div>
+          <div v-if="s.start_time" class="show-card-time">
+            {{ s.start_time }}<template v-if="s.end_time"> – {{ s.end_time }}</template>
+          </div>
+          <div v-if="s.host_username" class="show-card-host">Host: {{ s.host_username }}</div>
+          <div v-if="s.artists.length > 0" class="show-card-artists">
+            <span v-for="artist in s.artists" :key="artist.id" class="artist-chip">
+              {{ artist.name }}
+            </span>
+          </div>
+        </button>
+      </div>
+    </section>
+
     <ShowCreateModal
       :open="showCreateModal"
       @close="showCreateModal = false"
       @created="onShowCreated"
     />
+
+    <!-- Read-only show detail -->
+    <BaseModal :open="!!detailShow" :title="detailShow?.title" @close="detailShow = null">
+      <div v-if="detailShow" class="detail">
+        <div class="detail-row">
+          <span class="detail-label">Type</span>
+          <span>{{ showTypeBadge(detailShow.show_type) }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">Date</span>
+          <span>{{ fmtDate(detailShow.date) }}</span>
+        </div>
+        <div v-if="detailShow.start_time" class="detail-row">
+          <span class="detail-label">Time</span>
+          <span>
+            {{ detailShow.start_time }}<template v-if="detailShow.end_time"> – {{ detailShow.end_time }}</template>
+          </span>
+        </div>
+        <div v-if="detailShow.host_username" class="detail-row">
+          <span class="detail-label">Host</span>
+          <span>{{ detailShow.host_username }}</span>
+        </div>
+        <div v-if="detailShow.artists.length > 0" class="detail-row">
+          <span class="detail-label">Artists</span>
+          <div class="show-card-artists">
+            <span v-for="artist in detailShow.artists" :key="artist.id" class="artist-chip">
+              {{ artist.name }}
+            </span>
+          </div>
+        </div>
+        <div v-if="detailShow.description" class="detail-row detail-description">
+          <span class="detail-label">Description</span>
+          <p>{{ detailShow.description }}</p>
+        </div>
+      </div>
+      <template #footer>
+        <BaseButton variant="ghost" @click="detailShow = null">Close</BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
@@ -279,5 +369,70 @@ function showTypeBadge(type: string): string {
 .status-live {
   color: #ef4444;
   font-weight: var(--font-weight-bold);
+}
+
+/* All Shows (read-only overview) */
+.all-shows {
+  margin-top: var(--spacing-2xl);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-xl);
+}
+
+.all-shows-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  margin: 0 0 var(--spacing-xs);
+}
+
+.all-shows-subtitle {
+  color: var(--color-text-muted);
+  margin: 0 0 var(--spacing-lg);
+}
+
+.all-shows-error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.show-card-host {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
+/* Read-only detail modal */
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.detail-row {
+  display: flex;
+  gap: var(--spacing-md);
+  align-items: baseline;
+}
+
+.detail-label {
+  flex: 0 0 90px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.detail-description {
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.detail-description p {
+  margin: 0;
+  line-height: var(--line-height-relaxed);
+}
+
+.detail .show-card-artists {
+  margin-top: 0;
 }
 </style>

--- a/frontend/src/admin/showCreatePayload.ts
+++ b/frontend/src/admin/showCreatePayload.ts
@@ -1,0 +1,57 @@
+import type { Show } from './api';
+
+/** Form state collected by the create-show modal. */
+export interface ShowCreateForm {
+  title: string;
+  description: string;
+  showType: string;
+  /** YYYY-MM-DD derived from the start picker. */
+  date: string;
+  /** HH:MM derived from the start picker. */
+  startTime: string;
+  /** HH:MM derived from the end picker (admins only). */
+  endTime: string;
+}
+
+/**
+ * Build the `POST /api/shows` payload, applying the role-based field rules from
+ * issue #146.
+ *
+ * Hosts submit only title + start; the backend forces the show type, drops
+ * description/end time and self-assigns the host. Admins submit every field.
+ */
+export function buildShowCreatePayload(isAdmin: boolean, form: ShowCreateForm): Partial<Show> {
+  const base: Partial<Show> = {
+    title: form.title.trim(),
+    date: form.date,
+    start_time: form.startTime,
+  };
+
+  if (!isAdmin) return base;
+
+  return {
+    ...base,
+    show_type: form.showType,
+    end_time: form.endTime,
+    description: form.description,
+  };
+}
+
+/**
+ * Validate the create-show form for the given role. Returns an error message,
+ * or `null` when the form is ready to submit.
+ *
+ * Admins require a valid start/end range; hosts only require a start time.
+ */
+export function validateShowCreate(
+  isAdmin: boolean,
+  form: { title: string; startTime: string; endTime: string; startBeforeEnd: boolean }
+): string | null {
+  if (!form.title.trim()) return 'Title is required';
+  if (!form.startTime) return 'Start date & time is required';
+  if (isAdmin) {
+    if (!form.endTime) return 'End date & time is required';
+    if (!form.startBeforeEnd) return 'Start must be before end';
+  }
+  return null;
+}

--- a/frontend/tests/showCreatePayload.test.ts
+++ b/frontend/tests/showCreatePayload.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildShowCreatePayload,
+  validateShowCreate,
+  type ShowCreateForm,
+} from '../src/admin/showCreatePayload';
+
+const baseForm: ShowCreateForm = {
+  title: '  My Show  ',
+  description: 'desc',
+  showType: 'brunchtime',
+  date: '2026-06-01',
+  startTime: '20:00',
+  endTime: '22:00',
+};
+
+describe('buildShowCreatePayload', () => {
+  it('sends all fields for admins', () => {
+    expect(buildShowCreatePayload(true, baseForm)).toEqual({
+      title: 'My Show',
+      date: '2026-06-01',
+      start_time: '20:00',
+      show_type: 'brunchtime',
+      end_time: '22:00',
+      description: 'desc',
+    });
+  });
+
+  it('sends only title/date/start for hosts (no type, end, description)', () => {
+    const payload = buildShowCreatePayload(false, baseForm);
+    expect(payload).toEqual({
+      title: 'My Show',
+      date: '2026-06-01',
+      start_time: '20:00',
+    });
+    expect(payload).not.toHaveProperty('show_type');
+    expect(payload).not.toHaveProperty('end_time');
+    expect(payload).not.toHaveProperty('description');
+  });
+
+  it('trims the title', () => {
+    expect(buildShowCreatePayload(false, { ...baseForm, title: '  Spaced  ' }).title).toBe('Spaced');
+  });
+});
+
+describe('validateShowCreate', () => {
+  const ok = { title: 'T', startTime: '20:00', endTime: '22:00', startBeforeEnd: true };
+
+  it('passes for a complete admin form', () => {
+    expect(validateShowCreate(true, ok)).toBeNull();
+  });
+
+  it('passes for a host with only a start time', () => {
+    expect(validateShowCreate(false, { title: 'T', startTime: '20:00', endTime: '', startBeforeEnd: false })).toBeNull();
+  });
+
+  it('requires a title', () => {
+    expect(validateShowCreate(false, { ...ok, title: '   ' })).toBe('Title is required');
+  });
+
+  it('requires a start time', () => {
+    expect(validateShowCreate(false, { ...ok, startTime: '' })).toBe('Start date & time is required');
+  });
+
+  it('requires an end time for admins only', () => {
+    expect(validateShowCreate(true, { ...ok, endTime: '' })).toBe('End date & time is required');
+  });
+
+  it('rejects an inverted range for admins', () => {
+    expect(validateShowCreate(true, { ...ok, startBeforeEnd: false })).toBe('Start must be before end');
+  });
+});


### PR DESCRIPTION
Closes #146.

Two related host-show capabilities.

## 1. Hosts can create their own shows
Creation was admin-only; the "New Show" modal lived on the admin-only `/shows` route. Now a `host` creates a **self-assigned** show from a simplified form.

| Field | Admin / Superadmin | Host |
|-------|--------------------|------|
| Title | ✅ required | ✅ required |
| Start time | ✅ required | ✅ required |
| Show type | ✅ selectable | ❌ hidden → forced `external` |
| End time | ✅ required | ❌ not shown / not sent |
| Description | ✅ optional | ❌ not shown / not sent |
| Assignee | assigned later | 🔒 self (`host_user_id` = creator) |

- `UserRole::can_create_show()` + `require_show_creator` (host or admin; still 401s unauthenticated).
- `api_create_show`: hosts allowed; non-admins get forced type, self host-assignment, no description/end; `start_time`/`end_time` now optional. Admin path unchanged.
- Role-aware `ShowCreateModal.vue` + pure `buildShowCreatePayload`/`validateShowCreate` helpers (9 unit tests). Reachable from `FlowShowSelect`, `FlowNotAssigned` (no dead-end) and admin `ShowsPage`.

## 2. Hosts see a read-only overview of all shows
Hosts previously saw only their own assigned shows. The select page now also lists the full schedule (everyone's shows).

- `GET /api/shows-overview`: read-only list of **all** shows for any authenticated user, with `host_username` + artist names. Distinct literal path (not `/api/shows/overview`) to avoid a matchit 0.7 static-vs-`:id` route conflict.
- `FlowShowSelect`: "All Shows" section under "My Shows"; clicking any show opens a **read-only detail modal** (type/date/time/host/artists/description). "My Shows" stays selectable for streaming.

## Verification
- `cargo build` clean; clippy adds no new warnings.
- Frontend: 15/15 vitest pass; `vite build` compiles all SFCs; ESLint clean; `tsc` error count unchanged (pre-existing `.vue`-shim noise only).

## Notes (pre-existing, not touched)
- Backend **test target** doesn't compile on `main` (`recording.rs`: missing `tempfile` dev-dep + stale `add_marker` calls). Blocks running the new `models` tests. Follow-up.