### PR TITLE
docs(stream): fix Icecast HEAD-check + tone-ordering guidance

### DIFF
--- a/docs/stream-rework/local-test-harness/README.md
+++ b/docs/stream-rework/local-test-harness/README.md
@@ -30,15 +30,27 @@ In a second terminal, feed audio in:
 Liquidsoap serves **silence** to `/test.mp3` the moment it's up (thanks to `mksafe`),
 then switches to your audio within a few seconds of starting the push.
 
+> **Ordering matters.** Liquidsoap's RTMP puller gives up if the source isn't there
+> when it first connects, then sits on `mksafe` silence. So if `/test.mp3` is **playing
+> but silent**, the tone simply isn't reaching Liquidsoap: start `./push-test-tone.sh`,
+> then re-pull with `docker compose restart liquidsoap`. Verify with
+> `docker compose logs liquidsoap | tail` (want a successful connect to
+> `rtmp://nms:1935/live/stream-io-test`, not repeated failures).
+
 ## Validate (this mirrors the prod gates)
+
+> **Don't use `curl -I`/`-sI` against an Icecast mount** — Icecast answers `HEAD` with
+> `400 Bad Request` (it only serves `GET`/`SOURCE`). A 400 there does **not** mean the
+> mount is down. Use the GET-based checks below.
 
 | Check | How |
 |---|---|
-| NMS got the push | `curl -sI http://localhost:8000/live/stream-io-test.flv` → `200` (and `…/index.m3u8` once HLS warms up) |
-| Icecast serving MP3 | `curl -sI http://localhost:8010/test.mp3` → `200`, `Content-Type: audio/mpeg` |
+| NMS got the push | `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/live/stream-io-test.flv` → `200` |
+| Icecast serving MP3 | `curl -s -o /dev/null -w '%{http_code} %{content_type}\n' --max-time 3 http://localhost:8010/test.mp3` → `200 audio/mpeg` |
+| **Audio is non-silent** | `curl -s --max-time 5 http://localhost:8010/test.mp3 -o /tmp/t.mp3; ffmpeg -hide_banner -i /tmp/t.mp3 -af volumedetect -f null - 2>&1 \| grep mean_volume` — silence ≈ `-91 dB`, a 440 Hz tone ≈ `-20 dB` or louder |
 | Icecast stats | open `http://localhost:8010/admin/stats.xml` (user `admin` / pass `localadmin`) — one source, listener count |
-| Desktop playback | open `http://localhost:8010/test.mp3` in a browser |
-| **iOS gate** | on the iPhone, Safari → `http://<your-laptop-LAN-ip>:8010/test.mp3` — **must play** |
+| Desktop playback | open `http://localhost:8010/test.mp3` in a browser (ignore the player's duration readout — it's a meaningless estimate for a live stream) |
+| **iOS gate** | on the **iPhone's Safari address bar** (not a shell!), enter `http://<your-laptop-LAN-ip>:8010/test.mp3` — **must play** |
 
 Find your LAN IP: `ipconfig getifaddr en0` (macOS Wi-Fi).
 

--- a/docs/stream-rework/phase-2-icecast-runbook.md
+++ b/docs/stream-rework/phase-2-icecast-runbook.md
@@ -122,7 +122,7 @@ Place at `/etc/icecast2/icecast.xml` (apt) or `/usr/local/etc/icecast.xml` (KH s
 </icecast>
 ```
 
-Start it: `sudo systemctl enable --now icecast2` (apt) or run the KH binary under a unit you add. Confirm: `curl -sI http://127.0.0.1:8010/` → Icecast banner.
+Start it: `sudo systemctl enable --now icecast2` (apt) or run the KH binary under a unit you add. Confirm it's up: `curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8010/` → `200` (use GET, not `-I`/HEAD — Icecast returns 400 to HEAD).
 
 ### 1c. Pull RTMP → MP3 → Icecast with ffmpeg (run during a LIVE show so there's audio)
 
@@ -139,11 +139,18 @@ ffmpeg -hide_banner -loglevel warning \
 ## Step 2 — Validate (this is the gate)
 
 ```bash
-# Mount is live and serving MP3:
-curl -sI http://127.0.0.1:8010/test.mp3        # 200, Content-Type: audio/mpeg
+# Mount is live and serving MP3 (GET, not HEAD — Icecast answers HEAD with 400):
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' --max-time 3 http://127.0.0.1:8010/test.mp3
+# → 200 audio/mpeg
+# Confirm the audio is NOT silent (silence ≈ -91 dB; a real broadcast is much louder):
+curl -s --max-time 5 http://127.0.0.1:8010/test.mp3 -o /tmp/t.mp3
+ffmpeg -hide_banner -i /tmp/t.mp3 -af volumedetect -f null - 2>&1 | grep mean_volume
 # From your laptop (open the relay's firewall to your IP for 8010, or SSH-tunnel):
 ssh -L 8010:127.0.0.1:8010 <relay-host>        # then use http://127.0.0.1:8010/test.mp3 locally
 ```
+
+> If `/test.mp3` plays but is **silent**, the source isn't reaching the producer
+> (Liquidsoap's `mksafe` is filling with silence) — not a mount problem. See Step 3.
 
 - **Desktop browser:** `<audio controls src="http://127.0.0.1:8010/test.mp3">` plays.
 - **iPhone Safari (MANDATORY gate):** navigate Safari directly to `http://<relay>:8010/test.mp3` (or an HTML page with the `<audio>` tag served over the SAME http origin). It must play. ⚠️ It will **not** play if embedded in an `https://` page over `http://` audio (mixed-content block) — that's expected; production fixes it with TLS (Step 4). For this gate, test over plain http directly.


### PR DESCRIPTION
Doc fixes surfaced by a full local-harness run (PR #190) — all three confirmed against real behaviour:

- **`curl -I`/`-sI` on an Icecast mount returns `400 Bad Request`** (Icecast only serves GET/SOURCE). The validation steps now use GET-based status checks, plus a `volumedetect` check to distinguish a live mount from one serving `mksafe` silence (tone read -24.6 dB; silence ≈ -91 dB).
- **"Playing but silent" clarified:** Liquidsoap's RTMP puller falls back to `mksafe` silence if the source isn't present at connect → start the tone, then `docker compose restart liquidsoap` (logs then show `Switch to input.ffmpeg with transition`).
- The iOS URL goes in **mobile Safari**, not a shell; and ignore the browser's bogus live-stream duration readout.

Touches `docs/stream-rework/phase-2-icecast-runbook.md` + `local-test-harness/README.md`. Docs-only.

**Context:** the harness is now validated end-to-end — NMS 2.4.9 → Liquidsoap → Icecast `/test.mp3`, MP3 plays on desktop **and a real iPhone**. Phase-2 codec/transport gate cleared.