### PR TITLE
feat(auth): force self-chosen password on first login

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -299,6 +299,7 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             role TEXT NOT NULL DEFAULT 'host',
             created_by INTEGER,
             expires_at TEXT,
+            must_change_password INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT,
             FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
@@ -306,6 +307,16 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         "#,
     )
     .execute(pool)
+    .await?;
+
+    // Migration: force a self-chosen password after the admin-generated bootstrap
+    // password (set on create/reset, cleared once the user picks their own).
+    add_column_if_missing(
+        pool,
+        "users",
+        "must_change_password",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
     .await?;
 
     sqlx::query(

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -44,6 +44,7 @@ pub struct UserResponse {
     artist_id: Option<i64>,
     artist_name: Option<String>,
     has_show: bool,
+    must_change_password: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -133,6 +134,7 @@ pub async fn api_login(
             artist_id,
             artist_name,
             has_show,
+            must_change_password: user.must_change_password,
         },
         redirect_url: redirect_url.to_string(),
     };
@@ -195,6 +197,7 @@ pub async fn api_me(
                 artist_id,
                 artist_name,
                 has_show,
+                must_change_password: u.must_change_password,
             }))
         }
         None => Err(AppError::Unauthorized("Not authenticated".to_string())),
@@ -238,9 +241,53 @@ pub async fn api_change_password(
         ));
     }
 
-    // Hash and update password
+    // Hash and update password, clearing any forced-change flag
     let new_hash = auth::hash_password(&req.new_password)?;
-    sqlx::query("UPDATE users SET password_hash = ? WHERE id = ?")
+    sqlx::query("UPDATE users SET password_hash = ?, must_change_password = 0 WHERE id = ?")
+        .bind(&new_hash)
+        .bind(user.id)
+        .execute(&state.db)
+        .await?;
+
+    Ok(Json(serde_json::json!({ "success": true })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetInitialPasswordRequest {
+    new_password: String,
+}
+
+/// Set a self-chosen password on first login, replacing the admin-generated
+/// bootstrap password. Unlike `api_change_password`, this does not require the
+/// current password — the session proves identity — but it is only usable while
+/// `must_change_password` is set, so it cannot bypass verification afterwards.
+pub async fn api_set_initial_password(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<SetInitialPasswordRequest>,
+) -> Result<impl IntoResponse> {
+    let token = auth::get_session_from_headers(&headers);
+    let user = auth::get_current_user(&state, token.as_deref())
+        .await
+        .ok_or_else(|| AppError::Unauthorized("Not authenticated".to_string()))?;
+
+    // Only usable while a forced password change is pending.
+    if !user.must_change_password {
+        return Err(AppError::Forbidden(
+            "Password change is not required for this account".to_string(),
+        ));
+    }
+
+    // Validate new password
+    if req.new_password.len() < 8 {
+        return Err(AppError::BadRequest(
+            "New password must be at least 8 characters".to_string(),
+        ));
+    }
+
+    // Hash and update password, clearing the forced-change flag
+    let new_hash = auth::hash_password(&req.new_password)?;
+    sqlx::query("UPDATE users SET password_hash = ?, must_change_password = 0 WHERE id = ?")
         .bind(&new_hash)
         .bind(user.id)
         .execute(&state.db)
@@ -3235,7 +3282,8 @@ pub async fn api_create_user(
     let password_hash = auth::hash_password(&password)?;
 
     let result = sqlx::query(
-        "INSERT INTO users (username, password_hash, role, expires_at) VALUES (?, ?, ?, ?)",
+        "INSERT INTO users (username, password_hash, role, expires_at, must_change_password) \
+         VALUES (?, ?, ?, ?, 1)",
     )
     .bind(&req.username)
     .bind(&password_hash)
@@ -3491,11 +3539,11 @@ pub async fn api_reset_password(
         ));
     }
 
-    // Generate new password
+    // Generate new bootstrap password; force the user to choose their own on next login
     let password = auth::generate_session_token()[..16].to_string();
     let password_hash = auth::hash_password(&password)?;
 
-    sqlx::query("UPDATE users SET password_hash = ? WHERE id = ?")
+    sqlx::query("UPDATE users SET password_hash = ?, must_change_password = 1 WHERE id = ?")
         .bind(&password_hash)
         .bind(id)
         .execute(&state.db)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -316,6 +316,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/auth/change-password",
             post(handlers::api::api_change_password),
         )
+        .route(
+            "/api/auth/set-initial-password",
+            post(handlers::api::api_set_initial_password),
+        )
         // Artist flow — my show
         .route("/api/my-show", get(handlers::api::api_my_show))
         .route("/api/my-shows", get(handlers::api::api_my_shows_list))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -188,6 +188,9 @@ pub struct User {
     pub role: String,
     pub created_by: Option<i64>,
     pub expires_at: Option<String>,
+    /// True while the user must replace an admin-generated bootstrap password
+    /// with one they chose (set on create/reset, cleared on change).
+    pub must_change_password: bool,
     pub created_at: String,
     pub updated_at: Option<String>,
 }

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -74,6 +74,7 @@ export interface User {
   artist_id?: number;
   artist_name?: string;
   has_show?: boolean;
+  must_change_password?: boolean;
 }
 
 export interface LoginResponse {
@@ -88,6 +89,11 @@ export const authApi = {
   logout: () => api.post<void>('/api/auth/logout'),
 
   me: () => api.get<User>('/api/auth/me'),
+
+  // First-login password set: no current password required (session proves
+  // identity); only valid while the account has must_change_password set.
+  setInitialPassword: (newPassword: string) =>
+    api.post<void>('/api/auth/set-initial-password', { new_password: newPassword }),
 };
 
 // Overlay types

--- a/frontend/src/admin/pages/ChangePasswordPage.vue
+++ b/frontend/src/admin/pages/ChangePasswordPage.vue
@@ -1,18 +1,28 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
-import { usersApi } from '../api';
+import { authApi, usersApi } from '../api';
+import { useAuthStore } from '../stores/auth';
 import { BaseButton, FormInput } from '@shared/components';
 import { useFlash } from '../composables/useFlash';
 
 const router = useRouter();
 const flash = useFlash();
+const authStore = useAuthStore();
+
+// Forced first-login flow: the user still has an admin-generated password and
+// must replace it before reaching the rest of the app.
+const forced = computed(() => authStore.user?.must_change_password === true);
 
 const currentPassword = ref('');
 const newPassword = ref('');
 const confirmPassword = ref('');
 const loading = ref(false);
 const error = ref<string | null>(null);
+
+function defaultRouteForRole(): string {
+  return authStore.user?.role === 'host' ? '/stream' : '/dashboard';
+}
 
 async function changePassword() {
   if (newPassword.value !== confirmPassword.value) {
@@ -29,9 +39,15 @@ async function changePassword() {
   error.value = null;
 
   try {
-    await usersApi.changePassword(currentPassword.value, newPassword.value);
+    if (forced.value) {
+      // No current password required — the session proves identity.
+      await authApi.setInitialPassword(newPassword.value);
+      authStore.markPasswordChanged();
+    } else {
+      await usersApi.changePassword(currentPassword.value, newPassword.value);
+    }
     flash.success('Password changed successfully');
-    router.push('/artists');
+    router.push(defaultRouteForRole());
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to change password';
   } finally {
@@ -43,14 +59,19 @@ async function changePassword() {
 <template>
   <div class="change-password-page">
     <div class="page-header">
-      <h1 class="page-title">Change Password</h1>
+      <h1 class="page-title">{{ forced ? 'Set Your Password' : 'Change Password' }}</h1>
     </div>
 
     <div class="card" style="max-width: 500px;">
+      <p v-if="forced" class="forced-notice">
+        You're signed in with a temporary password. Choose your own password to continue.
+      </p>
+
       <form class="password-form" @submit.prevent="changePassword">
         <div v-if="error" class="flash-message error">{{ error }}</div>
 
         <FormInput
+          v-if="!forced"
           v-model="currentPassword"
           label="Current Password"
           type="password"
@@ -75,11 +96,11 @@ async function changePassword() {
         />
 
         <div class="form-actions">
-          <BaseButton type="button" variant="ghost" @click="router.back()">
+          <BaseButton v-if="!forced" type="button" variant="ghost" @click="router.back()">
             Cancel
           </BaseButton>
           <BaseButton type="submit" variant="primary" :loading="loading">
-            Change Password
+            {{ forced ? 'Set Password' : 'Change Password' }}
           </BaseButton>
         </div>
       </form>
@@ -88,6 +109,11 @@ async function changePassword() {
 </template>
 
 <style scoped>
+.forced-notice {
+  margin: 0 0 var(--spacing-md);
+  color: var(--color-text-muted, inherit);
+}
+
 .password-form {
   display: flex;
   flex-direction: column;

--- a/frontend/src/admin/router.ts
+++ b/frontend/src/admin/router.ts
@@ -204,6 +204,16 @@ router.beforeEach(async (to, _from, next) => {
     return;
   }
 
+  // Force a self-chosen password before anything else is reachable.
+  if (
+    authStore.isAuthenticated &&
+    authStore.user?.must_change_password &&
+    to.name !== 'change-password'
+  ) {
+    next({ name: 'change-password' });
+    return;
+  }
+
   if (requiredRoles && authStore.user && !requiredRoles.includes(authStore.user.role)) {
     next({ name: 'stream' }); // Redirect to stream if insufficient role
     return;

--- a/frontend/src/admin/stores/auth.ts
+++ b/frontend/src/admin/stores/auth.ts
@@ -56,6 +56,12 @@ export const useAuthStore = defineStore('auth', () => {
     error.value = null;
   }
 
+  // Clear the forced-change flag locally after the user sets their own password,
+  // so the router guard releases without requiring a full reload.
+  function markPasswordChanged(): void {
+    if (user.value) user.value.must_change_password = false;
+  }
+
   return {
     user,
     initialized,
@@ -66,5 +72,6 @@ export const useAuthStore = defineStore('auth', () => {
     logout,
     checkAuth,
     clearError,
+    markPasswordChanged,
   };
 });


### PR DESCRIPTION
## Summary
Forces users to set their own password on first login. The admin-generated password becomes a one-time bootstrap: a new `must_change_password` flag (set on user create + admin reset, cleared on change) gates the app until the user chooses their own password.

## Backend
- `users.must_change_password` column (CREATE TABLE + `add_column_if_missing` migration; defaults `0`, so existing users and the seeded superadmin are unaffected)
- set on create/reset, cleared on change
- new `POST /api/auth/set-initial-password` — sets a new password without the current one (session proves identity), usable **only** while the flag is set
- flag exposed via login + `/api/auth/me`

## Frontend
- router guard redirects flagged users to `/change-password` and blocks every other route until done
- `ChangePasswordPage` dual-mode: forced (new + confirm only, no cancel) vs voluntary; role-aware redirect after success (also fixes the old hardcoded `/artists` that broke hosts)

## Test plan
- [x] `cargo build` clean; `cargo clippy --bins` introduces no new warnings
- [x] `npm run build` + `npm run lint` pass
- [ ] Manual E2E: create user → log in with temp pw → forced to change → set new pw → lands on role default → re-login not forced; admin reset re-arms the flag
- No automated tests added (backend test target pre-broken; no FE auth/router harness)

Closes #152
