### PR TITLE
feat(stream): local Docker harness to rehearse the Icecast chain

### DIFF
--- a/docs/stream-rework/local-test-harness/README.md
+++ b/docs/stream-rework/local-test-harness/README.md
@@ -1,0 +1,72 @@
+# Local Icecast test harness
+
+Rehearse the **entire** Phase-2 chain — NodeMediaServer 2.4.9 → Liquidsoap → Icecast —
+on your laptop, fed by a synthetic tone. Validates the mount + **iOS playback** before
+you touch the fragile prod relay box, and without waiting for a live show.
+
+See the full prod procedure in [`../phase-2-icecast-runbook.md`](../phase-2-icecast-runbook.md).
+This harness is the "Tier 1 — local rehearsal" step.
+
+## Prerequisites
+
+- Docker + `docker compose`
+- `ffmpeg` on the host (for `push-test-tone.sh`) — or use the in-container fallback in that script
+- An iPhone on the **same Wi-Fi** as your laptop (for the iOS gate)
+
+## Run it
+
+```bash
+cd docs/stream-rework/local-test-harness
+docker compose up --build            # NMS + Icecast + Liquidsoap
+```
+
+In a second terminal, feed audio in:
+
+```bash
+./push-test-tone.sh                  # 440 Hz tone
+# ./push-test-tone.sh ~/music.mp3    # …or loop a real file to hear music
+```
+
+Liquidsoap serves **silence** to `/test.mp3` the moment it's up (thanks to `mksafe`),
+then switches to your audio within a few seconds of starting the push.
+
+## Validate (this mirrors the prod gates)
+
+| Check | How |
+|---|---|
+| NMS got the push | `curl -sI http://localhost:8000/live/stream-io-test.flv` → `200` (and `…/index.m3u8` once HLS warms up) |
+| Icecast serving MP3 | `curl -sI http://localhost:8010/test.mp3` → `200`, `Content-Type: audio/mpeg` |
+| Icecast stats | open `http://localhost:8010/admin/stats.xml` (user `admin` / pass `localadmin`) — one source, listener count |
+| Desktop playback | open `http://localhost:8010/test.mp3` in a browser |
+| **iOS gate** | on the iPhone, Safari → `http://<your-laptop-LAN-ip>:8010/test.mp3` — **must play** |
+
+Find your LAN IP: `ipconfig getifaddr en0` (macOS Wi-Fi).
+
+> **iOS note:** test over plain `http://` *directly* in Safari. iOS blocks `http` audio
+> embedded in an `https` page (mixed content) — that's expected and is solved in prod by
+> putting the mount behind TLS (runbook Step 4), not a codec problem.
+
+If the iPhone plays `/test.mp3`, the **codec + transport decision is validated** — MP3
+over Icecast reaches iOS, exactly as the migration needs.
+
+## Tear down
+
+```bash
+docker compose down -v
+```
+
+Pure local containers — nothing here connects to prod, the relay box, or R2.
+
+## Notes / knobs
+
+- **Passwords** (`localsource` / `localadmin`) live in `icecast/icecast.xml` and
+  `liquidsoap/moafunk.liq` — local-only; they must match each other.
+- **Codec:** the mount is `%mp3` on purpose (iOS-safe). Do **not** switch the public
+  mount to `%opus`/Ogg — iOS Safari can't decode it. Add Opus only as an *extra* mount.
+- **Liquidsoap version:** pinned to `savonet/liquidsoap:v2.2.5`; bump the tag in
+  `docker-compose.yml` if you prefer a newer 2.x. (`input.ffmpeg`/`mksafe` are stable across 2.x.)
+- **Icecast:** stock `icecast2` here for convenience; it's protocol-identical to
+  Icecast-KH for this test. Switch to KH before the real cutover (KH adds the relay/
+  listener-limit features Phase 4 needs).
+- Only the throwaway `stream-io-test` key is used, so this never resembles the real
+  `stream-io` mount even if you point it at a real NMS by mistake.

--- a/docs/stream-rework/local-test-harness/docker-compose.yml
+++ b/docs/stream-rework/local-test-harness/docker-compose.yml
@@ -1,0 +1,35 @@
+# Local rehearsal of the Phase-2 Icecast parallel-run (see ../phase-2-icecast-runbook.md).
+# Brings up the SAME chain as prod — NodeMediaServer 2.4.9 → Liquidsoap → Icecast —
+# on your laptop, fed by a synthetic test tone. Nothing here touches prod.
+#
+#   docker compose up --build         # start the stack
+#   ./push-test-tone.sh               # feed a 440 Hz tone into NMS (separate terminal)
+#   open http://localhost:8010/test.mp3   # desktop; iPhone uses http://<your-LAN-ip>:8010/test.mp3
+#
+name: moafunk-stream-test
+
+services:
+  # NodeMediaServer pinned to the prod version (2.4.9) — RTMP ingest + HTTP/HLS.
+  nms:
+    build: ./nms
+    ports:
+      - "1935:1935" # RTMP — push the test tone here
+      - "8000:8000" # NMS HTTP/HLS — verify the existing path is untouched
+    restart: unless-stopped
+
+  # Icecast — serves the new /test.mp3 mount (host 8010 → container 8000).
+  icecast:
+    build: ./icecast
+    ports:
+      - "8010:8000"
+    restart: unless-stopped
+
+  # Liquidsoap — pulls the RTMP locally from NMS and re-emits MP3 to Icecast.
+  # mksafe() means the mount serves silence until the tone is pushed, then audio.
+  liquidsoap:
+    image: savonet/liquidsoap:v2.2.5
+    depends_on: [nms, icecast]
+    volumes:
+      - ./liquidsoap/moafunk.liq:/moafunk.liq:ro
+    command: ["liquidsoap", "/moafunk.liq"]
+    restart: unless-stopped

--- a/docs/stream-rework/local-test-harness/icecast/Dockerfile
+++ b/docs/stream-rework/local-test-harness/icecast/Dockerfile
@@ -1,0 +1,9 @@
+# Stock Icecast (protocol-compatible with Icecast-KH for this rehearsal).
+# Swap to Icecast-KH before the real Phase-3 cutover; the mount/codec are identical.
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends icecast2 \
+ && rm -rf /var/lib/apt/lists/*
+COPY icecast.xml /etc/icecast2/icecast.xml
+EXPOSE 8000
+CMD ["icecast2", "-c", "/etc/icecast2/icecast.xml"]

--- a/docs/stream-rework/local-test-harness/icecast/icecast.xml
+++ b/docs/stream-rework/local-test-harness/icecast/icecast.xml
@@ -1,0 +1,53 @@
+<icecast>
+  <location>local</location>
+  <admin>admin@localhost</admin>
+
+  <limits>
+    <clients>50</clients>
+    <sources>4</sources>
+    <queue-size>524288</queue-size>
+    <burst-on-connect>1</burst-on-connect>
+    <burst-size>65536</burst-size>
+  </limits>
+
+  <!-- LOCAL-ONLY credentials. Must match liquidsoap/moafunk.liq. -->
+  <authentication>
+    <source-password>localsource</source-password>
+    <relay-password>localrelay</relay-password>
+    <admin-user>admin</admin-user>
+    <admin-password>localadmin</admin-password>
+  </authentication>
+
+  <listen-socket>
+    <port>8000</port>
+  </listen-socket>
+
+  <!-- The new MP3 mount (iOS-safe codec). Mounts are dynamic in Icecast; this
+       block just pins limits/visibility for parity with the prod runbook. -->
+  <mount type="normal">
+    <mount-name>/test.mp3</mount-name>
+    <max-listeners>50</max-listeners>
+    <public>0</public>
+  </mount>
+
+  <fileserve>1</fileserve>
+
+  <paths>
+    <logdir>/var/log/icecast2</logdir>
+    <webroot>/usr/share/icecast2/web</webroot>
+    <adminroot>/usr/share/icecast2/admin</adminroot>
+  </paths>
+
+  <!-- Started as root in the container, then drops to the icecast2 user. -->
+  <security>
+    <chroot>0</chroot>
+    <changeowner>
+      <user>icecast2</user>
+      <group>icecast</group>
+    </changeowner>
+  </security>
+
+  <logging>
+    <loglevel>3</loglevel>
+  </logging>
+</icecast>

--- a/docs/stream-rework/local-test-harness/liquidsoap/moafunk.liq
+++ b/docs/stream-rework/local-test-harness/liquidsoap/moafunk.liq
@@ -1,0 +1,22 @@
+# Local rehearsal producer: pull the live RTMP from NMS, re-emit MP3 to Icecast.
+# Mirrors the prod Liquidsoap script in ../phase-2-icecast-runbook.md, but points
+# at docker service names (nms, icecast) and the throwaway "stream-io-test" key.
+
+# Source: pull the test stream locally from NodeMediaServer.
+src = input.ffmpeg(format="flv", "rtmp://nms:1935/live/stream-io-test")
+
+# Never let the mount 404 if the source is absent — fall back to silence.
+radio = mksafe(src)
+
+# Output: MP3 to Icecast /test.mp3 (iOS-safe codec; NEVER Opus/Ogg for the public mount).
+output.icecast(
+  %mp3(bitrate=128, samplerate=44100, stereo=true),
+  host="icecast",
+  port=8000,
+  password="localsource",
+  mount="/test.mp3",
+  name="Moafunk (local test)",
+  description="Local Phase-2 parallel-run rehearsal",
+  genre="radio",
+  radio
+)

--- a/docs/stream-rework/local-test-harness/nms/Dockerfile
+++ b/docs/stream-rework/local-test-harness/nms/Dockerfile
@@ -1,0 +1,8 @@
+# NodeMediaServer pinned to the prod version (2.4.9), with ffmpeg for HLS.
+FROM node:16-alpine
+RUN apk add --no-cache ffmpeg
+WORKDIR /app
+RUN npm init -y >/dev/null 2>&1 && npm install node-media-server@2.4.9
+COPY app.js .
+EXPOSE 1935 8000
+CMD ["node", "app.js"]

--- a/docs/stream-rework/local-test-harness/nms/app.js
+++ b/docs/stream-rework/local-test-harness/nms/app.js
@@ -1,0 +1,31 @@
+// Minimal NodeMediaServer 2.4.9 config mirroring prod: RTMP ingest on 1935,
+// HTTP/HLS on 8000. The `trans` task transcodes each /live stream to HLS so you
+// can confirm the existing index.m3u8 path keeps working (untouched by Icecast).
+const NodeMediaServer = require('node-media-server');
+
+const config = {
+  rtmp: {
+    port: 1935,
+    chunk_size: 60000,
+    gop_cache: true,
+    ping: 30,
+    ping_timeout: 60,
+  },
+  http: {
+    port: 8000,
+    mediaroot: './media',
+    allow_origin: '*',
+  },
+  trans: {
+    ffmpeg: '/usr/bin/ffmpeg',
+    tasks: [
+      {
+        app: 'live',
+        hls: true,
+        hlsFlags: '[hls_time=2:hls_list_size=3:hls_flags=delete_segments]',
+      },
+    ],
+  },
+};
+
+new NodeMediaServer(config).run();

--- a/docs/stream-rework/local-test-harness/push-test-tone.sh
+++ b/docs/stream-rework/local-test-harness/push-test-tone.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Push a synthetic 440 Hz tone into the local NodeMediaServer as the throwaway
+# "stream-io-test" key — the same way a real broadcaster's RTMP would arrive,
+# but isolated from the real "stream-io" key. Needs ffmpeg on the host.
+#
+#   ./push-test-tone.sh                # 440 Hz tone
+#   ./push-test-tone.sh path/to.mp3    # loop a real file instead (hear music)
+#
+# Ctrl-C to stop. No host ffmpeg? Run it in a container instead:
+#   docker run --rm --network moafunk-stream-test_default jrottenberg/ffmpeg \
+#     -re -f lavfi -i sine=frequency=440 -c:a aac -b:a 128k -f flv \
+#     rtmp://nms:1935/live/stream-io-test
+set -euo pipefail
+
+KEY="stream-io-test"
+DEST="rtmp://localhost:1935/live/${KEY}"
+
+if [[ "${1:-}" != "" ]]; then
+  echo "Looping ${1} → ${DEST} (Ctrl-C to stop)…"
+  exec ffmpeg -hide_banner -re -stream_loop -1 -i "$1" \
+    -c:a aac -b:a 192k -ar 44100 -ac 2 -f flv "${DEST}"
+else
+  echo "Pushing 440 Hz test tone → ${DEST} (Ctrl-C to stop)…"
+  exec ffmpeg -hide_banner -re -f lavfi -i "sine=frequency=440:sample_rate=44100" \
+    -c:a aac -b:a 128k -ar 44100 -ac 2 -f flv "${DEST}"
+fi


### PR DESCRIPTION
A turnkey local rehearsal of the Phase-2 chain (**NMS 2.4.9 → Liquidsoap → Icecast**) so the mount + **iOS playback** can be validated on a laptop — before touching the fragile prod relay box and without waiting for a live show. Pairs with the runbook (`docs/stream-rework/phase-2-icecast-runbook.md`, PR #189) as its "Tier 1 — local rehearsal" step.

## Usage
```bash
cd docs/stream-rework/local-test-harness
docker compose up --build
./push-test-tone.sh                 # 440 Hz tone (or pass an .mp3 to loop)
# desktop:  http://localhost:8010/test.mp3
# iPhone:   http://<your-LAN-ip>:8010/test.mp3   ← the iOS gate
```

## What's in it
- **NMS** pinned to **2.4.9** (custom Dockerfile, ffmpeg for HLS) — RTMP 1935 + HTTP/HLS 8000.
- **Icecast** (stock `icecast2`, protocol-identical to KH for this test) serving `/test.mp3` on host 8010.
- **Liquidsoap** (`savonet/liquidsoap:v2.2.5`) pulls `rtmp://nms/live/stream-io-test`, `mksafe`→silence-until-audio, re-emits **`%mp3`** (iOS-safe).
- `push-test-tone.sh` feeds the throwaway **`stream-io-test`** key — fully isolated from the real `stream-io` mount.
- README with a per-stage verification table + the mixed-content caveat for the iOS check.

## Validation
Config/syntax verified: compose YAML, `icecast.xml` (XML well-formed), `app.js` (`node --check`), `push-test-tone.sh` (`bash -n`) all parse. The container bring-up itself is run by the operator — the sandbox can't pull images. Docs/tooling only; no app code touched.