### PR TITLE
feat(recording): crash-safe MPEG-TS segment recorder + concat finalize (#170)

### DIFF
--- a/backend/src/recording.rs
+++ b/backend/src/recording.rs
@@ -437,7 +437,8 @@ mod tests {
         assert_eq!(marker.artist_id, 1);
         assert_eq!(marker.track_type, "track1");
         assert_eq!(marker.duration_ms, 180000);
-        assert!(marker.offset_ms >= 0); // Should have some offset
+        // offset_ms is a u64 elapsed time; just assert it stays within a sane bound.
+        assert!(marker.offset_ms < 60_000);
 
         // Write some data
         manager.write_chunk(b"test audio data").await.unwrap();

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -1,13 +1,19 @@
 //! Stream bridge: manages FFmpeg process for WebM→RTMP audio streaming.
 //!
-//! Also supports tee-ing audio chunks to a file for recording purposes.
+//! Recording is tee'd to a **second, independent** FFmpeg process that writes
+//! crash-safe MPEG-TS segments (`-f segment`). A recorder crash then loses at
+//! most one ~10s segment instead of the whole show; the segments are
+//! concat-demuxed into a single artifact at stop. The live RTMP stream is never
+//! affected by a recording failure.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
+
+/// Length of each recording segment, in seconds. A crash loses at most one.
+const SEGMENT_SECONDS: u32 = 10;
 
 /// Current state of the audio stream.
 pub struct StreamState {
@@ -17,14 +23,19 @@ pub struct StreamState {
     ffmpeg_stdin: Option<ChildStdin>,
     /// Handle to the FFmpeg child process.
     ffmpeg_handle: Option<Child>,
-    /// Optional file handle for recording audio chunks to disk.
-    /// When Some, audio chunks are tee'd to this file alongside FFmpeg.
-    recording_file: Option<File>,
-    /// Path to the current recording file (for status reporting).
+    /// Stdin of the recording FFmpeg (segment muxer). When Some, audio chunks
+    /// are tee'd here alongside the streaming FFmpeg.
+    recording_stdin: Option<ChildStdin>,
+    /// Handle to the recording FFmpeg child process.
+    recording_handle: Option<Child>,
+    /// Directory holding the in-progress MPEG-TS segments for this session.
+    recording_seg_dir: Option<PathBuf>,
+    /// Final concat target — the single artifact stop produces from the segments
+    /// (also used for status reporting).
     recording_path: Option<PathBuf>,
-    /// Set when a recording-file write fails (e.g. disk full). The recording
-    /// is abandoned (file handle dropped) but the live stream keeps running.
-    /// Surfaced via [`StreamStatus`] so the failure is never silently swallowed.
+    /// Set when a recording tee write fails (e.g. disk full, or the recorder
+    /// FFmpeg died). The recording is abandoned but the live stream keeps
+    /// running. Surfaced via [`StreamStatus`] so it's never silently swallowed.
     recording_failed: Option<String>,
 }
 
@@ -40,7 +51,9 @@ impl StreamState {
             current_user: None,
             ffmpeg_stdin: None,
             ffmpeg_handle: None,
-            recording_file: None,
+            recording_stdin: None,
+            recording_handle: None,
+            recording_seg_dir: None,
             recording_path: None,
             recording_failed: None,
         }
@@ -54,7 +67,7 @@ impl StreamState {
 
     /// Returns true if recording to file is active.
     pub fn is_recording(&self) -> bool {
-        self.recording_file.is_some()
+        self.recording_stdin.is_some()
     }
 
     /// Returns the recording write-failure message, if a tee write has failed
@@ -186,79 +199,145 @@ impl StreamState {
             return Err(StreamError::NotStreaming);
         }
 
-        // Tee to recording file if active. A write failure here (e.g. disk full)
-        // must NOT silently corrupt the archive: surface it as a recording-failed
-        // status + error log, drop the file handle so we stop appending to a
-        // half-written file, and keep the live stream running.
-        if let Some(ref mut file) = self.recording_file {
-            if let Err(e) = file.write_all(data).await {
+        // Tee to the recording FFmpeg (segment muxer) if active. A write failure
+        // here (disk full, or the recorder died) must NOT silently corrupt the
+        // archive: surface it as a recording-failed status + error log, drop the
+        // recorder stdin (segments already flushed to disk survive), and keep the
+        // live stream running.
+        if let Some(ref mut stdin) = self.recording_stdin {
+            if let Err(e) = stdin.write_all(data).await {
                 let msg = e.to_string();
                 tracing::error!(
-                    "Recording write failed (archive will be incomplete): {} — path={:?}",
+                    "Recording tee write failed (archive will be incomplete): {} — segments={:?}",
                     msg,
-                    self.recording_path
+                    self.recording_seg_dir
                 );
                 self.recording_failed = Some(msg);
-                // Stop teeing — the file is now unreliable. The live stream
-                // (FFmpeg) is unaffected and continues.
-                self.recording_file = None;
+                // Stop teeing. Completed segments on disk are still recoverable
+                // at stop. The live stream (FFmpeg) is unaffected and continues.
+                self.recording_stdin = None;
             }
         }
 
         Ok(())
     }
 
-    /// Start recording audio chunks to a file.
+    /// Start recording by spawning a segment-muxer FFmpeg.
     ///
-    /// Creates the file at the specified path and begins tee-ing all audio chunks.
-    /// The file is created with the parent directories if needed.
+    /// Audio chunks tee'd via [`write_chunk`] are written to a second, independent
+    /// FFmpeg process that emits ~[`SEGMENT_SECONDS`]s MPEG-TS segments into a
+    /// sibling `.segs/` directory. At [`stop_recording`] the segments are
+    /// concat-demuxed into `path`. A crash loses at most the in-progress segment.
     ///
     /// # Arguments
-    /// * `path` - Path to the recording file (e.g., "./data/recordings-temp/recording_1_2026-01-28T19-30-00.webm")
+    /// * `path` - Final artifact path (e.g. ".../recording_1_2026-01-28T19-30-00.webm").
+    ///   The concatenated artifact is MPEG-TS; the extension is kept for
+    ///   backward compatibility with the existing R2 layout (FFmpeg probes
+    ///   content, not the name).
     pub async fn start_recording(&mut self, path: PathBuf) -> Result<(), StreamError> {
         // Close any existing recording first
-        if self.recording_file.is_some() {
+        if self.is_recording() {
             self.stop_recording().await?;
         }
 
-        // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                StreamError::RecordingError(format!("Failed to create directory: {}", e))
-            })?;
-        }
-
-        // Create the recording file
-        let file = File::create(&path).await.map_err(|e| {
-            StreamError::RecordingError(format!("Failed to create recording file: {}", e))
+        // Per-session segment directory: ".../recording_<id>_<ts>.segs/"
+        let seg_dir = path.with_extension("segs");
+        tokio::fs::create_dir_all(&seg_dir).await.map_err(|e| {
+            StreamError::RecordingError(format!("Failed to create segment directory: {}", e))
         })?;
 
-        tracing::info!("Started recording to {:?}", path);
+        let seg_pattern = seg_dir.join("seg_%05d.ts");
 
-        self.recording_file = Some(file);
+        // Recording FFmpeg: WebM/Opus on stdin → AAC → MPEG-TS segments.
+        // Audio-only means every frame is effectively a keyframe, so there is no
+        // segment-alignment caveat.
+        let mut child = Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-f",
+                "webm",
+                "-i",
+                "pipe:0",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "192k",
+                "-ar",
+                "48000",
+                "-ac",
+                "2",
+                "-f",
+                "segment",
+                "-segment_time",
+                &SEGMENT_SECONDS.to_string(),
+                "-segment_format",
+                "mpegts",
+                "-reset_timestamps",
+                "1",
+            ])
+            .arg(&seg_pattern)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| StreamError::FfmpegSpawn(e.to_string()))?;
+
+        let stdin = child.stdin.take().ok_or(StreamError::NoStdin)?;
+
+        tracing::info!(
+            "Started crash-safe segment recording to {:?} (final artifact {:?})",
+            seg_dir,
+            path
+        );
+
+        self.recording_stdin = Some(stdin);
+        self.recording_handle = Some(child);
+        self.recording_seg_dir = Some(seg_dir);
         self.recording_path = Some(path);
         self.recording_failed = None;
 
         Ok(())
     }
 
-    /// Stop recording and close the recording file.
+    /// Stop recording: signal EOF to the recorder, wait for it to flush the last
+    /// segment, then concat-demux all segments into the final artifact path.
     ///
-    /// Returns the path to the recording file if one was active.
+    /// Returns the path to the concatenated artifact if a recording was active.
     pub async fn stop_recording(&mut self) -> Result<Option<PathBuf>, StreamError> {
         let path = self.recording_path.take();
+        let seg_dir = self.recording_seg_dir.take();
 
-        if let Some(mut file) = self.recording_file.take() {
-            // Flush and close the file
-            if let Err(e) = file.flush().await {
-                tracing::warn!("Failed to flush recording file: {}", e);
-            }
-            if let Err(e) = file.shutdown().await {
-                tracing::warn!("Failed to close recording file: {}", e);
-            }
+        // Close stdin to signal EOF so FFmpeg finalizes the last segment.
+        if let Some(mut stdin) = self.recording_stdin.take() {
+            let _ = stdin.shutdown().await;
+        }
 
-            if let Some(ref p) = path {
-                tracing::info!("Stopped recording to {:?}", p);
+        // Wait for the recorder to exit (it may already be dead, e.g. crash).
+        if let Some(mut handle) = self.recording_handle.take() {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), handle.wait()).await {
+                Ok(Ok(status)) => tracing::info!("Recording FFmpeg exited with status: {}", status),
+                Ok(Err(e)) => tracing::warn!("Recording FFmpeg wait error: {}", e),
+                Err(_) => {
+                    tracing::warn!("Recording FFmpeg did not exit in time, killing...");
+                    let _ = handle.kill().await;
+                }
+            }
+        }
+
+        // Concat the surviving segments into the final artifact.
+        if let (Some(ref dir), Some(ref out)) = (&seg_dir, &path) {
+            if let Err(e) = concat_segments(dir, out).await {
+                tracing::error!("Failed to concat recording segments: {}", e);
+                self.recording_failed = Some(format!("Segment concat failed: {}", e));
+            } else {
+                tracing::info!("Concatenated recording segments into {:?}", out);
+            }
+            // Best-effort cleanup of the segment directory.
+            if let Err(e) = tokio::fs::remove_dir_all(dir).await {
+                tracing::warn!("Failed to clean up segment directory {:?}: {}", dir, e);
             }
         }
 
@@ -390,6 +469,99 @@ pub async fn start_prerecorded_stream(
     Ok(())
 }
 
+/// True if `path` names a recording segment (`seg_*.ts`).
+fn is_segment_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.starts_with("seg_") && n.ends_with(".ts"))
+        .unwrap_or(false)
+}
+
+/// Build an FFmpeg concat-demuxer list from ordered segment paths.
+/// Paths are app-controlled (`seg_%05d.ts`), so no quote-escaping is needed.
+fn build_concat_list(segments: &[PathBuf]) -> String {
+    let mut list = String::new();
+    for seg in segments {
+        list.push_str(&format!("file '{}'\n", seg.to_string_lossy()));
+    }
+    list
+}
+
+/// Concat-demux the MPEG-TS segments in `seg_dir` into a single `output` file.
+///
+/// Segments are concatenated in lexicographic order (`seg_00000.ts`, …), which
+/// matches their chronological order. Uses stream copy (`-c copy`) so there's no
+/// re-encode, and forces `-f mpegts` because the output path keeps a legacy
+/// `.webm` extension for R2-layout compatibility.
+async fn concat_segments(seg_dir: &Path, output: &Path) -> Result<(), StreamError> {
+    // Collect + sort the segment files.
+    let mut segments: Vec<PathBuf> = Vec::new();
+    let mut entries = tokio::fs::read_dir(seg_dir)
+        .await
+        .map_err(|e| StreamError::RecordingError(format!("read segment dir: {}", e)))?;
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|e| StreamError::RecordingError(format!("read segment entry: {}", e)))?
+    {
+        if is_segment_file(&entry.path()) {
+            segments.push(entry.path());
+        }
+    }
+    segments.sort();
+
+    if segments.is_empty() {
+        return Err(StreamError::RecordingError(
+            "no recording segments were produced".to_string(),
+        ));
+    }
+
+    // Build the concat demuxer list file.
+    let list = build_concat_list(&segments);
+    let list_path = seg_dir.join("concat_list.txt");
+    tokio::fs::write(&list_path, list)
+        .await
+        .map_err(|e| StreamError::RecordingError(format!("write concat list: {}", e)))?;
+
+    let status = Command::new("ffmpeg")
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "warning",
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+        ])
+        .arg(&list_path)
+        .args(["-c", "copy", "-f", "mpegts"])
+        .arg(output)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|e| StreamError::RecordingError(format!("spawn concat ffmpeg: {}", e)))?;
+
+    if !status.status.success() {
+        let stderr = String::from_utf8_lossy(&status.stderr);
+        return Err(StreamError::RecordingError(format!(
+            "concat ffmpeg failed: {}",
+            stderr.lines().last().unwrap_or("unknown error")
+        )));
+    }
+
+    tracing::info!(
+        "Concatenated {} segment(s) from {:?}",
+        segments.len(),
+        seg_dir
+    );
+    Ok(())
+}
+
 /// Status information for API responses.
 #[derive(serde::Serialize)]
 pub struct StreamStatus {
@@ -421,4 +593,43 @@ pub enum StreamError {
 
     #[error("Recording error: {0}")]
     RecordingError(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_files_are_recognized() {
+        assert!(is_segment_file(Path::new("/tmp/x.segs/seg_00000.ts")));
+        assert!(is_segment_file(Path::new("/tmp/x.segs/seg_00042.ts")));
+        assert!(!is_segment_file(Path::new("/tmp/x.segs/concat_list.txt")));
+        assert!(!is_segment_file(Path::new("/tmp/x.segs/seg_00000.tmp")));
+        assert!(!is_segment_file(Path::new("/tmp/x.segs/raw.webm")));
+    }
+
+    #[test]
+    fn concat_list_is_ordered_and_quoted() {
+        let segs = vec![
+            PathBuf::from("/r/seg_00000.ts"),
+            PathBuf::from("/r/seg_00001.ts"),
+            PathBuf::from("/r/seg_00002.ts"),
+        ];
+        let list = build_concat_list(&segs);
+        assert_eq!(
+            list,
+            "file '/r/seg_00000.ts'\nfile '/r/seg_00001.ts'\nfile '/r/seg_00002.ts'\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn concat_errors_when_no_segments_survive() {
+        // Simulates a crash before any segment was flushed: stop must surface an
+        // error rather than silently producing an empty artifact.
+        let dir = tempfile::TempDir::new().unwrap();
+        let out = dir.path().join("raw.webm");
+        let err = concat_segments(dir.path(), &out).await.unwrap_err();
+        assert!(matches!(err, StreamError::RecordingError(_)));
+        assert!(!out.exists());
+    }
 }


### PR DESCRIPTION
Closes #170 — Phase 1 of the stream rework (#164). Builds on #169.

## What

Replaces the single in-process WebM file tee with a **second, independent ffmpeg** that writes crash-safe MPEG-TS segments. A recorder crash now loses **at most one ~10s segment** instead of the whole show.

- `start_recording` spawns a segment-muxer ffmpeg: `webm/opus stdin → AAC → -f segment -segment_time 10 -segment_format mpegts -reset_timestamps 1` into a per-session `.segs/` dir. The live RTMP ffmpeg is **untouched**, so a recording failure can never stall the broadcast (tee kept independent).
- `write_chunk` tees to the recorder's stdin; a failure reuses #169's `recording_failed` surfacing. Completed segments already on disk survive.
- `stop_recording` signals EOF, waits, then **concat-demuxes** the surviving segments (`-f concat -c copy -f mpegts`) into the existing artifact path and cleans the seg dir.
- The R2 `raw.webm` key is kept for **backward compatibility** — ffmpeg probes content, not the extension, so old WebM recordings still finalize and the finalize pipeline is untouched.

## Design notes (defaults taken)
- **Two independent ffmpeg processes** (not a single `-f tee`) so the recorder is isolated from the live stream.
- Base archive is transcoded **Opus→AAC** (MPEG-TS doesn't carry Opus) — consistent with the RTMP side; HQ track replacement still happens at finalize from originals.
- Artifact stays under `raw.webm` (content is now TS) to avoid breaking existing recordings / the finalize download path.

## Verification
- Validated the **exact** acceptance flags end-to-end with a shell harness: 35s Opus → 4 segments; full concat **34.8s**; crash-survivor concat (last segment dropped) **29.9s**, a valid AAC/48k/stereo artifact.
- Unit tests added (`cargo test` green): segment recognition, concat-list ordering, and the no-segments-survived guard.
- `cargo build` / `clippy` / `fmt` clean.

## Incidental
- Fixes the pre-existing vacuous `marker.offset_ms >= 0` (`u64`) assert in `recording.rs` that **prevented the entire backend test target from compiling**. With the target now building, one **unrelated** pre-existing failure is revealed: `video::tests::test_brightness_analysis` (`video.rs:602`, brightness logic — nothing to do with recording). Left for a dedicated fix; flagging here for visibility.