### PR TITLE
feat(recording): dead-man's-switch alert + temp-file cleanup (#172)

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -189,6 +189,10 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     // (non-binding default — can be switched later).
     add_column_if_missing(pool, "shows", "stream_mode", "TEXT DEFAULT 'live'").await?;
 
+    // When the recording dead-man's-switch fired a "no recording" alert for this
+    // show. Ensures the alert is sent exactly once.
+    add_column_if_missing(pool, "shows", "recording_alert_sent_at", "TEXT").await?;
+
     // The user who created the show. Kept separate from host_user_id so a host
     // who assigns a guest as the host still retains edit rights over the show.
     add_column_if_missing(pool, "shows", "created_by", "INTEGER REFERENCES users(id)").await?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -664,6 +664,40 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    // Spawn background task to clean up orphaned recording temp files (stale
+    // `recording_*.webm` artifacts and `*.segs/` segment dirs left by a crash),
+    // older than ~1 day. Runs daily.
+    tokio::spawn(async move {
+        let dir = std::path::PathBuf::from("./data/recordings-temp");
+        let max_age = std::time::Duration::from_secs(24 * 60 * 60);
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
+        loop {
+            interval.tick().await;
+            match storage::cleanup_stale_files(&dir, max_age).await {
+                Ok(0) => {}
+                Ok(n) => tracing::info!("Recording temp cleanup removed {n} stale entr(y/ies)"),
+                Err(e) => tracing::error!("Recording temp cleanup failed: {e}"),
+            }
+        }
+    });
+
+    // Spawn the recording dead-man's-switch: alert (once) if a finished live show
+    // produced no recording. Checks every 5 minutes; self-guards via the
+    // `recording_alert_sent_at` column.
+    {
+        let state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(5 * 60));
+            loop {
+                interval.tick().await;
+                if state.telegram_bot.is_none() {
+                    continue;
+                }
+                scheduler::check_missing_recordings(state.clone()).await;
+            }
+        });
+    }
+
     let addr = format!("{}:{}", config.host, config.port);
     tracing::info!("Starting server on {}", addr);
 

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
-use chrono::{NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 use chrono_tz::Europe::Berlin;
 
 use crate::{models, telegram_notify, AppState};
+
+/// How long after a live show's scheduled end we wait before alerting that no
+/// recording was produced — avoids false alarms for a show that just ended or a
+/// finalize still in flight.
+const RECORDING_ALERT_GRACE_MINS: i64 = 15;
 
 /// Check if any artist Instagram previews need to be sent today.
 ///
@@ -121,5 +126,177 @@ pub async fn check_artist_preview_schedule(state: Arc<AppState>) {
                 );
             }
         }
+    }
+}
+
+/// Parse an "HH:MM" string into a `NaiveTime`.
+fn parse_hhmm(s: &str) -> Option<NaiveTime> {
+    NaiveTime::parse_from_str(s, "%H:%M").ok()
+}
+
+/// Compute a show's scheduled end as a UTC instant, interpreting `date`+`end_time`
+/// in Europe/Berlin. Handles overnight shows (end ≤ start → next calendar day).
+/// Returns `None` if the date/time can't be parsed or the local time is invalid
+/// (DST gap).
+fn show_end_utc(date: &str, start_time: Option<&str>, end_time: &str) -> Option<DateTime<Utc>> {
+    let day = NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?;
+    let end = parse_hhmm(end_time)?;
+    let mut end_dt = day.and_time(end);
+    if let Some(start) = start_time.and_then(parse_hhmm) {
+        if end <= start {
+            end_dt += chrono::Duration::days(1);
+        }
+    }
+    Berlin
+        .from_local_datetime(&end_dt)
+        .single()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// True if the show's scheduled end is at least `grace_mins` in the past relative
+/// to `now` — i.e. it's been long enough that a missing recording is a real miss.
+/// Operates on primitives so it's pure and unit-testable.
+fn recording_overdue(
+    date: &str,
+    start_time: Option<&str>,
+    end_time: Option<&str>,
+    now: DateTime<Utc>,
+    grace_mins: i64,
+) -> bool {
+    match show_end_utc(date, start_time, end_time.unwrap_or("")) {
+        Some(end) => now >= end + chrono::Duration::minutes(grace_mins),
+        None => false,
+    }
+}
+
+/// Dead-man's-switch: alert (exactly once) when a live show that should have been
+/// recorded produced no usable recording.
+///
+/// A show qualifies if it is live-mode, ended at least [`RECORDING_ALERT_GRACE_MINS`]
+/// ago, has no successful `recording_versions` row (statuses raw/finalizing/finalized
+/// — a short/corrupt recording is marked `failed` by the upload verifier and so
+/// counts as missing), and has not already been alerted. Scoped to the last 2 days
+/// so enabling the feature never back-alerts the whole archive.
+pub async fn check_missing_recordings(state: Arc<AppState>) {
+    let now = Utc::now();
+
+    let shows: Vec<models::Show> = match sqlx::query_as(
+        "SELECT * FROM shows s \
+         WHERE s.stream_mode = 'live' \
+           AND s.recording_alert_sent_at IS NULL \
+           AND s.end_time IS NOT NULL \
+           AND s.date >= date('now', '-2 days') \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM recording_versions rv \
+             WHERE rv.show_id = s.id \
+               AND rv.status IN ('raw', 'finalizing', 'finalized') \
+           )",
+    )
+    .fetch_all(&state.db)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Dead-man's-switch: failed to query shows: {e}");
+            return;
+        }
+    };
+
+    for show in &shows {
+        if !recording_overdue(
+            &show.date,
+            show.start_time.as_deref(),
+            show.end_time.as_deref(),
+            now,
+            RECORDING_ALERT_GRACE_MINS,
+        ) {
+            continue; // still live, just ended, or unparseable schedule
+        }
+
+        tracing::warn!(
+            "Dead-man's-switch: show {} ('{}') ended with no recording — alerting",
+            show.id,
+            show.title
+        );
+
+        telegram_notify::notify(
+            &state,
+            &format!(
+                "⚠️ No recording for show \"{}\" (#{}) on {}{}. The live archive may be missing — check the recorder.",
+                show.title,
+                show.id,
+                show.date,
+                show.end_time.as_deref().map(|t| format!(" ending {t}")).unwrap_or_default(),
+            ),
+        )
+        .await;
+
+        // Mark alerted regardless of Telegram delivery so we never spam on retry.
+        if let Err(e) =
+            sqlx::query("UPDATE shows SET recording_alert_sent_at = datetime('now') WHERE id = ?")
+                .bind(show.id)
+                .execute(&state.db)
+                .await
+        {
+            tracing::error!(
+                "Dead-man's-switch: failed to mark show {} as alerted: {e}",
+                show.id
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn show_end_utc_handles_evening_show() {
+        // 20:00 Berlin (CEST, summer) → 18:00 UTC.
+        let end = show_end_utc("2026-06-01", Some("18:00"), "20:00").unwrap();
+        assert_eq!(end.to_rfc3339(), "2026-06-01T18:00:00+00:00");
+    }
+
+    #[test]
+    fn show_end_utc_handles_overnight() {
+        // 23:00 → 01:00 crosses midnight, so end is the next day 01:00 Berlin.
+        let end = show_end_utc("2026-06-01", Some("23:00"), "01:00").unwrap();
+        // 01:00 CEST on 2026-06-02 → 23:00 UTC on 2026-06-01.
+        assert_eq!(end.to_rfc3339(), "2026-06-01T23:00:00+00:00");
+    }
+
+    #[test]
+    fn show_end_utc_rejects_garbage() {
+        assert!(show_end_utc("not-a-date", Some("18:00"), "20:00").is_none());
+        assert!(show_end_utc("2026-06-01", None, "nope").is_none());
+    }
+
+    #[test]
+    fn recording_overdue_respects_grace() {
+        let end = show_end_utc("2026-06-01", Some("18:00"), "20:00").unwrap();
+        // 10 min after end: within 15-min grace → not overdue.
+        assert!(!recording_overdue(
+            "2026-06-01",
+            Some("18:00"),
+            Some("20:00"),
+            end + chrono::Duration::minutes(10),
+            15
+        ));
+        // 20 min after end: past grace → overdue.
+        assert!(recording_overdue(
+            "2026-06-01",
+            Some("18:00"),
+            Some("20:00"),
+            end + chrono::Duration::minutes(20),
+            15
+        ));
+        // Unparseable schedule is never overdue (don't alert blindly).
+        assert!(!recording_overdue(
+            "bad",
+            None,
+            Some("20:00"),
+            end + chrono::Duration::minutes(60),
+            15
+        ));
     }
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -216,6 +216,57 @@ pub async fn ensure_multipart_abort_lifecycle(client: &aws_sdk_s3::Client, bucke
     }
 }
 
+/// Remove entries in `dir` whose modification time is older than `max_age`.
+///
+/// Handles both stale recording files (`recording_*.webm`) and orphaned segment
+/// directories (`*.segs/` left by a crashed recorder). Returns the count removed.
+/// Best-effort: a missing dir is a no-op, and per-entry errors are logged, not
+/// propagated, so a scheduled sweep never aborts mid-way.
+pub async fn cleanup_stale_files(
+    dir: &std::path::Path,
+    max_age: std::time::Duration,
+) -> std::io::Result<usize> {
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e),
+    };
+
+    let now = std::time::SystemTime::now();
+    let mut removed = 0usize;
+    while let Some(entry) = entries.next_entry().await? {
+        let meta = match entry.metadata().await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let modified = match meta.modified() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let age = now
+            .duration_since(modified)
+            .unwrap_or(std::time::Duration::ZERO);
+        if age < max_age {
+            continue;
+        }
+
+        let path = entry.path();
+        let result = if meta.is_dir() {
+            tokio::fs::remove_dir_all(&path).await
+        } else {
+            tokio::fs::remove_file(&path).await
+        };
+        match result {
+            Ok(()) => {
+                removed += 1;
+                tracing::info!("Cleaned up stale temp entry {:?}", path);
+            }
+            Err(e) => tracing::warn!("Failed to remove stale temp entry {:?}: {}", path, e),
+        }
+    }
+    Ok(removed)
+}
+
 /// List all objects in the bucket matching a given key prefix.
 pub async fn list_objects(state: &Arc<AppState>, prefix: &str) -> Result<Vec<StorageObject>> {
     let mut objects = Vec::new();
@@ -935,6 +986,49 @@ pub async fn upload_audio_to_pending_async(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn cleanup_removes_old_keeps_fresh_and_tolerates_missing_dir() {
+        use std::time::Duration;
+
+        // Missing directory → no-op, not an error.
+        let missing = std::path::Path::new("/tmp/does-not-exist-xyz-170");
+        assert_eq!(
+            cleanup_stale_files(missing, Duration::ZERO).await.unwrap(),
+            0
+        );
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // A stale file and a stale segment directory.
+        tokio::fs::write(dir.path().join("recording_1.webm"), b"x")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(dir.path().join("recording_1.segs"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("recording_1.segs/seg_00000.ts"), b"y")
+            .await
+            .unwrap();
+
+        // max_age 1h: nothing is that old yet → kept.
+        assert_eq!(
+            cleanup_stale_files(dir.path(), Duration::from_secs(3600))
+                .await
+                .unwrap(),
+            0
+        );
+        assert!(dir.path().join("recording_1.webm").exists());
+
+        // max_age 0: everything qualifies → file + dir removed (2 entries).
+        assert_eq!(
+            cleanup_stale_files(dir.path(), Duration::ZERO)
+                .await
+                .unwrap(),
+            2
+        );
+        assert!(!dir.path().join("recording_1.webm").exists());
+        assert!(!dir.path().join("recording_1.segs").exists());
+    }
 
     /// Integration test against a **real R2 bucket**. Validates the checksum
     /// landmine fix end-to-end: a multi-part upload with explicit CRC32C must


### PR DESCRIPTION
Closes #172 — completes Phase 1 of the stream rework (#164). Builds on #169/#170/#171.

## What

Alerts when a scheduled live show produced **no recording**, and sweeps orphaned temp files.

- **Dead-man's-switch** (`scheduler::check_missing_recordings`, run every 5 min): finds live-mode shows that ended ≥15 min ago (Berlin time, overnight-aware) with **no successful** `recording_versions` row (`raw`/`finalizing`/`finalized`). A short/corrupt recording is already marked `failed` by the #171 verifier, so it correctly counts as missing. Fires **exactly one** Telegram alert per show, guarded by a new `shows.recording_alert_sent_at` column. Scoped to the last 2 days so enabling it never back-alerts the whole archive.
- **Temp-file cleanup** (`storage::cleanup_stale_files`, daily): removes `recording_*.webm` files and orphaned `*.segs/` segment dirs in `./data/recordings-temp` older than ~1 day. Tolerates a missing dir and per-entry errors.

## Verification
- Unit tests (all green): Berlin/overnight end-time computation, grace-window overdue logic (within-grace vs past-grace vs unparseable), and cleanup age/keep/missing-dir behavior.
- `cargo build` / `clippy` / `fmt` clean.
- The dead-man's-switch's exactly-once + "short recording counts as missing" behavior is enforced by the `recording_alert_sent_at` guard and the `status NOT IN (...)` query respectively.

## Notes
- The 15-min grace (`RECORDING_ALERT_GRACE_MINS`) covers a slow finalize/upload after a long show; tunable if needed.
- Pre-existing unrelated `video::tests::test_brightness_analysis` failure (surfaced by the #170 test-target fix) remains open — not on this path.