### PR TITLE
feat(shows): block overlapping show times + drag day-view picker

### DIFF
--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -25,6 +25,9 @@ pub enum AppError {
     #[error("Not found: {0}")]
     NotFound(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
@@ -70,6 +73,10 @@ impl IntoResponse for AppError {
                 (StatusCode::BAD_REQUEST, msg.clone())
             }
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            AppError::Conflict(msg) => {
+                tracing::warn!("Conflict: {}", msg);
+                (StatusCode::CONFLICT, msg.clone())
+            }
             AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
             AppError::FileTooLarge(max) => (

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -2819,6 +2819,56 @@ pub async fn api_show_detail(
     }))
 }
 
+/// Whether two same-day time windows clash. Times are zero-padded "HH:MM", so
+/// lexical comparison matches chronological order. A missing end is treated as a
+/// zero-length point at its start; identical starts always clash (catches the
+/// "two shows booked at the same time" case even when end times are absent).
+fn time_windows_overlap(
+    start_a: &str,
+    end_a: Option<&str>,
+    start_b: &str,
+    end_b: Option<&str>,
+) -> bool {
+    let end_a = end_a.unwrap_or(start_a);
+    let end_b = end_b.unwrap_or(start_b);
+    // Half-open overlap [start, end), plus an explicit equal-start collision.
+    (start_a < end_b && start_b < end_a) || start_a == start_b
+}
+
+/// Reject if the proposed window overlaps another show on the same date.
+/// `exclude_id` skips the show being edited (so it never clashes with itself).
+/// No start time → nothing to check (the window is undefined).
+async fn ensure_no_show_conflict(
+    state: &AppState,
+    date: &str,
+    start_time: Option<&str>,
+    end_time: Option<&str>,
+    exclude_id: Option<i64>,
+) -> Result<()> {
+    let Some(start) = start_time else {
+        return Ok(());
+    };
+
+    let others: Vec<(String, String, Option<String>)> = sqlx::query_as(
+        "SELECT title, start_time, end_time FROM shows \
+         WHERE date = ? AND id != ? AND start_time IS NOT NULL",
+    )
+    .bind(date)
+    .bind(exclude_id.unwrap_or(-1))
+    .fetch_all(&state.db)
+    .await?;
+
+    for (title, other_start, other_end) in others {
+        if time_windows_overlap(start, end_time, &other_start, other_end.as_deref()) {
+            return Err(AppError::Conflict(format!(
+                "This time overlaps an existing show \"{}\" on {}",
+                title, date
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateShowRequest {
     title: String,
@@ -2928,6 +2978,17 @@ pub async fn api_create_show(
         Some("prerecorded") => "prerecorded",
         _ => "live",
     };
+
+    // Refuse to double-book a slot: the new window must not overlap another show
+    // on the same date.
+    ensure_no_show_conflict(
+        &state,
+        &req.date,
+        req.start_time.as_deref(),
+        end_time.as_deref(),
+        None,
+    )
+    .await?;
 
     let result = sqlx::query(
         "INSERT INTO shows (title, date, description, status, show_type, start_time, end_time, host_user_id, stream_mode, created_by) VALUES (?, ?, ?, 'scheduled', ?, ?, ?, ?, ?, ?)",
@@ -3172,7 +3233,7 @@ pub async fn api_update_show(
     Json(req): Json<UpdateShowRequest>,
 ) -> Result<impl IntoResponse> {
     // Admins (any show) or the assigned host (their own show) may update.
-    let (user, _show) = require_show_editor(&state, &headers, id).await?;
+    let (user, existing) = require_show_editor(&state, &headers, id).await?;
 
     // show_type and ai_bio are admin-only fields; hosts have no UI for them.
     if !user.role_enum().can_access_admin() && (req.show_type.is_some() || req.ai_bio.is_some()) {
@@ -3232,6 +3293,15 @@ pub async fn api_update_show(
 
     if updates.is_empty() {
         return Err(AppError::BadRequest("No fields to update".to_string()));
+    }
+
+    // If the schedule window is being touched, make sure it doesn't collide with
+    // another show. Fall back to the show's current values for fields left unset.
+    if req.date.is_some() || req.start_time.is_some() || req.end_time.is_some() {
+        let date = req.date.as_deref().unwrap_or(&existing.date);
+        let start_time = req.start_time.as_deref().or(existing.start_time.as_deref());
+        let end_time = req.end_time.as_deref().or(existing.end_time.as_deref());
+        ensure_no_show_conflict(&state, date, start_time, end_time, Some(id)).await?;
     }
 
     let query_str = format!("UPDATE shows SET {} WHERE id = ?", updates.join(", "));
@@ -5495,4 +5565,64 @@ pub async fn require_show_editor(
     }
 
     Ok((user, show))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::time_windows_overlap;
+
+    #[test]
+    fn distinct_windows_do_not_overlap() {
+        // 20:00–22:00 vs 22:00–23:00: touch at the boundary, half-open → no clash.
+        assert!(!time_windows_overlap(
+            "20:00",
+            Some("22:00"),
+            "22:00",
+            Some("23:00")
+        ));
+        // Fully separate.
+        assert!(!time_windows_overlap(
+            "18:00",
+            Some("19:00"),
+            "20:00",
+            Some("21:00")
+        ));
+    }
+
+    #[test]
+    fn partially_overlapping_windows_clash() {
+        assert!(time_windows_overlap(
+            "20:00",
+            Some("22:00"),
+            "21:00",
+            Some("23:00")
+        ));
+        // Containment.
+        assert!(time_windows_overlap(
+            "20:00",
+            Some("23:00"),
+            "21:00",
+            Some("22:00")
+        ));
+    }
+
+    #[test]
+    fn identical_start_always_clashes() {
+        // Same start, even with no end times recorded.
+        assert!(time_windows_overlap("20:00", None, "20:00", None));
+        assert!(time_windows_overlap(
+            "20:00",
+            Some("22:00"),
+            "20:00",
+            Some("21:00")
+        ));
+    }
+
+    #[test]
+    fn missing_end_is_a_point_inside_another_window() {
+        // A start-only show at 21:00 falls inside 20:00–22:00.
+        assert!(time_windows_overlap("21:00", None, "20:00", Some("22:00")));
+        // ...but a point at 22:00 is outside the half-open [20:00, 22:00).
+        assert!(!time_windows_overlap("22:00", None, "20:00", Some("22:00")));
+    }
 }

--- a/frontend/src/admin/__tests__/showConflict.test.ts
+++ b/frontend/src/admin/__tests__/showConflict.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { rangesOverlap, findConflictingShow } from '../showConflict';
+import type { ScheduleItem } from '../api';
+
+const at = (h: number, m = 0) => new Date(2026, 5, 1, h, m);
+
+function show(partial: Partial<ScheduleItem> & Pick<ScheduleItem, 'id' | 'date'>): ScheduleItem {
+  return {
+    title: 'Show',
+    start_time: undefined,
+    end_time: undefined,
+    status: 'scheduled',
+    show_type: 'external',
+    artists: [],
+    ...partial,
+  } as ScheduleItem;
+}
+
+describe('rangesOverlap', () => {
+  it('treats boundary-touching windows as free (half-open)', () => {
+    expect(rangesOverlap(at(20), at(22), at(22), at(23))).toBe(false);
+  });
+
+  it('detects partial overlap and containment', () => {
+    expect(rangesOverlap(at(20), at(22), at(21), at(23))).toBe(true);
+    expect(rangesOverlap(at(20), at(23), at(21), at(22))).toBe(true);
+  });
+
+  it('treats identical starts as a clash even without end times', () => {
+    expect(rangesOverlap(at(20), null, at(20), null)).toBe(true);
+  });
+
+  it('treats a start-only point inside another window as a clash', () => {
+    expect(rangesOverlap(at(21), null, at(20), at(22))).toBe(true);
+    expect(rangesOverlap(at(22), null, at(20), at(22))).toBe(false);
+  });
+});
+
+describe('findConflictingShow', () => {
+  const shows: ScheduleItem[] = [
+    show({ id: 1, date: '2026-06-01', start_time: '20:00', end_time: '22:00', title: 'Evening' }),
+    show({ id: 2, date: '2026-06-02', start_time: '20:00', end_time: '22:00', title: 'Other day' }),
+  ];
+
+  it('returns null when the slot is free', () => {
+    expect(findConflictingShow(at(22), at(23), shows)).toBeNull();
+  });
+
+  it('returns the clashing show on the same day', () => {
+    expect(findConflictingShow(at(21), at(23), shows)?.id).toBe(1);
+  });
+
+  it('ignores shows on other days', () => {
+    // 20:00–22:00 on June 1 does not clash with the June 2 show.
+    expect(findConflictingShow(at(20), at(22), [shows[1]])).toBeNull();
+  });
+
+  it('skips the excluded show (e.g. the one being edited)', () => {
+    expect(findConflictingShow(at(20), at(22), shows, 1)).toBeNull();
+  });
+
+  it('ignores shows without a start time', () => {
+    const noTime = [show({ id: 3, date: '2026-06-01', title: 'TBD' })];
+    expect(findConflictingShow(at(20), at(22), noTime)).toBeNull();
+  });
+});

--- a/frontend/src/admin/components/show-wizard/DayTimeline.vue
+++ b/frontend/src/admin/components/show-wizard/DayTimeline.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, nextTick } from 'vue';
+import type { ScheduleItem } from '../../api';
+
+/**
+ * Apple-Calendar-style single-day timeline. Hours run top→bottom; clicking an
+ * empty slot drops a default one-hour show, and the block's top/bottom handles
+ * drag to resize. Works purely in "minutes from midnight"; the parent maps that
+ * onto the selected calendar date. Existing shows render as read-only blocks so
+ * the user can see (and avoid) conflicts.
+ */
+const props = defineProps<{
+  /** Selected day, "YYYY-MM-DD". Used to filter `shows` to this day. */
+  date: string;
+  /** Current show window, minutes from midnight, or null when nothing placed. */
+  startMinutes: number | null;
+  endMinutes: number | null;
+  /** All scheduled shows; the component renders those on `date`. */
+  shows: ScheduleItem[];
+  /** Whether the placed block overlaps an existing show (drives styling). */
+  conflict?: boolean;
+  /** Visible height of the scroll viewport, in px (matched to the calendar). */
+  height?: number;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update', value: { start: number; end: number }): void;
+}>();
+
+const HOUR_PX = 48;
+const GUTTER_PX = 52;
+const SNAP_MIN = 15;
+const DAY_MIN = 24 * 60;
+const DEFAULT_DURATION = 60;
+const MIN_DURATION = 15;
+
+const gridHeight = `${24 * HOUR_PX}px`;
+const gutter = `${GUTTER_PX}px`;
+const hours = Array.from({ length: 24 }, (_, h) => h);
+
+const scrollHeight = computed(() => `${props.height ?? 420}px`);
+
+const scrollEl = ref<HTMLElement | null>(null);
+const innerEl = ref<HTMLElement | null>(null);
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function fmt(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function parseTime(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Pointer Y → snapped minutes, relative to the grid's content box. */
+function pointerMinutes(e: PointerEvent): number {
+  const rect = innerEl.value!.getBoundingClientRect();
+  const raw = ((e.clientY - rect.top) / HOUR_PX) * 60;
+  return clamp(Math.round(raw / SNAP_MIN) * SNAP_MIN, 0, DAY_MIN);
+}
+
+const hasBlock = computed(() => props.startMinutes !== null && props.endMinutes !== null);
+
+const selectedStyle = computed(() => {
+  if (!hasBlock.value) return {};
+  const top = (props.startMinutes! / 60) * HOUR_PX;
+  const height = ((props.endMinutes! - props.startMinutes!) / 60) * HOUR_PX;
+  return { top: `${top}px`, height: `${height}px` };
+});
+
+const selectedLabel = computed(() =>
+  hasBlock.value ? `${fmt(props.startMinutes!)}–${fmt(props.endMinutes!)}` : ''
+);
+
+/** Existing shows on this day, as positioned read-only blocks. */
+const dayEvents = computed(() => {
+  return props.shows
+    .filter((s) => s.date === props.date && s.start_time)
+    .map((s) => {
+      const start = parseTime(s.start_time!);
+      const end = s.end_time ? parseTime(s.end_time) : start + DEFAULT_DURATION;
+      return {
+        id: s.id,
+        title: s.title,
+        label: `${fmt(start)}–${fmt(end)}`,
+        top: (start / 60) * HOUR_PX,
+        height: (Math.max(end - start, MIN_DURATION) / 60) * HOUR_PX,
+      };
+    });
+});
+
+// ── Click-to-create ─────────────────────────────────────────────────────────
+
+function onGridPointerDown(e: PointerEvent): void {
+  // Snap the click to the hour it lands in; default to a one-hour show.
+  const start = clamp(Math.floor(pointerMinutes(e) / 60) * 60, 0, DAY_MIN - DEFAULT_DURATION);
+  emit('update', { start, end: start + DEFAULT_DURATION });
+}
+
+// ── Drag to move / resize ────────────────────────────────────────────────────
+
+type DragMode = 'move' | 'start' | 'end';
+let dragMode: DragMode | null = null;
+let dragOffset = 0; // for move: pointer minute − block start
+
+function startDrag(mode: DragMode, e: PointerEvent): void {
+  if (!hasBlock.value) return;
+  dragMode = mode;
+  dragOffset = pointerMinutes(e) - props.startMinutes!;
+  window.addEventListener('pointermove', onDrag);
+  window.addEventListener('pointerup', endDrag);
+}
+
+function onDrag(e: PointerEvent): void {
+  if (!dragMode || !hasBlock.value) return;
+  let start = props.startMinutes!;
+  let end = props.endMinutes!;
+  const ptr = pointerMinutes(e);
+  if (dragMode === 'start') {
+    start = clamp(ptr, 0, end - MIN_DURATION);
+  } else if (dragMode === 'end') {
+    end = clamp(ptr, start + MIN_DURATION, DAY_MIN);
+  } else {
+    const dur = end - start;
+    start = clamp(ptr - dragOffset, 0, DAY_MIN - dur);
+    end = start + dur;
+  }
+  emit('update', { start, end });
+}
+
+function endDrag(): void {
+  dragMode = null;
+  window.removeEventListener('pointermove', onDrag);
+  window.removeEventListener('pointerup', endDrag);
+}
+
+// ── Auto-scroll so the placed block is in view when the day changes ───────────
+
+function scrollToBlock(): void {
+  if (!scrollEl.value || props.startMinutes === null) return;
+  const y = (props.startMinutes / 60) * HOUR_PX;
+  scrollEl.value.scrollTop = Math.max(0, y - HOUR_PX * 1.5);
+}
+
+onMounted(() => nextTick(scrollToBlock));
+watch(
+  () => props.date,
+  () => nextTick(scrollToBlock)
+);
+</script>
+
+<template>
+  <div class="day-timeline">
+    <div ref="scrollEl" class="tl-scroll" :style="{ height: scrollHeight }">
+      <div
+        ref="innerEl"
+        class="tl-grid"
+        :style="{ height: gridHeight }"
+        @pointerdown="onGridPointerDown"
+      >
+        <div v-for="h in hours" :key="h" class="tl-hour" :style="{ top: `${h * HOUR_PX}px` }">
+          <span class="tl-hour-label">{{ String(h).padStart(2, '0') }}:00</span>
+        </div>
+
+        <!-- Existing shows (read-only) -->
+        <div
+          v-for="ev in dayEvents"
+          :key="ev.id"
+          class="tl-event tl-event--existing"
+          :style="{ top: `${ev.top}px`, height: `${ev.height}px` }"
+        >
+          <span class="tl-event-title">{{ ev.title }}</span>
+          <span class="tl-event-time">{{ ev.label }}</span>
+        </div>
+
+        <!-- The show being scheduled (draggable) -->
+        <div
+          v-if="hasBlock"
+          class="tl-event tl-event--selected"
+          :class="{ 'tl-event--conflict': conflict }"
+          :style="selectedStyle"
+          @pointerdown.stop="startDrag('move', $event)"
+        >
+          <div class="tl-handle tl-handle--top" @pointerdown.stop="startDrag('start', $event)" />
+          <span class="tl-event-time">{{ selectedLabel }}</span>
+          <div class="tl-handle tl-handle--bottom" @pointerdown.stop="startDrag('end', $event)" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.day-timeline {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  overflow: hidden;
+}
+
+.tl-scroll {
+  overflow-y: auto;
+}
+
+.tl-grid {
+  position: relative;
+  width: 100%;
+  /* Empty area is the click target; block + handles set their own cursors. */
+  cursor: copy;
+  touch-action: pan-y;
+}
+
+.tl-hour {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 0;
+  border-top: 1px solid var(--color-border);
+  pointer-events: none;
+}
+
+.tl-hour-label {
+  position: absolute;
+  top: -0.6em;
+  left: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  padding-right: var(--spacing-xs);
+}
+
+.tl-event {
+  position: absolute;
+  left: v-bind(gutter);
+  right: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--spacing-sm);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--font-size-sm);
+  box-sizing: border-box;
+}
+
+.tl-event-title {
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tl-event-time {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.tl-event--existing {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border-light);
+  color: var(--color-text-muted);
+  pointer-events: none;
+}
+
+.tl-event--selected {
+  background: var(--color-primary);
+  color: var(--color-primary-text, #000);
+  cursor: grab;
+  touch-action: none;
+  z-index: 2;
+  justify-content: center;
+  font-weight: var(--font-weight-bold);
+}
+
+.tl-event--selected:active {
+  cursor: grabbing;
+}
+
+.tl-event--conflict {
+  background: var(--color-error);
+  color: #fff;
+}
+
+.tl-handle {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 10px;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.tl-handle--top {
+  top: 0;
+}
+
+.tl-handle--bottom {
+  bottom: 0;
+}
+
+/* A grab affordance line on each handle. */
+.tl-handle::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 3px;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+.tl-handle--top::after {
+  top: 2px;
+}
+
+.tl-handle--bottom::after {
+  bottom: 2px;
+}
+</style>

--- a/frontend/src/admin/components/show-wizard/WizardDate.vue
+++ b/frontend/src/admin/components/show-wizard/WizardDate.vue
@@ -1,21 +1,31 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
 import { useShowWizard } from '../../composables';
-import { showsApi, type Show } from '../../api';
 import MonthCalendar from '../MonthCalendar.vue';
+import DayTimeline from './DayTimeline.vue';
 
 const wizard = useShowWizard();
-const { startDateTime, endDateTime } = wizard;
+const { startDateTime, endDateTime, scheduledShows, conflictingShow } = wizard;
 
-const shows = ref<Show[]>([]);
+// Match the timeline's height to the calendar's (which changes with 5/6-week
+// months) by measuring it live.
+const calWrap = ref<HTMLElement | null>(null);
+const calHeight = ref(420);
+let resizeObserver: ResizeObserver | null = null;
 
-onMounted(async () => {
-  try {
-    const res = await showsApi.overview();
-    shows.value = res.shows as Show[];
-  } catch {
-    shows.value = [];
+onMounted(() => {
+  void wizard.loadScheduledShows();
+  if (calWrap.value && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      if (calWrap.value) calHeight.value = calWrap.value.clientHeight;
+    });
+    resizeObserver.observe(calWrap.value);
+    calHeight.value = calWrap.value.clientHeight;
   }
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
 });
 
 function pad(n: number): string {
@@ -38,12 +48,38 @@ const selectedDateLabel = computed(() => {
   });
 });
 
+/** Midnight of the selected day, in epoch ms — the timeline's minute origin. */
+const dayBase = computed(() => {
+  if (!selectedDateStr.value) return null;
+  const [y, m, d] = selectedDateStr.value.split('-').map(Number);
+  return new Date(y, m - 1, d, 0, 0, 0, 0).getTime();
+});
+
+/** Show window as minutes-from-midnight, so a cross-midnight end stays > start. */
+const startMinutes = computed(() =>
+  startDateTime.value && dayBase.value !== null
+    ? Math.round((startDateTime.value.getTime() - dayBase.value) / 60000)
+    : null
+);
+const endMinutes = computed(() =>
+  endDateTime.value && dayBase.value !== null
+    ? Math.round((endDateTime.value.getTime() - dayBase.value) / 60000)
+    : null
+);
+
 function onDayClick(dateStr: string) {
   const [y, m, d] = dateStr.split('-').map(Number);
   const s = startDateTime.value;
   const e = endDateTime.value;
   startDateTime.value = new Date(y, m - 1, d, s ? s.getHours() : 20, s ? s.getMinutes() : 0);
   endDateTime.value = new Date(y, m - 1, d, e ? e.getHours() : 22, e ? e.getMinutes() : 0);
+}
+
+/** Apply a window dragged/clicked on the timeline back onto the Date refs. */
+function onTimelineUpdate({ start, end }: { start: number; end: number }) {
+  if (dayBase.value === null) return;
+  startDateTime.value = new Date(dayBase.value + start * 60000);
+  endDateTime.value = new Date(dayBase.value + end * 60000);
 }
 
 function timeModel(target: 'start' | 'end') {
@@ -71,9 +107,25 @@ const endTime = timeModel('end');
   <div class="step">
     <h2 class="step-title">When is the show?</h2>
 
-    <MonthCalendar class="compact" :shows="shows" @day-click="onDayClick" />
+    <div class="date-grid">
+      <div ref="calWrap" class="cal-wrap">
+        <MonthCalendar class="compact" :shows="scheduledShows" @day-click="onDayClick" />
+      </div>
 
-    <div v-if="selectedDateLabel" class="time-row">
+      <DayTimeline
+        v-if="selectedDateStr"
+        :date="selectedDateStr"
+        :start-minutes="startMinutes"
+        :end-minutes="endMinutes"
+        :shows="scheduledShows"
+        :conflict="!!conflictingShow"
+        :height="calHeight"
+        @update="onTimelineUpdate"
+      />
+      <div v-else class="timeline-placeholder">Pick a day in the calendar.</div>
+    </div>
+
+    <div v-if="selectedDateLabel && selectedDateStr" class="time-controls">
       <span class="selected-date">{{ selectedDateLabel }}</span>
       <div class="time-fields">
         <label class="time-field">
@@ -85,11 +137,15 @@ const endTime = timeModel('end');
           <input v-model="endTime" type="time" class="time-input" />
         </label>
       </div>
-      <p v-if="!wizard.rangeValid.value && wizard.rangeError.value" class="field-error">
+      <p v-if="conflictingShow" class="field-error">
+        This overlaps “{{ conflictingShow.title }}” ({{ conflictingShow.start_time
+        }}<template v-if="conflictingShow.end_time">–{{ conflictingShow.end_time }}</template
+        >). Pick another time.
+      </p>
+      <p v-else-if="!wizard.rangeValid.value && wizard.rangeError.value" class="field-error">
         {{ wizard.rangeError.value }}
       </p>
     </div>
-    <p v-else class="step-hint">Pick a day in the calendar above.</p>
   </div>
 </template>
 
@@ -102,27 +158,45 @@ const endTime = timeModel('end');
   text-align: center;
 }
 
-.step-hint {
-  color: var(--color-text-muted);
-  margin: var(--spacing-lg) 0 0;
-  text-align: center;
+.date-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: var(--spacing-xl);
+  align-items: start;
 }
 
-.time-row {
-  margin-top: var(--spacing-lg);
+/* Enlarge the month calendar so it matches the day timeline's height. */
+.date-grid :deep(.month-calendar.compact .vc-day) {
+  min-height: 52px;
+}
+
+.timeline-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
   text-align: center;
+  padding: var(--spacing-lg);
+}
+
+.time-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-lg);
 }
 
 .selected-date {
-  display: block;
   font-weight: var(--font-weight-bold);
   color: var(--color-text);
-  margin-bottom: var(--spacing-md);
 }
 
 .time-fields {
   display: flex;
-  justify-content: center;
   gap: var(--spacing-lg);
 }
 
@@ -151,6 +225,13 @@ const endTime = timeModel('end');
 .field-error {
   color: var(--color-error);
   font-size: var(--font-size-sm);
-  margin: var(--spacing-md) 0 0;
+  margin: 0;
+}
+
+@media (max-width: 800px) {
+  .date-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-lg);
+  }
 }
 </style>

--- a/frontend/src/admin/composables/useShowWizard.ts
+++ b/frontend/src/admin/composables/useShowWizard.ts
@@ -8,8 +8,10 @@ import {
   type ShowTemplate,
   type AdminUser,
   type GuestCredentials,
+  type ScheduleItem,
 } from '../api';
 import { useDateTimeRange } from './useDateTimeRange';
+import { findConflictingShow } from '../showConflict';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -56,6 +58,9 @@ const coverPreviewUrl = ref<string | null>(null);
 
 // Date / time (start + end)
 const range = useDateTimeRange();
+
+// All scheduled shows, used to block double-booking a time slot on the date step.
+const scheduledShows = ref<ScheduleItem[]>([]);
 
 // Host step: assign an existing user, or create a guest who becomes the host.
 const assignableUsers = ref<AdminUser[]>([]);
@@ -104,6 +109,11 @@ const currentStep = computed<WizardStep>(() => steps.value[stepIndex.value] ?? '
 const isFirstStep = computed(() => stepIndex.value === 0);
 const isLastStep = computed(() => stepIndex.value === steps.value.length - 1);
 
+/** The already-scheduled show whose time the chosen window overlaps, if any. */
+const conflictingShow = computed(() =>
+  findConflictingShow(range.startDateTime.value, range.endDateTime.value, scheduledShows.value)
+);
+
 /** Whether the current step is complete enough to advance. */
 const canProceed = computed(() => {
   switch (currentStep.value) {
@@ -118,7 +128,7 @@ const canProceed = computed(() => {
     case 'description':
       return true; // optional
     case 'date':
-      return range.isValid.value;
+      return range.isValid.value && conflictingShow.value === null;
     case 'host':
       // Either pick an existing user, or name a guest to create.
       return hostMode.value === 'existing'
@@ -242,6 +252,16 @@ async function loadTemplates(): Promise<void> {
   }
 }
 
+/** Load every scheduled show so the date step can block overlapping slots. */
+async function loadScheduledShows(): Promise<void> {
+  try {
+    const res = await showsApi.overview();
+    scheduledShows.value = res.shows as ScheduleItem[];
+  } catch {
+    scheduledShows.value = [];
+  }
+}
+
 async function loadAssignableUsers(): Promise<void> {
   // Non-admins can't list users; a host's only "existing" choice is themselves.
   // Default to self so they can self-assign and proceed immediately.
@@ -340,6 +360,7 @@ function start(opts: {
   newDescription.value = '';
   setCover(null);
   range.reset();
+  scheduledShows.value = [];
   assignableUsers.value = [];
   assigneeLoading.value = false;
   assigneeUserId.value = null;
@@ -378,6 +399,8 @@ export function useShowWizard() {
     endDateTime: range.endDateTime,
     rangeValid: range.isValid,
     rangeError: range.validationError,
+    scheduledShows: readonly(scheduledShows),
+    conflictingShow,
     assignableUsers: readonly(assignableUsers),
     assigneeLoading: readonly(assigneeLoading),
     assigneeUserId,
@@ -417,6 +440,7 @@ export function useShowWizard() {
     goToStep,
     setCover,
     loadTemplates,
+    loadScheduledShows,
     loadAssignableUsers,
     submit,
   };

--- a/frontend/src/admin/pages/ShowWizard.vue
+++ b/frontend/src/admin/pages/ShowWizard.vue
@@ -64,10 +64,12 @@ function onCancel() {
 }
 
 function leave() {
-  if (isAdmin.value) {
-    router.push(createdShowId.value ? `/shows/${createdShowId.value}` : '/shows');
+  // After creation, land on the new show's detail page (hosts and guests can
+  // view it too). Fall back to the role's home if we somehow have no id.
+  if (createdShowId.value) {
+    router.push(`/shows/${createdShowId.value}`);
   } else {
-    router.push('/stream');
+    router.push(isAdmin.value ? '/shows' : '/stream');
   }
 }
 

--- a/frontend/src/admin/showConflict.ts
+++ b/frontend/src/admin/showConflict.ts
@@ -1,0 +1,49 @@
+import type { ScheduleItem } from './api';
+
+/**
+ * Whether two time windows clash. A missing end is treated as a zero-length
+ * point at its start, and identical starts always clash — mirrors the backend's
+ * `time_windows_overlap` so the wizard blocks exactly what the API would reject.
+ */
+export function rangesOverlap(
+  startA: Date,
+  endA: Date | null,
+  startB: Date,
+  endB: Date | null
+): boolean {
+  const ea = (endA ?? startA).getTime();
+  const eb = (endB ?? startB).getTime();
+  const sa = startA.getTime();
+  const sb = startB.getTime();
+  // Half-open overlap [start, end), plus an explicit equal-start collision.
+  return (sa < eb && sb < ea) || sa === sb;
+}
+
+/** Build a Date from a "YYYY-MM-DD" date and "HH:MM" time. */
+function parseDateTime(date: string, time: string): Date {
+  const [y, m, d] = date.split('-').map(Number);
+  const [hh, mm] = time.split(':').map(Number);
+  return new Date(y, m - 1, d, hh, mm);
+}
+
+/**
+ * Find the first scheduled show whose time window overlaps [start, end).
+ * `excludeId` skips a show (e.g. the one being edited). Shows without a start
+ * time can't be placed on the clock and are ignored. Returns null when free.
+ */
+export function findConflictingShow(
+  start: Date | null,
+  end: Date | null,
+  shows: ScheduleItem[],
+  excludeId?: number
+): ScheduleItem | null {
+  if (!start) return null;
+  for (const show of shows) {
+    if (show.id === excludeId) continue;
+    if (!show.start_time) continue;
+    const showStart = parseDateTime(show.date, show.start_time);
+    const showEnd = show.end_time ? parseDateTime(show.date, show.end_time) : null;
+    if (rangesOverlap(start, end, showStart, showEnd)) return show;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #163.

## What
Blocks scheduling a show when its time window overlaps an existing show, and adds an Apple-Calendar-style day-view time picker.

### Conflict blocking (both layers)
- **Backend** — `AppError::Conflict` (HTTP 409), pure `time_windows_overlap` helper, and `ensure_no_show_conflict` (queries same-date shows, excludes self on edit). Wired into `api_create_show` and `api_update_show`. Half-open `[start, end)` overlap; missing end = zero-length point; identical starts always clash. 4 unit tests.
- **Frontend** — `showConflict.ts` (`rangesOverlap` / `findConflictingShow`) mirrors backend semantics. The wizard date step loads all scheduled shows, exposes `conflictingShow`, and gates `canProceed`. 9 Vitest cases.

### Day-view picker (`DayTimeline.vue`)
- Hour grid beside the month calendar. Click an empty slot → default 1-hour show; drag top/bottom handles to resize, body to move (15-min snap).
- Existing shows render as read-only blocks; the placed block turns red on conflict.
- Height tracks the calendar via a `ResizeObserver` so both columns match.

### UX
- After creation, navigate to the new show's detail page (`/shows/:id`) for hosts and admins, instead of the overview / stream.

## Verification
- Backend: `cargo fmt` + `clippy` clean, 4/4 overlap tests pass.
- Frontend: 31/31 Vitest, ESLint clean, no new `tsc` errors (pre-existing `.vue`-resolution errors only).
- Drag interaction needs a manual browser check (no real layout in jsdom).