### PR TITLE
style(backend): apply cargo fmt

### DIFF
--- a/backend/src/ai.rs
+++ b/backend/src/ai.rs
@@ -382,7 +382,8 @@ STRICT rules:\n\
 This is a hard limit — shorten if needed. Prioritise being concise over exhaustive.\n\
 - Output ONLY the show description, nothing else.";
 
-const NON_UNHEARD_BIO_PROMPT: &str = "You write short, engaging show descriptions for Moafunk Radio events.\n\n\
+const NON_UNHEARD_BIO_PROMPT: &str =
+    "You write short, engaging show descriptions for Moafunk Radio events.\n\n\
 You will be given the show title, show type (e.g., 'brunchtime' or 'external'), \
 and a description that provides context about the event.\n\n\
 Write a compelling show description that:\n\
@@ -400,10 +401,7 @@ This is a hard limit — shorten if needed. Prioritise being concise over exhaus
 - Output ONLY the show description, nothing else.";
 
 /// Generate a show bio from description text only (for non-UNHEARD shows).
-pub async fn generate_show_bio_from_text(
-    config: &Config,
-    user_content: &str,
-) -> Result<String> {
+pub async fn generate_show_bio_from_text(config: &Config, user_content: &str) -> Result<String> {
     let api_key = config
         .openai_api_key
         .as_ref()
@@ -411,7 +409,10 @@ pub async fn generate_show_bio_from_text(
 
     tracing::info!("Calling OpenAI API for non-UNHEARD show bio generation");
     let bio = call_openai(api_key, NON_UNHEARD_BIO_PROMPT, user_content, 0.7, 300).await?;
-    tracing::info!("Non-UNHEARD show bio generated successfully ({} chars)", bio.len());
+    tracing::info!(
+        "Non-UNHEARD show bio generated successfully ({} chars)",
+        bio.len()
+    );
     Ok(bio)
 }
 
@@ -490,11 +491,7 @@ pub async fn generate_and_store_show_bio(
             show.title, show_type, description
         );
 
-        let bio = generate_show_bio_from_text(
-            &state.config,
-            &user_content,
-        )
-        .await?;
+        let bio = generate_show_bio_from_text(&state.config, &user_content).await?;
 
         sqlx::query("UPDATE shows SET ai_bio = ?, updated_at = datetime('now') WHERE id = ?")
             .bind(&bio)

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -86,7 +86,10 @@ impl IntoResponse for AppError {
             }
             AppError::Config(msg) => {
                 tracing::error!("Configuration error: {}", msg);
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Configuration error: {}", msg))
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Configuration error: {}", msg),
+                )
             }
             AppError::External(msg) => {
                 tracing::error!("External service error: {}", msg);

--- a/backend/src/handlers/settings.rs
+++ b/backend/src/handlers/settings.rs
@@ -1,11 +1,6 @@
 use std::sync::Arc;
 
-use axum::{
-    extract::State,
-    http::HeaderMap,
-    response::IntoResponse,
-    Json,
-};
+use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use crate::{auth, db, telegram_notify, AppError, AppState, Result};
@@ -33,9 +28,7 @@ pub async fn get_notifications(
         .ok_or_else(|| AppError::Unauthorized("Not authenticated".to_string()))?;
 
     if !user.role_enum().can_access_admin() {
-        return Err(AppError::Forbidden(
-            "Admin access required".to_string(),
-        ));
+        return Err(AppError::Forbidden("Admin access required".to_string()));
     }
 
     let enabled = db::is_notifications_enabled(&state.db).await;
@@ -56,9 +49,7 @@ pub async fn set_notifications(
         .ok_or_else(|| AppError::Unauthorized("Not authenticated".to_string()))?;
 
     if !user.role_enum().can_access_admin() {
-        return Err(AppError::Forbidden(
-            "Admin access required".to_string(),
-        ));
+        return Err(AppError::Forbidden("Admin access required".to_string()));
     }
 
     let value = if req.enabled { "true" } else { "false" };

--- a/backend/src/pdf.rs
+++ b/backend/src/pdf.rs
@@ -219,11 +219,32 @@ pub fn generate_artist_pdf(
     lines.push((12, String::new()));
 
     lines.push((14, "Social Media".to_string()));
-    lines.push((12, format!("Instagram: {}", artist.instagram.as_deref().unwrap_or("N/A"))));
-    lines.push((12, format!("SoundCloud: {}", artist.soundcloud.as_deref().unwrap_or("N/A"))));
-    lines.push((12, format!("Bandcamp: {}", artist.bandcamp.as_deref().unwrap_or("N/A"))));
-    lines.push((12, format!("Spotify: {}", artist.spotify.as_deref().unwrap_or("N/A"))));
-    lines.push((12, format!("Other: {}", artist.other_social.as_deref().unwrap_or("N/A"))));
+    lines.push((
+        12,
+        format!(
+            "Instagram: {}",
+            artist.instagram.as_deref().unwrap_or("N/A")
+        ),
+    ));
+    lines.push((
+        12,
+        format!(
+            "SoundCloud: {}",
+            artist.soundcloud.as_deref().unwrap_or("N/A")
+        ),
+    ));
+    lines.push((
+        12,
+        format!("Bandcamp: {}", artist.bandcamp.as_deref().unwrap_or("N/A")),
+    ));
+    lines.push((
+        12,
+        format!("Spotify: {}", artist.spotify.as_deref().unwrap_or("N/A")),
+    ));
+    lines.push((
+        12,
+        format!("Other: {}", artist.other_social.as_deref().unwrap_or("N/A")),
+    ));
     lines.push((12, String::new()));
 
     lines.push((14, "Things to Mention".to_string()));
@@ -276,7 +297,8 @@ pub fn generate_artist_pdf(
         b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj"
             .to_vec(),
     );
-    objects.push(b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj".to_vec());
+    objects
+        .push(b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj".to_vec());
 
     let stream_obj = {
         let mut s = Vec::new();

--- a/backend/src/telegram.rs
+++ b/backend/src/telegram.rs
@@ -1051,7 +1051,11 @@ async fn handle_aig_pub(
         .ok_or_else(|| format!("Artist {artist_id} not found"))?;
 
     // Remove buttons and show progress
-    let token = state.config.telegram_bot_token.as_deref().unwrap_or_default();
+    let token = state
+        .config
+        .telegram_bot_token
+        .as_deref()
+        .unwrap_or_default();
     let chat_id = state.config.telegram_admin_chat_id.unwrap_or_default();
 
     if let Some(preview_msg_id) = artist.telegram_preview_message_id {
@@ -1061,7 +1065,12 @@ async fn handle_aig_pub(
             1024,
         );
         let _ = telegram_notify::edit_message_caption_raw(
-            token, chat_id, preview_msg_id, &progress_caption, "", None,
+            token,
+            chat_id,
+            preview_msg_id,
+            &progress_caption,
+            "",
+            None,
         )
         .await;
     }
@@ -1088,7 +1097,12 @@ async fn handle_aig_pub(
                     1024,
                 );
                 let _ = telegram_notify::edit_message_caption_raw(
-                    token, chat_id, preview_msg_id, &success_caption, "", None,
+                    token,
+                    chat_id,
+                    preview_msg_id,
+                    &success_caption,
+                    "",
+                    None,
                 )
                 .await;
             }
@@ -1109,7 +1123,12 @@ async fn handle_aig_pub(
                     artist.track2_video_key.is_some(),
                 );
                 let _ = telegram_notify::edit_message_caption_raw(
-                    token, chat_id, preview_msg_id, &error_caption, "", Some(&markup),
+                    token,
+                    chat_id,
+                    preview_msg_id,
+                    &error_caption,
+                    "",
+                    Some(&markup),
                 )
                 .await;
             }
@@ -1119,17 +1138,20 @@ async fn handle_aig_pub(
             // Restore buttons with error
             if let Some(preview_msg_id) = artist.telegram_preview_message_id {
                 let caption = artist.instagram_caption.as_deref().unwrap_or("");
-                let error_caption = telegram_notify::truncate_caption(
-                    &format!("{caption}\n\n❌ Error: {e}"),
-                    1024,
-                );
+                let error_caption =
+                    telegram_notify::truncate_caption(&format!("{caption}\n\n❌ Error: {e}"), 1024);
                 let markup = telegram_notify::build_artist_preview_keyboard(
                     artist_id,
                     artist.track1_video_key.is_some(),
                     artist.track2_video_key.is_some(),
                 );
                 let _ = telegram_notify::edit_message_caption_raw(
-                    token, chat_id, preview_msg_id, &error_caption, "", Some(&markup),
+                    token,
+                    chat_id,
+                    preview_msg_id,
+                    &error_caption,
+                    "",
+                    Some(&markup),
                 )
                 .await;
             }
@@ -1445,7 +1467,9 @@ async fn handle_aig_sort(
         .await;
     }
 
-    bot.answer_callback_query(&q.id).text("✅ Reordered").await?;
+    bot.answer_callback_query(&q.id)
+        .text("✅ Reordered")
+        .await?;
     Ok(())
 }
 
@@ -1464,7 +1488,11 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
 
     let session = match session {
         Some(s) => {
-            tracing::info!("Edit session found for chat {chat_id}: field={:?}, artist_id={:?}", s.field, s.artist_id);
+            tracing::info!(
+                "Edit session found for chat {chat_id}: field={:?}, artist_id={:?}",
+                s.field,
+                s.artist_id
+            );
             s
         }
         None => return Ok(()), // No active session — silently ignore
@@ -1498,12 +1526,11 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
                 .await;
 
                 // Rebuild keyboard from artist
-                let artist: models::Artist =
-                    sqlx::query_as("SELECT * FROM artists WHERE id = ?")
-                        .bind(artist_id)
-                        .fetch_optional(&state.db)
-                        .await?
-                        .ok_or_else(|| format!("Artist {artist_id} not found"))?;
+                let artist: models::Artist = sqlx::query_as("SELECT * FROM artists WHERE id = ?")
+                    .bind(artist_id)
+                    .fetch_optional(&state.db)
+                    .await?
+                    .ok_or_else(|| format!("Artist {artist_id} not found"))?;
 
                 let markup = telegram_notify::build_artist_preview_keyboard(
                     artist_id,
@@ -1592,7 +1619,9 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
                     .put_object()
                     .bucket(&state.config.r2_bucket_name)
                     .key(&key)
-                    .body(aws_sdk_s3::primitives::ByteStream::from(photo_bytes.clone()))
+                    .body(aws_sdk_s3::primitives::ByteStream::from(
+                        photo_bytes.clone(),
+                    ))
                     .content_type("image/jpeg")
                     .send()
                     .await
@@ -1607,12 +1636,11 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
                 .await;
 
                 // Rebuild keyboard
-                let artist: models::Artist =
-                    sqlx::query_as("SELECT * FROM artists WHERE id = ?")
-                        .bind(artist_id)
-                        .fetch_optional(&state.db)
-                        .await?
-                        .ok_or_else(|| format!("Artist {artist_id} not found"))?;
+                let artist: models::Artist = sqlx::query_as("SELECT * FROM artists WHERE id = ?")
+                    .bind(artist_id)
+                    .fetch_optional(&state.db)
+                    .await?
+                    .ok_or_else(|| format!("Artist {artist_id} not found"))?;
 
                 let markup = telegram_notify::build_artist_preview_keyboard(
                     artist_id,
@@ -1687,14 +1715,15 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
             req.await?;
         }
         models::TelegramEditField::Timecode => {
-            tracing::info!("Timecode edit session active for chat {chat_id}, artist_id={:?}", session.artist_id);
+            tracing::info!(
+                "Timecode edit session active for chat {chat_id}, artist_id={:?}",
+                session.artist_id
+            );
             let input = match msg.text() {
                 Some(text) => text.to_string(),
                 None => {
-                    let mut req = bot.send_message(
-                        msg.chat.id,
-                        "❌ Please send a timecode (e.g. 1:30 or 90).",
-                    );
+                    let mut req = bot
+                        .send_message(msg.chat.id, "❌ Please send a timecode (e.g. 1:30 or 90).");
                     if let Some(tid) = state.config.telegram_topic_id {
                         req = req.message_thread_id(ThreadId(MessageId(tid)));
                     }
@@ -1710,10 +1739,7 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
                 }
                 Err(err_msg) => {
                     // Re-insert session so user can try again
-                    let mut req = bot.send_message(
-                        msg.chat.id,
-                        format!("❌ {err_msg}"),
-                    );
+                    let mut req = bot.send_message(msg.chat.id, format!("❌ {err_msg}"));
                     if let Some(tid) = state.config.telegram_topic_id {
                         req = req.message_thread_id(ThreadId(MessageId(tid)));
                     }

--- a/backend/src/video.rs
+++ b/backend/src/video.rs
@@ -74,7 +74,15 @@ pub async fn generate_track_preview_video(
         .map_err(|e| AppError::Internal(format!("Failed to create temp dir: {}", e)))?;
 
     // Ensure cleanup even on error
-    let result = generate_inner(state, artist_image_key, track_key, duration, start_offset_secs, &temp_dir).await;
+    let result = generate_inner(
+        state,
+        artist_image_key,
+        track_key,
+        duration,
+        start_offset_secs,
+        &temp_dir,
+    )
+    .await;
 
     // Clean up temp directory
     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
@@ -136,8 +144,15 @@ pub async fn generate_and_store_artist_videos(state: Arc<AppState>, artist_id: i
             artist_id
         );
 
-        match generate_track_preview_video(&state, &image_key, track_key, "", VIDEO_DURATION_SECS, 0)
-            .await
+        match generate_track_preview_video(
+            &state,
+            &image_key,
+            track_key,
+            "",
+            VIDEO_DURATION_SECS,
+            0,
+        )
+        .await
         {
             Ok(mp4_bytes) => {
                 let video_key = format!("artists/{}/{}_video/preview.mp4", artist_id, label);
@@ -469,16 +484,16 @@ async fn compose_video(
                 // Audio codec
                 "-c:a".to_string(),
                 "aac".to_string(),
-            "-b:a".to_string(),
-            "192k".to_string(),
-            "-ar".to_string(),
-            "44100".to_string(),
-            // Web/Instagram compatibility
-            "-movflags".to_string(),
-            "+faststart".to_string(),
-            // Overwrite
-            "-y".to_string(),
-            output_str.to_string(),
+                "-b:a".to_string(),
+                "192k".to_string(),
+                "-ar".to_string(),
+                "44100".to_string(),
+                // Web/Instagram compatibility
+                "-movflags".to_string(),
+                "+faststart".to_string(),
+                // Overwrite
+                "-y".to_string(),
+                output_str.to_string(),
             ]);
             a
         })


### PR DESCRIPTION
Whitespace / line-wrapping only — exactly what `cargo fmt` produces (verified: `cargo fmt --check` is clean with these changes, flags them without). No identifiers, literals, arguments, or control flow touched; zero behavioral change.

Files: `ai.rs`, `error.rs`, `handlers/settings.rs`, `pdf.rs`, `telegram.rs`, `video.rs`.

These surfaced mid-session from a stray fmt run, unrelated to #155; splitting them out keeps the tree fmt-clean.