### PR TITLE
feat(stream): broadcaster preview player for the Icecast /test mount (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,26 @@ Live streaming web radio from Moabit, Berlin.
 ### Installation
 
 1. Clone the repository:
+
 ```sh
 git clone https://github.com/yourusername/live.moafunk.de.git
 cd live.moafunk.de
 ```
 
 2. Switch into the frontend directory:
+
 ```sh
 cd frontend
 ```
 
 3. Install Node.js dependencies:
+
 ```sh
 npm install
 ```
 
 4. Copy environment variables template:
+
 ```sh
 cp .env.example .env
 ```
@@ -54,6 +58,7 @@ cp .env.example .env
 ### Running Locally
 
 1. Generate tracks data from SoundCloud:
+
 ```sh
 cd frontend
 uv run scripts/generate_relisten.py \
@@ -62,6 +67,7 @@ uv run scripts/generate_relisten.py \
 ```
 
 2. Start development server:
+
 ```sh
 cd frontend
 npm run dev
@@ -94,20 +100,21 @@ The output will be in `frontend/dist/`.
 
 Create a `.env` file with the following variables:
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VITE_STREAM_HLS_URL` | HLS stream URL (for iOS devices) | `https://stream.moafunk.de/live/stream-io/index.m3u8` |
-| `VITE_STREAM_FLV_URL` | FLV stream URL (for desktop) | `https://stream.moafunk.de/live/stream-io.flv` |
-| `VITE_ANALYTICS_DOMAIN` | Plausible analytics domain | `live.moafunk.de` |
-| `VITE_ANALYTICS_SCRIPT_URL` | Plausible script URL | `https://plausible.moafunk.de/js/plausible.js` |
+| Variable                       | Description                                                                              | Default                                               |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `VITE_STREAM_HLS_URL`          | HLS stream URL (for iOS devices)                                                         | `https://stream.moafunk.de/live/stream-io/index.m3u8` |
+| `VITE_STREAM_FLV_URL`          | FLV stream URL (for desktop)                                                             | `https://stream.moafunk.de/live/stream-io.flv`        |
+| `VITE_STREAM_ICECAST_TEST_URL` | Icecast `/test` mount for the broadcaster preview player (#175); empty hides the preview | _(empty)_                                             |
+| `VITE_ANALYTICS_DOMAIN`        | Plausible analytics domain                                                               | `live.moafunk.de`                                     |
+| `VITE_ANALYTICS_SCRIPT_URL`    | Plausible script URL                                                                     | `https://plausible.moafunk.de/js/plausible.js`        |
 
 ### Required for SoundCloud API (CI/CD)
 
 These must be set as GitHub Secrets:
 
-| Secret | Description | How to Get |
-|--------|-------------|------------|
-| `SOUNDCLOUD_CLIENT_ID` | SoundCloud OAuth Client ID | [SoundCloud Apps](https://soundcloud.com/you/apps) |
+| Secret                     | Description                    | How to Get                                         |
+| -------------------------- | ------------------------------ | -------------------------------------------------- |
+| `SOUNDCLOUD_CLIENT_ID`     | SoundCloud OAuth Client ID     | [SoundCloud Apps](https://soundcloud.com/you/apps) |
 | `SOUNDCLOUD_CLIENT_SECRET` | SoundCloud OAuth Client Secret | [SoundCloud Apps](https://soundcloud.com/you/apps) |
 
 ## Project Structure
@@ -142,17 +149,17 @@ These must be set as GitHub Secrets:
 
 ## Available Commands
 
-| Command | Description |
-|---------|-------------|
-| `npm run dev` | Start Vite development server |
-| `npm run build` | Build for production |
-| `npm run preview` | Preview production build locally |
-| `npm test` | Run Vitest tests |
-| `npm run test:ui` | Run tests with UI |
-| `npm run lint` | Lint code with ESLint |
-| `npm run lint:fix` | Fix linting issues automatically |
-| `npm run format` | Format code with Prettier |
-| `npm run typecheck` | Type-check TypeScript files |
+| Command                 | Description                              |
+| ----------------------- | ---------------------------------------- |
+| `npm run dev`           | Start Vite development server            |
+| `npm run build`         | Build for production                     |
+| `npm run preview`       | Preview production build locally         |
+| `npm test`              | Run Vitest tests                         |
+| `npm run test:ui`       | Run tests with UI                        |
+| `npm run lint`          | Lint code with ESLint                    |
+| `npm run lint:fix`      | Fix linting issues automatically         |
+| `npm run format`        | Format code with Prettier                |
+| `npm run typecheck`     | Type-check TypeScript files              |
 | `npm run generate:html` | Generate re-listen.html from tracks.json |
 
 ## CI/CD Pipeline
@@ -162,12 +169,13 @@ The project uses GitHub Actions for automated builds and deployment.
 ### Frontend (GitHub Pages)
 
 On push to `main`:
-   - Fetch SoundCloud tracks → `public/data/tracks.json`
-   - Generate `re-listen.html` from JSON
-   - Install Node.js dependencies
-   - Run linting and tests
-   - Build with Vite
-   - Deploy to GitHub Pages
+
+- Fetch SoundCloud tracks → `public/data/tracks.json`
+- Generate `re-listen.html` from JSON
+- Install Node.js dependencies
+- Run linting and tests
+- Build with Vite
+- Deploy to GitHub Pages
 
 See [.github/workflows/deploy.yml](.github/workflows/deploy.yml) for details.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,6 +3,9 @@
 # Stream URLs
 VITE_STREAM_HLS_URL=https://stream.moafunk.de/live/stream-io/index.m3u8
 VITE_STREAM_FLV_URL=https://stream.moafunk.de/live/stream-io.flv
+# Icecast /test mount for the broadcaster preview player (#175). Leave empty
+# until the Phase-2 Icecast stack is live (then e.g. https://radio.live.moafunk.de/test.mp3).
+VITE_STREAM_ICECAST_TEST_URL=
 
 # Analytics Configuration
 VITE_ANALYTICS_DOMAIN=live.moafunk.de

--- a/frontend/src/admin/components/StreamPreviewPlayer.vue
+++ b/frontend/src/admin/components/StreamPreviewPlayer.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+// Broadcaster self-monitoring preview (#175). Plays the Icecast `/test` mount so
+// the host can confirm their audio is actually reaching the relay before/while
+// going live. Plain <audio controls> — playback is opt-in (no autoplay) so it
+// never starts feedback on its own.
+defineProps<{
+  /** The Icecast `/test` mount URL (MP3). Component is only mounted when set. */
+  src: string;
+}>();
+</script>
+
+<template>
+  <section class="preview-player">
+    <div class="preview-header">
+      <span class="preview-icon">🎧</span>
+      <span class="preview-title">Listen to your stream</span>
+    </div>
+    <audio class="preview-audio" controls preload="none" :src="src">
+      Your browser can’t play this stream.
+    </audio>
+    <p class="preview-hint">
+      Use <strong>headphones</strong> — this is the relay feed and runs a few seconds behind live,
+      so playing it on speakers will echo. It confirms your audio is reaching the server.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.preview-player {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.preview-icon {
+  font-size: 1.2rem;
+}
+
+.preview-title {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+
+.preview-audio {
+  width: 100%;
+}
+
+.preview-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin: var(--spacing-sm) 0 0;
+}
+</style>

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -4,11 +4,17 @@ import { useRouter } from 'vue-router';
 import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
 import { streamApi, recordingApi, hostFlowApi } from '@admin/api';
 import DbMeter from '@admin/components/DbMeter.vue';
+import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
+import { config } from '@/config';
 
 const router = useRouter();
 const flow = useHostFlow();
 const show = computed(() => flow.show.value);
 const isLiveMode = computed(() => flow.uploadMode.value === 'live');
+
+// Broadcaster preview (#175): only shown for a live broadcast and only when an
+// Icecast /test mount is configured (empty until the Phase-2 stack is live).
+const previewUrl = config.stream.icecastTestUrl;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Phase: waiting (before stream starts) vs streaming (after go-live)
@@ -528,6 +534,10 @@ onUnmounted(() => {
         <div v-if="audioCapture" class="audio-level-section">
           <DbMeter :media-stream="audioCapture.mediaStream.value" label="Audio Level" />
         </div>
+
+        <!-- Broadcaster preview: hear the relay feed (#175). Hidden unless a
+             /test mount is configured. -->
+        <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
 
         <div class="stop-section">
           <button class="btn-stop" :disabled="stopping" @click="handleStop">

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -6,6 +6,9 @@ export const config = {
     hls:
       import.meta.env.VITE_STREAM_HLS_URL || 'https://stream.moafunk.de/live/stream-io/index.m3u8',
     flv: import.meta.env.VITE_STREAM_FLV_URL || 'https://stream.moafunk.de/live/stream-io.flv',
+    // Icecast `/test` mount for the broadcaster preview player (#175). Empty by
+    // default → the preview stays hidden until the Phase-2 Icecast stack is live.
+    icecastTestUrl: import.meta.env.VITE_STREAM_ICECAST_TEST_URL || '',
   },
   analytics: {
     domain: import.meta.env.VITE_ANALYTICS_DOMAIN || 'live.moafunk.de',


### PR DESCRIPTION
## What
- Add a **broadcaster preview player** so a live host can hear the relay feed and confirm their audio is reaching the server before/while going live.
- `StreamPreviewPlayer.vue`: plain `<audio controls preload="none">` (opt-in, no autoplay → can't start feedback) + a headphones/latency hint.
- Rendered in `FlowOnAir`'s live streaming phase, gated on a configured mount.
- `VITE_STREAM_ICECAST_TEST_URL` → `config.stream.icecastTestUrl` (empty by default → preview hidden until the Phase-2 Icecast stack is live). Documented in README + `.env.example`.

## Why
Issue **#175** (Phase 2 of #164, req #2 "test before go-live") and a step toward the Hetzner migration (#194). Points at the `/test` Icecast mount that #173/#174 stand up.

## How
Self-contained component takes the mount URL as a prop; `FlowOnAir` only mounts it when `config.stream.icecastTestUrl` is non-empty, so there's zero visible change until the Icecast `/test` mount exists. No autoplay keeps it from echoing through speakers.

## Test plan
- [x] `npm run build` (Vite) — `FlowOnAir` chunk compiles with the new component
- [x] `npm run lint` clean
- [ ] With `VITE_STREAM_ICECAST_TEST_URL` set to a live `/test.mp3`, go live (live mode) → preview appears, plays the relay feed on the broadcaster's device
- [ ] Empty/unset → preview is hidden (default)

## Risk
**Low.** Hidden by default (empty env var); no change to the existing flow until configured. Pure additive frontend.

> Note: repo-wide `vue-tsc` typecheck fails **pre-existing** on a clean tree (no `*.vue` type shim + stale `node_modules`); unaffected by this PR. Worth a separate fix.
