### PR TITLE
feat(stream): configurable producer push target + Icecast output (#174)

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,3 +1,4 @@
+use serde::de::Error as _; // brings `envy::Error::custom` (serde::de::Error) into scope
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -34,11 +35,27 @@ pub struct Config {
     #[serde(skip)]
     pub r2_endpoint: String,
 
-    // RTMP streaming settings
+    // Live producer output target.
+    // "rtmp" (default) pushes FLV to NodeMediaServer; "icecast" pushes MP3 to an
+    // Icecast mount (the Hetzner stream stack). See `producer_target()`.
+    #[serde(default = "default_stream_output")]
+    pub stream_output: String,
+
+    // RTMP streaming settings (used when stream_output = "rtmp")
     #[serde(default = "default_rtmp_url")]
     pub rtmp_url: String,
     #[serde(default = "default_rtmp_stream_key")]
     pub rtmp_stream_key: String,
+
+    // Icecast streaming settings (used when stream_output = "icecast").
+    // Full source URL incl. credentials + mount, e.g.
+    // `icecast://source:hackme@127.0.0.1:8010/live.mp3`. Required when
+    // stream_output = "icecast" (validated at load).
+    pub icecast_url: Option<String>,
+    #[serde(default = "default_icecast_bitrate")]
+    pub icecast_bitrate: String,
+    #[serde(default = "default_icecast_sample_rate")]
+    pub icecast_sample_rate: u32,
 
     // Optional assets used for ZIP-time image stamping
     // If not set, the code will fall back to local paths under ./data.
@@ -123,12 +140,25 @@ fn default_bucket_name() -> String {
     "unheard-artists-dev".to_string()
 }
 
+fn default_stream_output() -> String {
+    "rtmp".to_string()
+}
+
 fn default_rtmp_url() -> String {
     "rtmp://stream.moafunk.de/live".to_string()
 }
 
 fn default_rtmp_stream_key() -> String {
     "stream-io".to_string()
+}
+
+fn default_icecast_bitrate() -> String {
+    // 128 kbps MP3 — the codec/bitrate validated on iOS in the Phase-2 harness.
+    "128k".to_string()
+}
+
+fn default_icecast_sample_rate() -> u32 {
+    44100
 }
 
 fn default_ffmpeg_bitrate() -> String {
@@ -164,6 +194,12 @@ impl Config {
     pub fn from_env() -> Result<Self, envy::Error> {
         let mut config: Config = envy::from_env()?;
         config.r2_endpoint = format!("https://{}.r2.cloudflarestorage.com", config.r2_account_id);
+
+        // Fail fast on a misconfigured producer rather than silently falling back
+        // to RTMP (which would punch the live stream off the intended mount).
+        validate_stream_output(&config.stream_output, config.icecast_url.as_deref())
+            .map_err(envy::Error::custom)?;
+
         Ok(config)
     }
 
@@ -200,7 +236,72 @@ impl Config {
         format!("{}/{}", self.rtmp_url, self.rtmp_stream_key)
     }
 
+    /// Where the live producer ffmpeg pushes the encoded audio. Validated at load
+    /// (see [`Config::from_env`]), so this is infallible: `icecast` is only
+    /// returned when `icecast_url` is present.
+    pub fn producer_target(&self) -> crate::stream_bridge::PushTarget {
+        use crate::stream_bridge::PushTarget;
+        match self.stream_output.as_str() {
+            "icecast" => PushTarget::Icecast {
+                url: self.icecast_url.clone().unwrap_or_default(),
+                bitrate: self.icecast_bitrate.clone(),
+                sample_rate: self.icecast_sample_rate,
+            },
+            // Default + "rtmp": validated to be the only other accepted value.
+            _ => PushTarget::Rtmp {
+                destination: self.rtmp_destination(),
+            },
+        }
+    }
+
     pub fn telegram_instagram_account(&self) -> &str {
         self.telegram_instagram_account.as_deref().unwrap_or("prod")
+    }
+}
+
+/// Validate the producer output selection. `icecast` requires a non-empty
+/// `ICECAST_URL`; any value other than `rtmp`/`icecast` is rejected. Pure (no
+/// env access) so it's unit-testable without building a full [`Config`].
+fn validate_stream_output(stream_output: &str, icecast_url: Option<&str>) -> Result<(), String> {
+    match stream_output {
+        "rtmp" => Ok(()),
+        "icecast" => {
+            if icecast_url.map(str::trim).unwrap_or("").is_empty() {
+                Err("STREAM_OUTPUT=icecast requires ICECAST_URL (icecast://source:pw@host:port/mount)"
+                    .to_string())
+            } else {
+                Ok(())
+            }
+        }
+        other => Err(format!(
+            "invalid STREAM_OUTPUT '{other}' (expected 'rtmp' or 'icecast')"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtmp_output_is_valid_without_icecast_url() {
+        assert!(validate_stream_output("rtmp", None).is_ok());
+    }
+
+    #[test]
+    fn icecast_output_requires_a_url() {
+        assert!(validate_stream_output("icecast", None).is_err());
+        assert!(validate_stream_output("icecast", Some("   ")).is_err());
+        assert!(validate_stream_output(
+            "icecast",
+            Some("icecast://source:pw@127.0.0.1:8010/live.mp3")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn unknown_output_is_rejected() {
+        assert!(validate_stream_output("srt", Some("x")).is_err());
+        assert!(validate_stream_output("", None).is_err());
     }
 }

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -5408,7 +5408,7 @@ pub async fn api_my_show_go_live(
 
     // Generate a long-lived presigned URL for FFmpeg to read from (4 hours)
     let presigned_url = storage::get_presigned_url(&state, key, 4 * 3600).await?;
-    let rtmp_destination = state.config.rtmp_destination();
+    let push_target = state.config.producer_target();
 
     tracing::info!(
         "Starting prerecorded stream for show_id={}, user='{}', key='{}'",
@@ -5422,7 +5422,7 @@ pub async fn api_my_show_go_live(
         &state.stream_state,
         user.username.clone(),
         &presigned_url,
-        &rtmp_destination,
+        &push_target,
     )
     .await
     .map_err(|e| AppError::Internal(format!("Failed to start prerecorded stream: {}", e)))?;

--- a/backend/src/handlers/stream_ws.rs
+++ b/backend/src/handlers/stream_ws.rs
@@ -160,13 +160,10 @@ async fn handle_stream_socket(
     let (mut sender, mut receiver) = socket.split();
 
     // Start the stream
-    let rtmp_destination = state.config.rtmp_destination();
+    let push_target = state.config.producer_target();
     {
         let mut stream = stream_state.lock().await;
-        if let Err(e) = stream
-            .start_stream(username.clone(), &rtmp_destination)
-            .await
-        {
+        if let Err(e) = stream.start_stream(username.clone(), &push_target).await {
             tracing::error!("Failed to start stream: {}", e);
             let _ = sender
                 .send(Message::Text(format!("error: {}", e).into()))

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -22,6 +22,93 @@ const SEGMENT_SECONDS: u32 = 10;
 /// WebM/Opus fragments ≈ tens of seconds of slack.
 const RECORDING_CHANNEL_CAP: usize = 1024;
 
+/// Where the live producer ffmpeg pushes the encoded audio.
+///
+/// This selects only the **output** leg of the live-stream ffmpeg (encoder +
+/// muxer + destination). The recording tee is a separate ffmpeg
+/// ([`StreamState::start_recording`]) and is unaffected by the push target, so
+/// switching `Rtmp` ↔ `Icecast` never disturbs the archive.
+#[derive(Clone, Debug)]
+pub enum PushTarget {
+    /// RTMP/FLV ingest (NodeMediaServer). `destination` includes the stream key,
+    /// e.g. `rtmp://stream.moafunk.de/live/stream-io`.
+    Rtmp { destination: String },
+    /// Icecast mount (MP3 — the iOS-safe codec validated in the Phase-2 harness).
+    /// `url` is the full source URL incl. credentials + mount, e.g.
+    /// `icecast://source:pw@127.0.0.1:8010/live.mp3`.
+    Icecast {
+        url: String,
+        bitrate: String,
+        sample_rate: u32,
+    },
+}
+
+impl PushTarget {
+    /// FFmpeg output args (encoder + muxer + destination) for this target. The
+    /// caller prepends the input args (`-f webm -i pipe:0`, or `-re -i <url>`).
+    fn output_args(&self) -> Vec<String> {
+        match self {
+            PushTarget::Rtmp { destination } => vec![
+                "-c:a".into(),
+                "aac".into(),
+                "-b:a".into(),
+                "192k".into(),
+                "-ar".into(),
+                "48000".into(),
+                "-ac".into(),
+                "2".into(),
+                "-f".into(),
+                "flv".into(),
+                destination.clone(),
+            ],
+            PushTarget::Icecast {
+                url,
+                bitrate,
+                sample_rate,
+            } => vec![
+                "-c:a".into(),
+                "libmp3lame".into(),
+                "-b:a".into(),
+                bitrate.clone(),
+                "-ar".into(),
+                sample_rate.to_string(),
+                "-ac".into(),
+                "2".into(),
+                // Drop any video track and tag the Icecast content-type as MP3.
+                "-vn".into(),
+                "-content_type".into(),
+                "audio/mpeg".into(),
+                "-f".into(),
+                "mp3".into(),
+                url.clone(),
+            ],
+        }
+    }
+
+    /// Destination string safe to log — the Icecast URL's password is redacted.
+    pub fn redacted(&self) -> String {
+        match self {
+            PushTarget::Rtmp { destination } => destination.clone(),
+            PushTarget::Icecast { url, .. } => redact_icecast_password(url),
+        }
+    }
+}
+
+/// Redact the password in an `icecast://user:pass@host:port/mount` URL for logs.
+/// Returns the input unchanged if it doesn't match that shape.
+fn redact_icecast_password(url: &str) -> String {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    let Some((creds, host)) = rest.split_once('@') else {
+        return url.to_string();
+    };
+    match creds.split_once(':') {
+        Some((user, _pass)) => format!("{scheme}://{user}:***@{host}"),
+        None => url.to_string(),
+    }
+}
+
 /// Current state of the audio stream.
 pub struct StreamState {
     /// Username of the currently streaming user (if any).
@@ -88,15 +175,15 @@ impl StreamState {
         self.recording_failed.as_deref()
     }
 
-    /// Start streaming for the given user to the specified RTMP destination.
+    /// Start streaming for the given user to the specified push target.
     ///
     /// # Arguments
     /// * `user` - Username of the streamer
-    /// * `rtmp_destination` - Full RTMP URL including stream key (e.g., rtmp://host/live/key)
+    /// * `target` - Where to push the encoded audio (RTMP/FLV or Icecast/MP3)
     pub async fn start_stream(
         &mut self,
         user: String,
-        rtmp_destination: &str,
+        target: &PushTarget,
     ) -> Result<(), StreamError> {
         // Clean up any existing stream first
         if self.is_active() {
@@ -106,37 +193,23 @@ impl StreamState {
         tracing::info!(
             "Starting stream for user '{}' to {}",
             user,
-            rtmp_destination
+            target.redacted()
         );
 
         // Spawn FFmpeg process:
         // - Input: WebM/Opus from stdin
-        // - Output: AAC audio to RTMP
-        // - High quality audio settings for smooth playback
+        // - Output: encoder + muxer + destination per the configured push target
         let mut child = Command::new("ffmpeg")
             .args([
                 "-hide_banner",
                 "-loglevel",
                 "warning",
-                // Input from stdin as WebM container
                 "-f",
                 "webm",
                 "-i",
                 "pipe:0",
-                // Audio codec: AAC with good quality
-                "-c:a",
-                "aac",
-                "-b:a",
-                "192k",
-                "-ar",
-                "48000",
-                "-ac",
-                "2",
-                // Output format: FLV for RTMP
-                "-f",
-                "flv",
-                rtmp_destination,
             ])
+            .args(target.output_args())
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -408,7 +481,8 @@ pub fn new_shared_state() -> SharedStreamState {
     std::sync::Arc::new(Mutex::new(StreamState::new()))
 }
 
-/// Start a prerecorded stream: FFmpeg reads from a URL and outputs to RTMP.
+/// Start a prerecorded stream: FFmpeg reads from a URL and outputs to the
+/// configured push target.
 ///
 /// Unlike live streaming (where audio chunks are piped via stdin), this spawns
 /// FFmpeg with `-re` (real-time playback) reading directly from the presigned
@@ -417,7 +491,7 @@ pub async fn start_prerecorded_stream(
     stream_state: &SharedStreamState,
     user: String,
     input_url: &str,
-    rtmp_destination: &str,
+    target: &PushTarget,
 ) -> Result<(), StreamError> {
     {
         let mut state = stream_state.lock().await;
@@ -430,7 +504,7 @@ pub async fn start_prerecorded_stream(
         tracing::info!(
             "Starting prerecorded stream for user '{}' to {}",
             user,
-            rtmp_destination
+            target.redacted()
         );
 
         // Spawn FFmpeg with file/URL input:
@@ -443,18 +517,8 @@ pub async fn start_prerecorded_stream(
                 "-re",
                 "-i",
                 input_url,
-                "-c:a",
-                "aac",
-                "-b:a",
-                "192k",
-                "-ar",
-                "48000",
-                "-ac",
-                "2",
-                "-f",
-                "flv",
-                rtmp_destination,
             ])
+            .args(target.output_args())
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -667,6 +731,78 @@ mod tests {
         assert_eq!(
             list,
             "file '/r/seg_00000.ts'\nfile '/r/seg_00001.ts'\nfile '/r/seg_00002.ts'\n"
+        );
+    }
+
+    #[test]
+    fn rtmp_target_emits_flv_output_args() {
+        let t = PushTarget::Rtmp {
+            destination: "rtmp://host/live/key".to_string(),
+        };
+        let args = t.output_args();
+        // Ends with the FLV muxer + destination.
+        assert_eq!(
+            &args[args.len() - 3..],
+            &[
+                "-f".to_string(),
+                "flv".to_string(),
+                "rtmp://host/live/key".to_string()
+            ]
+        );
+        assert!(args.iter().any(|a| a == "aac"));
+    }
+
+    #[test]
+    fn icecast_target_emits_mp3_output_args() {
+        let t = PushTarget::Icecast {
+            url: "icecast://source:pw@127.0.0.1:8010/live.mp3".to_string(),
+            bitrate: "128k".to_string(),
+            sample_rate: 44100,
+        };
+        let args = t.output_args();
+        assert!(args.iter().any(|a| a == "libmp3lame"));
+        assert!(args.windows(2).any(|w| w == ["-b:a", "128k"]));
+        assert!(args.windows(2).any(|w| w == ["-ar", "44100"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-content_type", "audio/mpeg"]));
+        // MP3 muxer + Icecast URL last.
+        assert_eq!(
+            &args[args.len() - 3..],
+            &[
+                "-f".to_string(),
+                "mp3".to_string(),
+                "icecast://source:pw@127.0.0.1:8010/live.mp3".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn icecast_password_is_redacted_for_logs() {
+        let t = PushTarget::Icecast {
+            url: "icecast://source:s3cret@127.0.0.1:8010/live.mp3".to_string(),
+            bitrate: "128k".to_string(),
+            sample_rate: 44100,
+        };
+        let r = t.redacted();
+        assert_eq!(r, "icecast://source:***@127.0.0.1:8010/live.mp3");
+        assert!(!r.contains("s3cret"));
+        // RTMP has no secret to redact.
+        assert_eq!(
+            PushTarget::Rtmp {
+                destination: "rtmp://host/live/key".to_string()
+            }
+            .redacted(),
+            "rtmp://host/live/key"
+        );
+    }
+
+    #[test]
+    fn redact_passthrough_on_non_icecast_shapes() {
+        assert_eq!(redact_icecast_password("not a url"), "not a url");
+        assert_eq!(
+            redact_icecast_password("icecast://host:8010/m"),
+            "icecast://host:8010/m"
         );
     }
 

--- a/docs/stream-rework/local-test-harness/README.md
+++ b/docs/stream-rework/local-test-harness/README.md
@@ -61,6 +61,26 @@ Find your LAN IP: `ipconfig getifaddr en0` (macOS Wi-Fi).
 If the iPhone plays `/test.mp3`, the **codec + transport decision is validated** — MP3
 over Icecast reaches iOS, exactly as the migration needs.
 
+## Greenfield (no-NMS) rehearsal — the #194 target chain
+
+The default harness above mirrors the *parallel-run* (NMS still in the loop). To rehearse
+the **end state** from issue #194 — where NodeMediaServer and RTMP are gone and the backend
+pushes straight into Liquidsoap (decision **B**) — use the no-NMS compose file:
+
+```bash
+cd docs/stream-rework/local-test-harness
+docker compose -f docker-compose.no-nms.yml up --build
+```
+
+Chain: `producer (ffmpeg) ──icecast SOURCE──▶ Liquidsoap harbor ─▶ Icecast /live.mp3`.
+The `producer` service runs the **exact** ffmpeg output args the Rust backend emits for
+`PushTarget::Icecast` (`backend/src/stream_bridge.rs`), so a green run validates the real
+backend→Liquidsoap→Icecast leg — no NMS, no RTMP. Validate with the same gates as above,
+but against **`/live.mp3`** (e.g. `http://localhost:8010/live.mp3`, and the iPhone-on-LAN
+Safari check). `mksafe` still fills silence until the producer connects.
+
+Tear down with `docker compose -f docker-compose.no-nms.yml down -v`.
+
 ## Tear down
 
 ```bash

--- a/docs/stream-rework/local-test-harness/docker-compose.no-nms.yml
+++ b/docs/stream-rework/local-test-harness/docker-compose.no-nms.yml
@@ -1,0 +1,64 @@
+# Greenfield (no-NMS) rehearsal of the #194 target chain — decision (B):
+#
+#   producer (ffmpeg) ──icecast SOURCE──▶ Liquidsoap harbor ─▶ Icecast /live.mp3
+#
+# There is NO NodeMediaServer and NO RTMP here — this is the architecture that
+# replaces them. The `producer` runs the EXACT ffmpeg output args the Rust
+# backend emits for `PushTarget::Icecast` (see backend/src/stream_bridge.rs),
+# only swapping the WebM-on-stdin input for a synthetic test tone. So a green run
+# proves the backend→Liquidsoap→Icecast leg end-to-end, codec and all.
+#
+#   docker compose -f docker-compose.no-nms.yml up --build
+#   open http://localhost:8010/live.mp3        # desktop; iPhone uses http://<LAN-ip>:8010/live.mp3
+#
+# Nothing here touches prod, the relay box, or R2.
+name: moafunk-stream-test-no-nms
+
+services:
+  # Icecast — serves the public /live.mp3 mount (host 8010 → container 8000).
+  icecast:
+    build: ./icecast
+    ports:
+      - "8010:8000"
+    restart: unless-stopped
+
+  # Liquidsoap — harbor input (receives the producer push) → mksafe → Icecast.
+  liquidsoap:
+    image: savonet/liquidsoap:v2.2.5
+    depends_on: [icecast]
+    volumes:
+      - ./liquidsoap/moafunk-harbor.liq:/moafunk.liq:ro
+    command: ["liquidsoap", "/moafunk.liq"]
+    restart: unless-stopped
+
+  # Producer — stands in for the backend. Pushes a 440 Hz tone to the Liquidsoap
+  # harbor using the SAME ffmpeg output chain as PushTarget::Icecast::output_args:
+  #   -c:a libmp3lame -b:a 128k -ar 44100 -ac 2 -vn -content_type audio/mpeg -f mp3 icecast://…
+  # restart keeps it retrying until the harbor is listening (no ordering dance).
+  producer:
+    image: jrottenberg/ffmpeg:6.1-alpine
+    depends_on: [liquidsoap]
+    command:
+      - "-hide_banner"
+      - "-loglevel"
+      - "warning"
+      - "-re"
+      - "-f"
+      - "lavfi"
+      - "-i"
+      - "sine=frequency=440:sample_rate=48000"
+      - "-c:a"
+      - "libmp3lame"
+      - "-b:a"
+      - "128k"
+      - "-ar"
+      - "44100"
+      - "-ac"
+      - "2"
+      - "-vn"
+      - "-content_type"
+      - "audio/mpeg"
+      - "-f"
+      - "mp3"
+      - "icecast://source:harborpw@liquidsoap:8005/live"
+    restart: unless-stopped

--- a/docs/stream-rework/local-test-harness/liquidsoap/moafunk-harbor.liq
+++ b/docs/stream-rework/local-test-harness/liquidsoap/moafunk-harbor.liq
@@ -1,0 +1,31 @@
+# Greenfield (no-NMS) rehearsal — issue #194 decision (B).
+#
+# The backend ffmpeg pushes MP3 straight into Liquidsoap's HARBOR (which speaks
+# the Icecast SOURCE protocol); Liquidsoap re-emits to Icecast. This is the path
+# that REPLACES NodeMediaServer: there is no RTMP and no NMS anywhere in the chain.
+#
+#   backend ffmpeg ──icecast://…@liquidsoap:8005/live──▶ input.harbor ─▶ mksafe ─▶ Icecast /live.mp3
+#
+# Compare with moafunk.liq (the NMS parallel-run rehearsal), which instead PULLS
+# RTMP from NodeMediaServer via input.ffmpeg.
+
+# Harbor input: receive the producer's source push on port 8005, mount "live".
+# Same wire protocol as an Icecast source, so the backend's existing
+# `-f mp3 icecast://source:pw@host:port/mount` output targets it unchanged.
+src = input.harbor("live", port=8005, password="harborpw")
+
+# Never let the public mount 404 if the producer drops — fall back to silence.
+radio = mksafe(src)
+
+# Output: MP3 to Icecast /live.mp3 (iOS-safe codec; NEVER Opus/Ogg for the public mount).
+output.icecast(
+  %mp3(bitrate=128, samplerate=44100, stereo=true),
+  host="icecast",
+  port=8000,
+  password="localsource",
+  mount="/live.mp3",
+  name="Moafunk (no-NMS rehearsal)",
+  description="Greenfield backend->harbor->Icecast chain (#194 decision B)",
+  genre="radio",
+  radio
+)


### PR DESCRIPTION
## What
- Teach the live producer to push to **RTMP/FLV** (NodeMediaServer, default) **or an Icecast MP3 mount**, selected purely by config.
- `config.rs`: `STREAM_OUTPUT` (`rtmp`|`icecast`) + `ICECAST_URL`/`ICECAST_BITRATE`/`ICECAST_SAMPLE_RATE`, validated at load (no silent fallback); new `Config::producer_target()`.
- `stream_bridge.rs`: `PushTarget` enum owning the ffmpeg output args (FLV/AAC vs MP3/libmp3lame + Icecast content-type) and a password-redacting log helper; `start_stream` / `start_prerecorded_stream` now take `&PushTarget`.
- Harness: `docker-compose.no-nms.yml` + `moafunk-harbor.liq` rehearse the greenfield `backend → Liquidsoap harbor → Icecast` chain (no NMS, no RTMP).

## Why
Issue **#174** (Phase 2 of #164), and the lever the Hetzner consolidation (**#194**) needs to retire NodeMediaServer and push backend → Liquidsoap over localhost. Decision **B** (Liquidsoap harbor) from #194.

## How
The recording tee is a *separate* ffmpeg process (`start_recording`), so switching the push target never restarts the recorder — #174's "go-live switch must not gap the archive" holds by construction. The Icecast output uses `-c:a libmp3lame … -vn -content_type audio/mpeg -f mp3` (MP3 is the iOS-safe codec validated in the Phase-2 harness; never Opus/Ogg for the public mount).

## Test plan
- [x] `cargo build`, `cargo clippy` (only pre-existing `video.rs` warnings)
- [x] Unit tests: `PushTarget` output args + URL redaction; `STREAM_OUTPUT` validation
- [x] MP3 encoder chain produces decodable 128k/44.1k/stereo (local ffmpeg + ffprobe)
- [x] **Full no-NMS chain validated live** (`docker-compose.no-nms.yml`): producer (exact `PushTarget::Icecast` args) → Liquidsoap harbor → Icecast `/live.mp3` → HTTP 200 `audio/mpeg`, mp3/44100/stereo, mean_volume −25 dB (audible, not silence)
- [ ] iPhone-on-LAN Safari plays `/live.mp3` (manual physical gate)

## Risk
**Low.** Default behaviour is unchanged: `STREAM_OUTPUT` defaults to `rtmp` and `producer_target()` returns the existing `rtmp_destination()`. Icecast is opt-in via config. Rollback = revert; runtime rollback = set `STREAM_OUTPUT=rtmp`.
