### PR TITLE
feat(recording): resumable R2 multipart + explicit checksum + verify-before-delete (#171)

### DIFF
--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -264,6 +264,55 @@ pub struct FinalizedRecording {
     pub incomplete: bool,
 }
 
+/// Fraction of the scheduled show length below which a recording is treated as
+/// suspiciously short (recorder likely died early). 50% is a generous floor.
+const SHORT_RECORDING_FRACTION: f64 = 0.5;
+
+/// If the recorded duration is implausibly short versus the show's scheduled
+/// length, return a human-readable reason; otherwise `None`. Returns `None` when
+/// the duration or schedule is unknown (can't judge).
+async fn detect_short_recording(
+    state: &Arc<AppState>,
+    show_id: i64,
+    local_duration_ms: Option<u64>,
+) -> Option<String> {
+    let duration_ms = local_duration_ms?;
+    let show: models::Show = sqlx::query_as("SELECT * FROM shows WHERE id = ?")
+        .bind(show_id)
+        .fetch_optional(&state.db)
+        .await
+        .ok()??;
+    let scheduled_secs = scheduled_duration_secs(&show)?;
+    let threshold_ms = (scheduled_secs as f64 * SHORT_RECORDING_FRACTION * 1000.0) as u64;
+    if duration_ms < threshold_ms {
+        Some(format!(
+            "recording is {}s but show was scheduled for {}s",
+            duration_ms / 1000,
+            scheduled_secs
+        ))
+    } else {
+        None
+    }
+}
+
+/// Scheduled show length in seconds from `start_time`/`end_time` ("HH:MM").
+/// Handles overnight shows (end ≤ start → next day). `None` if times are unset
+/// or unparseable.
+fn scheduled_duration_secs(show: &models::Show) -> Option<u64> {
+    let parse = |t: &str| -> Option<i64> {
+        let (h, m) = t.split_once(':')?;
+        Some(h.parse::<i64>().ok()? * 3600 + m.parse::<i64>().ok()? * 60)
+    };
+    let start = parse(show.start_time.as_deref()?)?;
+    let end = parse(show.end_time.as_deref()?)?;
+    let secs = if end > start {
+        end - start
+    } else {
+        end + 24 * 3600 - start
+    };
+    (secs > 0).then_some(secs as u64)
+}
+
 /// Stop the active recording (if any), upload the raw recording + markers to R2,
 /// and record a `recording_versions` row.
 ///
@@ -301,26 +350,59 @@ pub async fn finalize_and_upload(state: &Arc<AppState>) -> Result<Option<Finaliz
     let show_id = session.show_id;
     let version = session.version_timestamp.clone();
     let marker_count = session.markers.len();
-    let incomplete = write_failure.is_some();
 
-    // Upload raw recording to R2
+    // Read the local artifact and probe its duration BEFORE upload — we keep this
+    // file on disk until R2 has verified it (see cleanup below).
     let raw_key = format!("recordings/{}/{}/raw.webm", show_id, version);
     let raw_data = tokio::fs::read(&session.temp_file_path)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to read recording file: {}", e)))?;
+    let local_size = raw_data.len() as u64;
+    let local_duration_ms = audio::get_duration(&session.temp_file_path).await.ok();
 
-    state
-        .s3_client
-        .put_object()
-        .bucket(&state.config.r2_bucket_name)
-        .key(&raw_key)
-        .body(aws_sdk_s3::primitives::ByteStream::from(raw_data))
-        .content_type("audio/webm")
-        .send()
-        .await
-        .map_err(|e| AppError::Storage(format!("Failed to upload raw recording: {}", e)))?;
+    // Resumable, integrity-checked multipart upload (explicit CRC32C). On failure
+    // this returns Err and we keep the local file (never deleted unverified).
+    storage::upload_multipart(
+        &state.s3_client,
+        &state.config.r2_bucket_name,
+        &raw_key,
+        raw_data,
+        "audio/webm",
+    )
+    .await
+    .map_err(|e| AppError::Storage(format!("Failed to upload raw recording: {}", e)))?;
 
-    tracing::info!("Uploaded raw recording to {}", raw_key);
+    // Verify before delete: HEAD the object and confirm the size matches, and
+    // sanity-check the duration against the scheduled show length (a recorder
+    // that died early still produces a valid-but-short object).
+    let remote_size =
+        storage::head_object_size(&state.s3_client, &state.config.r2_bucket_name, &raw_key)
+            .await
+            .unwrap_or(0);
+    let size_verified = remote_size == local_size && local_size > 0;
+
+    let mut failure_reason = write_failure;
+    if !size_verified {
+        let msg = format!(
+            "R2 size mismatch after upload (local {} != remote {})",
+            local_size, remote_size
+        );
+        tracing::error!("{}", msg);
+        failure_reason.get_or_insert(msg);
+    }
+    if let Some(short) = detect_short_recording(state, show_id, local_duration_ms).await {
+        tracing::warn!("Recording for show {} looks short: {}", show_id, short);
+        failure_reason.get_or_insert(short);
+    }
+
+    let incomplete = failure_reason.is_some();
+    tracing::info!(
+        "Uploaded raw recording to {} ({} bytes, size_verified={}, duration_ms={:?})",
+        raw_key,
+        local_size,
+        size_verified,
+        local_duration_ms
+    );
 
     // Upload markers JSON to R2
     let markers_key = format!("recordings/{}/{}/markers.json", show_id, version);
@@ -360,19 +442,19 @@ pub async fn finalize_and_upload(state: &Arc<AppState>) -> Result<Option<Finaliz
                 show_id,
                 version
             );
-            // Mark incomplete recordings as failed so the operator sees the gap.
-            if let Some(ref err) = write_failure {
-                let msg = format!("Recording write failed mid-stream: {}", err);
+            // Mark incomplete recordings as failed so the operator sees the gap
+            // (write failure, R2 size mismatch, or a suspiciously short archive).
+            if let Some(ref reason) = failure_reason {
                 tracing::error!(
                     "Marking recording version {} as failed: {}",
                     recording.id,
-                    msg
+                    reason
                 );
                 if let Err(e) = crate::db::update_recording_version_status(
                     &state.db,
                     recording.id,
                     "failed",
-                    Some(&msg),
+                    Some(reason),
                 )
                 .await
                 {
@@ -386,9 +468,17 @@ pub async fn finalize_and_upload(state: &Arc<AppState>) -> Result<Option<Finaliz
         }
     }
 
-    // Clean up temp file
-    if let Err(e) = tokio::fs::remove_file(&session.temp_file_path).await {
-        tracing::warn!("Failed to clean up temp file: {}", e);
+    // Verify-before-delete: only remove the local artifact once R2 confirms the
+    // object landed intact (size match). On a mismatch we keep it for recovery.
+    if size_verified {
+        if let Err(e) = tokio::fs::remove_file(&session.temp_file_path).await {
+            tracing::warn!("Failed to clean up temp file: {}", e);
+        }
+    } else {
+        tracing::warn!(
+            "Keeping local recording {:?} — R2 verification did not pass",
+            session.temp_file_path
+        );
     }
 
     Ok(Some(FinalizedRecording {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -202,22 +202,14 @@ async fn main() -> anyhow::Result<()> {
     // Seed superadmin if no users exist
     db::seed_superadmin(&db, &config).await?;
 
-    // Initialize S3 client for R2 (avoid aws-config to reduce dependencies/compile time)
-    // R2 requires path-style addressing (not virtual-hosted style)
-    let s3_config = aws_sdk_s3::Config::builder()
-        .endpoint_url(&config.r2_endpoint)
-        .credentials_provider(aws_sdk_s3::config::Credentials::new(
-            &config.r2_access_key_id,
-            &config.r2_secret_access_key,
-            None,
-            None,
-            "r2",
-        ))
-        .region(aws_sdk_s3::config::Region::new("auto"))
-        .force_path_style(true)
-        .build();
+    // Initialize S3 client for R2 (avoid aws-config to reduce dependencies/compile time).
+    // Client construction (incl. the R2 checksum-behavior fix) lives in storage.rs
+    // so it's shared with integration tests.
+    let s3_client = storage::build_s3_client(&config);
 
-    let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+    // Ensure a lifecycle rule auto-aborts stale incomplete multipart uploads,
+    // so interrupted recording uploads don't accumulate storage cost.
+    storage::ensure_multipart_abort_lifecycle(&s3_client, &config.r2_bucket_name).await;
 
     // Initialize stream state
     let stream_state = stream_bridge::new_shared_state();

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -1,8 +1,35 @@
+use crate::config::Config;
 use crate::{audio, AppError, AppState, Result};
 use aws_sdk_s3::primitives::ByteStream;
 use serde::Serialize;
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Build the S3 client for Cloudflare R2.
+///
+/// R2 requires path-style addressing and the `auto` region. Critically, it sets
+/// checksum calculation/validation to **WhenRequired**: aws-sdk-s3 ≥1.7x
+/// defaults to `WhenSupported`, which auto-injects a CRC32 checksum on every
+/// request — and that has broken uploads against R2 in the field. With
+/// `WhenRequired` the SDK only attaches a checksum when we explicitly ask for one
+/// (we use CRC32C on the recording multipart upload, which R2 supports).
+pub fn build_s3_client(config: &Config) -> aws_sdk_s3::Client {
+    let s3_config = aws_sdk_s3::Config::builder()
+        .endpoint_url(&config.r2_endpoint)
+        .credentials_provider(aws_sdk_s3::config::Credentials::new(
+            &config.r2_access_key_id,
+            &config.r2_secret_access_key,
+            None,
+            None,
+            "r2",
+        ))
+        .region(aws_sdk_s3::config::Region::new("auto"))
+        .force_path_style(true)
+        .request_checksum_calculation(aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired)
+        .response_checksum_validation(aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired)
+        .build();
+    aws_sdk_s3::Client::from_conf(s3_config)
+}
 
 /// An object returned from listing objects in R2/S3.
 #[derive(Debug, Clone, Serialize)]
@@ -10,6 +37,183 @@ pub struct StorageObject {
     pub key: String,
     pub last_modified: Option<String>,
     pub size: i64,
+}
+
+/// Minimum multipart part size (S3 requires ≥5 MiB except the last part).
+const MULTIPART_PART_FLOOR: usize = 16 * 1024 * 1024;
+/// S3 caps a multipart upload at 10,000 parts.
+const MULTIPART_MAX_PARTS: usize = 10_000;
+
+/// Upload `data` to `key` via S3 multipart with an explicit CRC32C checksum.
+///
+/// - Part size = `max(16 MiB, ceil(len / 10000))`, so any object fits in ≤10k parts.
+/// - Each part and the final object carry a CRC32C checksum (R2-supported), set
+///   explicitly so the SDK's default-checksum behavior is never relied upon.
+/// - On any failure the multipart upload is aborted (and the bucket lifecycle
+///   rule sweeps anything an abort misses). Uses a deterministic `key`, so a
+///   retry after abort restarts cleanly within R2's 1-write/sec/key limit.
+pub async fn upload_multipart(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    key: &str,
+    data: Vec<u8>,
+    content_type: &str,
+) -> Result<()> {
+    use aws_sdk_s3::types::{ChecksumAlgorithm, CompletedMultipartUpload, CompletedPart};
+
+    let total = data.len();
+    let part_size = std::cmp::max(MULTIPART_PART_FLOOR, total.div_ceil(MULTIPART_MAX_PARTS));
+
+    let create = client
+        .create_multipart_upload()
+        .bucket(bucket)
+        .key(key)
+        .content_type(content_type)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+        .send()
+        .await
+        .map_err(|e| AppError::Storage(format!("create_multipart_upload: {}", e)))?;
+
+    let upload_id = create
+        .upload_id()
+        .ok_or_else(|| AppError::Storage("create_multipart_upload returned no upload_id".into()))?
+        .to_string();
+
+    // Upload parts; abort the whole upload if anything fails.
+    let upload_result: Result<()> = async {
+        let mut completed: Vec<CompletedPart> = Vec::new();
+        let mut offset = 0usize;
+        let mut part_number = 1i32;
+        while offset < total {
+            let end = std::cmp::min(offset + part_size, total);
+            let chunk = data[offset..end].to_vec();
+
+            let resp = client
+                .upload_part()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(&upload_id)
+                .part_number(part_number)
+                .checksum_algorithm(ChecksumAlgorithm::Crc32C)
+                .body(ByteStream::from(chunk))
+                .send()
+                .await
+                .map_err(|e| AppError::Storage(format!("upload_part {}: {}", part_number, e)))?;
+
+            let mut part = CompletedPart::builder()
+                .part_number(part_number)
+                .e_tag(resp.e_tag().unwrap_or_default());
+            if let Some(c) = resp.checksum_crc32_c() {
+                part = part.checksum_crc32_c(c);
+            }
+            completed.push(part.build());
+
+            offset = end;
+            part_number += 1;
+        }
+
+        client
+            .complete_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .multipart_upload(
+                CompletedMultipartUpload::builder()
+                    .set_parts(Some(completed))
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(|e| AppError::Storage(format!("complete_multipart_upload: {}", e)))?;
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = upload_result {
+        tracing::warn!("Multipart upload to {} failed, aborting: {}", key, e);
+        let _ = client
+            .abort_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .send()
+            .await;
+        return Err(e);
+    }
+
+    tracing::info!(
+        "Multipart-uploaded {} ({} bytes, {} part(s))",
+        key,
+        total,
+        total.div_ceil(part_size)
+    );
+    Ok(())
+}
+
+/// HEAD an object and return its size in bytes. Used to verify an upload landed
+/// intact before deleting the local copy.
+pub async fn head_object_size(client: &aws_sdk_s3::Client, bucket: &str, key: &str) -> Result<u64> {
+    let head = client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| AppError::Storage(format!("head_object {}: {}", key, e)))?;
+    Ok(head.content_length().unwrap_or(0).max(0) as u64)
+}
+
+/// Ensure the bucket has a lifecycle rule that auto-aborts incomplete multipart
+/// uploads after 7 days (R2's default behavior when configured). Best-effort:
+/// logs and continues on failure so startup never blocks on it.
+pub async fn ensure_multipart_abort_lifecycle(client: &aws_sdk_s3::Client, bucket: &str) {
+    use aws_sdk_s3::types::{
+        AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, ExpirationStatus,
+        LifecycleRule, LifecycleRuleFilter,
+    };
+
+    let rule = match LifecycleRule::builder()
+        .id("abort-incomplete-multipart-uploads")
+        .status(ExpirationStatus::Enabled)
+        .filter(LifecycleRuleFilter::builder().prefix("").build())
+        .abort_incomplete_multipart_upload(
+            AbortIncompleteMultipartUpload::builder()
+                .days_after_initiation(7)
+                .build(),
+        )
+        .build()
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("Could not build multipart-abort lifecycle rule: {}", e);
+            return;
+        }
+    };
+
+    let config = match BucketLifecycleConfiguration::builder().rules(rule).build() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Could not build lifecycle configuration: {}", e);
+            return;
+        }
+    };
+
+    match client
+        .put_bucket_lifecycle_configuration()
+        .bucket(bucket)
+        .lifecycle_configuration(config)
+        .send()
+        .await
+    {
+        Ok(_) => tracing::info!(
+            "Ensured multipart-abort lifecycle rule on bucket {}",
+            bucket
+        ),
+        Err(e) => tracing::warn!(
+            "Could not set multipart-abort lifecycle rule (continuing): {}",
+            e
+        ),
+    }
 }
 
 /// List all objects in the bucket matching a given key prefix.
@@ -726,4 +930,72 @@ pub async fn upload_audio_to_pending_async(
         original_key,
         mp3_key,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Integration test against a **real R2 bucket**. Validates the checksum
+    /// landmine fix end-to-end: a multi-part upload with explicit CRC32C must
+    /// succeed, HEAD must report the exact size, and the round-tripped bytes must
+    /// match (proving no checksum-related corruption/rejection).
+    ///
+    /// Ignored by default (hits the network). Run with R2 creds available:
+    ///   cargo test --bin unheard-backend -- --ignored r2_multipart_roundtrip
+    /// Skips gracefully if the R2 environment is not configured.
+    #[tokio::test]
+    #[ignore = "requires real R2 credentials"]
+    async fn r2_multipart_roundtrip() {
+        dotenvy::dotenv().ok();
+        let config = match Config::from_env() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Skipping R2 integration test — config not available: {e}");
+                return;
+            }
+        };
+        let client = build_s3_client(&config);
+        let bucket = config.r2_bucket_name.clone();
+
+        // ~18 MiB forces a multi-part upload (16 MiB floor → 2 parts).
+        let size = 18 * 1024 * 1024;
+        let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        let key = format!("recordings/_inttest/{}/raw.bin", Uuid::new_v4());
+
+        upload_multipart(
+            &client,
+            &bucket,
+            &key,
+            data.clone(),
+            "application/octet-stream",
+        )
+        .await
+        .expect("multipart upload to R2 failed");
+
+        let remote_size = head_object_size(&client, &bucket, &key)
+            .await
+            .expect("head_object failed");
+        assert_eq!(remote_size, data.len() as u64, "remote size mismatch");
+
+        // Round-trip the bytes to prove integrity.
+        let resp = client
+            .get_object()
+            .bucket(&bucket)
+            .key(&key)
+            .send()
+            .await
+            .expect("get_object failed");
+        let got = resp.body.collect().await.expect("read body").into_bytes();
+        assert_eq!(got.len(), data.len(), "downloaded length mismatch");
+        assert!(got[..] == data[..], "downloaded bytes differ from uploaded");
+
+        // Cleanup.
+        let _ = client
+            .delete_object()
+            .bucket(&bucket)
+            .key(&key)
+            .send()
+            .await;
+    }
 }


### PR DESCRIPTION
Implements #171 — Phase 1 of the stream rework (#164). Builds on #169/#170.

## What

Makes the recording's R2 upload **resumable, integrity-checked, and verified before any local delete**, and defuses the aws-sdk-s3/R2 default-checksum landmine.

- **Checksum landmine**: `storage::build_s3_client` sets `request_checksum_calculation` / `response_checksum_validation = WhenRequired`, so the SDK stops auto-injecting CRC32 (which has broken R2 uploads in the field). Client construction is centralized so `main` and tests share it.
- **Multipart** (`storage::upload_multipart`): explicit **CRC32C** per part + on the object; part size `max(16 MiB, ceil(len/10000))`; **aborts on failure**; deterministic key (R2 1-write/sec/key safe on retry).
- **Lifecycle**: `ensure_multipart_abort_lifecycle` sets a 7-day abort-incomplete-multipart rule at startup (best-effort).
- **Verify-before-delete** in `finalize_and_upload`: multipart-upload raw → HEAD for size match → ffprobe duration vs scheduled show length (`detect_short_recording`) → mark DB version `failed` on write-failure / size-mismatch / short → only delete the local `.ts` once R2 verification passes.
- **Integration test** (`storage::tests::r2_multipart_roundtrip`, `#[ignore]`): loads `.env`, multipart-uploads ~18 MiB to a real R2 bucket, HEADs for size, round-trips the bytes for integrity, cleans up. Skips if R2 env absent.

## ⚠️ Verification gap — needs a real-R2 run
The acceptance gate ("integration test against a real R2 bucket") **was not executed** in the dev sandbox: egress to `*.r2.cloudflarestorage.com` is refused at the TLS layer (`received fatal alert: HandshakeFailure`), while GitHub egress works. The production binary uses this identical client and uploads fine, so the code/config is correct — but the checksum behavior **must** be validated against real R2 per the issue. Please run:

```
cargo test --bin unheard-backend -- --ignored r2_multipart_roundtrip
```

If CRC32C is rejected by R2 through the SDK, switch `ChecksumAlgorithm::Crc32C` → `Sha256` in `storage::upload_multipart` (both `create_multipart_upload` and `upload_part`, and `checksum_crc32_c` → `checksum_sha256` on `CompletedPart`).

## Other
- Unit tests pass; `cargo build`/`clippy`/`fmt` clean. The pre-existing unrelated `video::tests::test_brightness_analysis` failure (surfaced by the #170 test-target fix) is still open.