### PR TITLE
feat(stream): Icecast listener/quality telemetry + /api/stream/metrics + admin display (#177)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,6 +35,22 @@ MAX_UPLOAD_SIZE_MB=250
 # Logging
 RUST_LOG=info,tower_http=debug
 
+# Live stream producer (where the broadcaster's audio is pushed)
+# STREAM_OUTPUT: "rtmp" (default, → NodeMediaServer) or "icecast"
+# STREAM_OUTPUT=rtmp
+# RTMP_URL=rtmp://stream.moafunk.de/live
+# RTMP_STREAM_KEY=stream-io
+# When STREAM_OUTPUT=icecast, ICECAST_URL is required (source URL incl. creds + mount):
+# ICECAST_URL=icecast://source:hackme@127.0.0.1:8010/live.mp3
+# ICECAST_BITRATE=128k
+# ICECAST_SAMPLE_RATE=44100
+
+# Icecast listener/quality telemetry poller (#177)
+# ICECAST_STATUS_URL: status-json.xsl endpoint. If unset, derived from ICECAST_URL
+# (host:port → http://host:port/status-json.xsl); poller stays off if neither is set.
+# ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl
+# ICECAST_METRICS_POLL_SECS=15
+
 # Optional: show ZIP artist image stamping
 # If set, the artist picture inside each ZIP will be stamped with the artist name and logo.
 ARTIST_LOGO_DIR=./assets/artist_logos

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -56,6 +56,13 @@ pub struct Config {
     pub icecast_bitrate: String,
     #[serde(default = "default_icecast_sample_rate")]
     pub icecast_sample_rate: u32,
+    // Icecast status endpoint for the listener/quality poller (#177), e.g.
+    // `http://127.0.0.1:8010/status-json.xsl`. If unset, it's derived from
+    // `icecast_url` (host:port → http://host:port/status-json.xsl); if neither
+    // is set, the poller stays disabled.
+    pub icecast_status_url: Option<String>,
+    #[serde(default = "default_icecast_metrics_poll_secs")]
+    pub icecast_metrics_poll_secs: u64,
 
     // Optional assets used for ZIP-time image stamping
     // If not set, the code will fall back to local paths under ./data.
@@ -161,6 +168,11 @@ fn default_icecast_sample_rate() -> u32 {
     44100
 }
 
+fn default_icecast_metrics_poll_secs() -> u64 {
+    // ~10-15s keeps the admin listener count near-live without hammering Icecast.
+    15
+}
+
 fn default_ffmpeg_bitrate() -> String {
     "320k".to_string()
 }
@@ -257,6 +269,36 @@ impl Config {
     pub fn telegram_instagram_account(&self) -> &str {
         self.telegram_instagram_account.as_deref().unwrap_or("prod")
     }
+
+    /// Icecast `/status-json.xsl` URL for the metrics poller (#177): the explicit
+    /// `icecast_status_url` if set, otherwise derived from `icecast_url`. `None`
+    /// disables the poller.
+    pub fn icecast_status_url(&self) -> Option<String> {
+        if let Some(u) = self.icecast_status_url.as_deref() {
+            let t = u.trim();
+            if !t.is_empty() {
+                return Some(t.to_string());
+            }
+        }
+        self.icecast_url.as_deref().and_then(derive_status_url)
+    }
+}
+
+/// Derive `http://host:port/status-json.xsl` from a source URL like
+/// `icecast://user:pass@host:port/mount`. Returns `None` if the host:port can't
+/// be isolated.
+fn derive_status_url(icecast_url: &str) -> Option<String> {
+    let after_scheme = icecast_url.split_once("://").map(|(_, r)| r)?;
+    // Drop optional `user:pass@` credentials.
+    let after_creds = after_scheme
+        .rsplit_once('@')
+        .map(|(_, r)| r)
+        .unwrap_or(after_scheme);
+    let host_port = after_creds.split('/').next()?;
+    if host_port.is_empty() {
+        return None;
+    }
+    Some(format!("http://{host_port}/status-json.xsl"))
 }
 
 /// Validate the producer output selection. `icecast` requires a non-empty
@@ -303,5 +345,24 @@ mod tests {
     fn unknown_output_is_rejected() {
         assert!(validate_stream_output("srt", Some("x")).is_err());
         assert!(validate_stream_output("", None).is_err());
+    }
+
+    #[test]
+    fn status_url_derived_from_source_url() {
+        assert_eq!(
+            derive_status_url("icecast://source:pw@127.0.0.1:8010/live.mp3").as_deref(),
+            Some("http://127.0.0.1:8010/status-json.xsl")
+        );
+        // No credentials in the URL.
+        assert_eq!(
+            derive_status_url("icecast://radio.example.com:8000/test.mp3").as_deref(),
+            Some("http://radio.example.com:8000/status-json.xsl")
+        );
+    }
+
+    #[test]
+    fn status_url_derivation_rejects_malformed() {
+        assert_eq!(derive_status_url("no-scheme"), None);
+        assert_eq!(derive_status_url("icecast://"), None);
     }
 }

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -1699,6 +1699,7 @@ mod tests {
             config: config.clone(),
             s3_client: s3_client.clone(),
             stream_state: crate::stream_bridge::new_shared_state(),
+            stream_metrics: crate::stream_metrics::new_shared(),
             recording_manager: crate::recording::new_shared_manager(temp_dir.clone()),
             recording_finalizer: Arc::new(tokio::sync::Mutex::new(None)),
             cover_debounce: Arc::new(tokio::sync::RwLock::new(HashMap::new())),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,6 +14,7 @@ mod scheduler;
 mod soundcloud;
 mod storage;
 mod stream_bridge;
+mod stream_metrics;
 mod telegram;
 mod telegram_notify;
 mod video;
@@ -58,6 +59,9 @@ pub struct AppState {
     pub config: Config,
     pub s3_client: aws_sdk_s3::Client,
     pub stream_state: SharedStreamState,
+    /// Cached Icecast listener/quality telemetry, refreshed by the metrics
+    /// poller (`stream_metrics`) and served at `GET /api/stream/metrics`.
+    pub stream_metrics: stream_metrics::SharedStreamMetrics,
     /// Recording session manager for show recordings
     pub recording_manager: SharedRecordingManager,
     /// Handle to a pending grace-period finalize task (set when a live stream
@@ -95,6 +99,13 @@ async fn stream_ws_handler(
 
 async fn stream_status_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     handlers::stream_ws::stream_status(State(state.stream_state.clone())).await
+}
+
+/// Latest cached Icecast listener/quality telemetry (#177). Read-only snapshot;
+/// the poller refreshes the cache in the background.
+async fn stream_metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let metrics = state.stream_metrics.read().await.clone();
+    axum::Json(metrics)
 }
 
 async fn stream_stop_handler(
@@ -243,6 +254,7 @@ async fn main() -> anyhow::Result<()> {
         config: config.clone(),
         s3_client,
         stream_state,
+        stream_metrics: stream_metrics::new_shared(),
         recording_manager,
         recording_finalizer: Arc::new(tokio::sync::Mutex::new(None)),
         cover_debounce,
@@ -618,6 +630,7 @@ async fn main() -> anyhow::Result<()> {
             get(handlers::stream_test_ws::stream_test_ws_handler),
         )
         .route("/api/stream/status", get(stream_status_handler))
+        .route("/api/stream/metrics", get(stream_metrics_handler))
         .route("/api/stream/stop", post(stream_stop_handler))
         // Recording API for show recording with timecoded track markers
         .route("/api/recording/start", post(recording_start_handler))
@@ -709,6 +722,10 @@ async fn main() -> anyhow::Result<()> {
             }
         });
     }
+
+    // Spawn the Icecast listener/quality telemetry poller (#177). No-op if no
+    // status URL is configured (or derivable from icecast_url).
+    stream_metrics::spawn_poller(state.clone());
 
     let addr = format!("{}:{}", config.host, config.port);
     tracing::info!("Starting server on {}", addr);

--- a/backend/src/stream_metrics.rs
+++ b/backend/src/stream_metrics.rs
@@ -1,0 +1,276 @@
+//! Icecast listener/quality telemetry (#177).
+//!
+//! Polls Icecast `GET /status-json.xsl` on an interval, normalizes the per-mount
+//! stats (handling the documented `icestats.source` object-vs-array quirk), and
+//! caches the latest snapshot in [`crate::AppState`] for `GET /api/stream/metrics`
+//! and the admin SPA. Icecast's persistent connections give a *genuine*
+//! concurrent listener count — something HLS structurally can't.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+use crate::AppState;
+
+/// Per-request timeout — the poller must never hang on a wedged Icecast.
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+
+/// Latest snapshot served from cache. Always present (starts as "never polled":
+/// `online=false`, no `polled_at_ms`, no `error`).
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct StreamMetrics {
+    /// True if the last poll succeeded AND at least one source is connected.
+    pub online: bool,
+    /// Total listeners across all mounts.
+    pub total_listeners: u64,
+    /// Per-mount detail.
+    pub mounts: Vec<MountMetrics>,
+    /// Unix-ms timestamp of the last successful poll, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub polled_at_ms: Option<i64>,
+    /// Set when the last poll failed (network/parse); mounts are then empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Quality + listener stats for a single Icecast mount.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct MountMetrics {
+    /// Mount path, e.g. `/live.mp3` (derived from the source `listenurl`).
+    pub mount: String,
+    pub listeners: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listener_peak: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitrate: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub samplerate: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channels: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<String>,
+}
+
+pub type SharedStreamMetrics = Arc<RwLock<StreamMetrics>>;
+
+pub fn new_shared() -> SharedStreamMetrics {
+    Arc::new(RwLock::new(StreamMetrics::default()))
+}
+
+// ── Raw `/status-json.xsl` shape ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct StatusJson {
+    icestats: IceStats,
+}
+
+#[derive(Deserialize)]
+struct IceStats {
+    #[serde(default)]
+    source: Option<SourceField>,
+}
+
+/// Icecast serializes `source` as a single object when exactly one mount is
+/// connected, and as an array when several are. Untagged so either parses; an
+/// array can't deserialize into the (map-shaped) struct and vice-versa, so the
+/// two variants are disjoint regardless of order.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SourceField {
+    One(Box<RawSource>),
+    Many(Vec<RawSource>),
+}
+
+#[derive(Deserialize)]
+struct RawSource {
+    #[serde(default)]
+    listeners: Option<u64>,
+    #[serde(default)]
+    listener_peak: Option<u64>,
+    #[serde(default)]
+    bitrate: Option<u64>,
+    #[serde(default)]
+    samplerate: Option<u64>,
+    #[serde(default)]
+    channels: Option<u64>,
+    #[serde(default)]
+    server_name: Option<String>,
+    #[serde(default)]
+    listenurl: Option<String>,
+}
+
+/// Extract the mount path from a `listenurl` like `http://host:8000/live.mp3`.
+fn mount_from_listenurl(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    after_scheme
+        .find('/')
+        .map(|i| after_scheme[i..].to_string())
+}
+
+/// Parse a `/status-json.xsl` body into a normalized snapshot. `polled_at_ms`
+/// is left `None` here and stamped by the caller on success.
+fn parse_status(body: &str) -> Result<StreamMetrics, String> {
+    let parsed: StatusJson =
+        serde_json::from_str(body).map_err(|e| format!("parse status-json: {e}"))?;
+
+    let raw_sources = match parsed.icestats.source {
+        Some(SourceField::One(s)) => vec![*s],
+        Some(SourceField::Many(v)) => v,
+        None => vec![],
+    };
+
+    let mounts: Vec<MountMetrics> = raw_sources
+        .into_iter()
+        .map(|s| MountMetrics {
+            mount: s
+                .listenurl
+                .as_deref()
+                .and_then(mount_from_listenurl)
+                .unwrap_or_default(),
+            listeners: s.listeners.unwrap_or(0),
+            listener_peak: s.listener_peak,
+            bitrate: s.bitrate,
+            samplerate: s.samplerate,
+            channels: s.channels,
+            server_name: s.server_name,
+        })
+        .collect();
+
+    let total_listeners = mounts.iter().map(|m| m.listeners).sum();
+
+    Ok(StreamMetrics {
+        online: !mounts.is_empty(),
+        total_listeners,
+        mounts,
+        polled_at_ms: None,
+        error: None,
+    })
+}
+
+async fn fetch(client: &reqwest::Client, url: &str) -> Result<StreamMetrics, String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("status {}", resp.status()));
+    }
+    let body = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+    parse_status(&body)
+}
+
+/// One poll cycle: fetch + parse, stamping the timestamp on success. Never
+/// panics — a failure becomes an `online=false` snapshot carrying the error.
+async fn poll_once(client: &reqwest::Client, url: &str) -> StreamMetrics {
+    match fetch(client, url).await {
+        Ok(mut m) => {
+            m.polled_at_ms = Some(chrono::Utc::now().timestamp_millis());
+            m
+        }
+        Err(e) => {
+            tracing::warn!("Icecast metrics poll failed: {e}");
+            StreamMetrics {
+                online: false,
+                error: Some(e),
+                ..Default::default()
+            }
+        }
+    }
+}
+
+/// Spawn the background poller. No-op (logged) when no status URL is configured,
+/// so it's safe to call unconditionally at startup before Icecast exists.
+pub fn spawn_poller(state: Arc<AppState>) {
+    let Some(url) = state.config.icecast_status_url() else {
+        tracing::info!(
+            "Icecast metrics poller disabled (no ICECAST_STATUS_URL and no icecast_url to derive from)"
+        );
+        return;
+    };
+    let interval_secs = state.config.icecast_metrics_poll_secs.max(1);
+    let cache = state.stream_metrics.clone();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    tracing::info!("Starting Icecast metrics poller: {url} every {interval_secs}s");
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        loop {
+            interval.tick().await;
+            let snapshot = poll_once(&client, &url).await;
+            *cache.write().await = snapshot;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_source_object() {
+        // One connected mount → `source` is an OBJECT.
+        let body = r#"{"icestats":{"source":{
+            "listeners":7,"listener_peak":12,"bitrate":128,"samplerate":44100,
+            "channels":2,"server_name":"Moafunk","listenurl":"http://h:8010/live.mp3"}}}"#;
+        let m = parse_status(body).unwrap();
+        assert!(m.online);
+        assert_eq!(m.total_listeners, 7);
+        assert_eq!(m.mounts.len(), 1);
+        let mount = &m.mounts[0];
+        assert_eq!(mount.mount, "/live.mp3");
+        assert_eq!(mount.listeners, 7);
+        assert_eq!(mount.bitrate, Some(128));
+        assert_eq!(mount.samplerate, Some(44100));
+        assert_eq!(mount.channels, Some(2));
+    }
+
+    #[test]
+    fn parses_multiple_sources_array() {
+        // Several mounts → `source` is an ARRAY. The object-vs-array quirk.
+        let body = r#"{"icestats":{"source":[
+            {"listeners":3,"listenurl":"http://h:8010/live.mp3"},
+            {"listeners":5,"listenurl":"http://h:8010/test.mp3"}]}}"#;
+        let m = parse_status(body).unwrap();
+        assert!(m.online);
+        assert_eq!(m.total_listeners, 8);
+        assert_eq!(m.mounts.len(), 2);
+        assert_eq!(m.mounts[0].mount, "/live.mp3");
+        assert_eq!(m.mounts[1].mount, "/test.mp3");
+    }
+
+    #[test]
+    fn handles_no_sources_connected() {
+        // Idle Icecast → no `source` key at all.
+        let m = parse_status(r#"{"icestats":{}}"#).unwrap();
+        assert!(!m.online);
+        assert_eq!(m.total_listeners, 0);
+        assert!(m.mounts.is_empty());
+    }
+
+    #[test]
+    fn missing_optional_fields_default_gracefully() {
+        let body = r#"{"icestats":{"source":{"listenurl":"http://h:8010/live.mp3"}}}"#;
+        let m = parse_status(body).unwrap();
+        assert_eq!(m.mounts[0].listeners, 0);
+        assert_eq!(m.mounts[0].bitrate, None);
+    }
+
+    #[test]
+    fn rejects_garbage_body() {
+        assert!(parse_status("not json").is_err());
+    }
+
+    #[test]
+    fn mount_path_extracted_from_listenurl() {
+        assert_eq!(
+            mount_from_listenurl("http://host:8010/live.mp3").as_deref(),
+            Some("/live.mp3")
+        );
+        assert_eq!(mount_from_listenurl("http://host:8010").as_deref(), None);
+    }
+}

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -856,8 +856,30 @@ export interface StreamStatus {
   user?: string;
 }
 
+/** Per-mount Icecast telemetry (#177). */
+export interface StreamMountMetrics {
+  mount: string;
+  listeners: number;
+  listener_peak?: number;
+  bitrate?: number;
+  samplerate?: number;
+  channels?: number;
+  server_name?: string;
+}
+
+/** Cached Icecast listener/quality snapshot from `GET /api/stream/metrics`. */
+export interface StreamMetrics {
+  online: boolean;
+  total_listeners: number;
+  mounts: StreamMountMetrics[];
+  polled_at_ms?: number;
+  error?: string;
+}
+
 export const streamApi = {
   status: () => api.get<StreamStatus>('/api/stream/status'),
+
+  metrics: () => api.get<StreamMetrics>('/api/stream/metrics'),
 
   stop: () => api.post<void>('/api/stream/stop'),
 };

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
-import { streamApi, recordingApi, hostFlowApi } from '@admin/api';
+import { streamApi, recordingApi, hostFlowApi, type StreamMetrics } from '@admin/api';
 import DbMeter from '@admin/components/DbMeter.vue';
 import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
 import { config } from '@/config';
@@ -172,6 +172,7 @@ const streamSocket = useStreamSocket({
     if (streamActive.value && !streamEnded.value) {
       streamEnded.value = true;
       stopElapsed();
+      stopMetrics();
     }
   },
   onError: (msg) => {
@@ -227,6 +228,11 @@ function transitionToStreaming() {
     pollRecordingStatus();
     recordingPollInterval = setInterval(pollRecordingStatus, 3000);
   }
+  // Live listener/quality telemetry (#177) — only useful for a live broadcast.
+  if (isLiveMode.value) {
+    pollMetrics();
+    metricsInterval = setInterval(pollMetrics, 10000);
+  }
   if (show.value?.end_time) {
     updateEndTimeCountdown();
     endTimeInterval = setInterval(updateEndTimeCountdown, 1000);
@@ -268,6 +274,42 @@ function stopElapsed() {
   }
 }
 
+// ─── Live Icecast telemetry (#177) ───────────────────────────────────────────
+// Polled while streaming. Degrades gracefully: when the Icecast stack isn't live
+// (or offline), the panels just show a dash instead of real numbers.
+const metrics = ref<StreamMetrics | null>(null);
+let metricsInterval: ReturnType<typeof setInterval> | null = null;
+
+async function pollMetrics() {
+  try {
+    metrics.value = await streamApi.metrics();
+  } catch {
+    // Ignore — backend may not expose metrics yet / Icecast not configured.
+  }
+}
+
+function stopMetrics() {
+  if (metricsInterval) {
+    clearInterval(metricsInterval);
+    metricsInterval = null;
+  }
+}
+
+const metricsOnline = computed(() => metrics.value?.online === true);
+const listenerCount = computed(() => (metricsOnline.value ? metrics.value!.total_listeners : null));
+const primaryMount = computed(() => metrics.value?.mounts?.[0] ?? null);
+const audioQuality = computed(() => {
+  if (!metricsOnline.value) return null;
+  const m = primaryMount.value;
+  if (!m) return null;
+  const parts: string[] = [];
+  if (m.bitrate) parts.push(`${m.bitrate} kbps`);
+  if (m.samplerate) parts.push(`${(m.samplerate / 1000).toFixed(1)} kHz`);
+  if (m.channels === 2) parts.push('stereo');
+  else if (m.channels === 1) parts.push('mono');
+  return parts.length ? parts.join(' · ') : null;
+});
+
 // ─── Stop streaming ─────────────────────────────────────────────────────────
 const stopping = ref(false);
 
@@ -281,6 +323,7 @@ function handleStop() {
   }
   streamEnded.value = true;
   stopElapsed();
+  stopMetrics();
 }
 
 async function handleStopUpload() {
@@ -292,6 +335,7 @@ async function handleStopUpload() {
   }
   streamEnded.value = true;
   stopElapsed();
+  stopMetrics();
   if (statusInterval) {
     clearInterval(statusInterval);
     statusInterval = null;
@@ -311,6 +355,7 @@ async function handleStopAndChangeSettings() {
     isRecording.value = false;
   }
   stopElapsed();
+  stopMetrics();
   if (statusInterval) {
     clearInterval(statusInterval);
     statusInterval = null;
@@ -456,6 +501,7 @@ onUnmounted(() => {
     beepCtx = null;
   }
   stopElapsed();
+  stopMetrics();
   stopEndTimeInterval();
   if (statusInterval) {
     clearInterval(statusInterval);
@@ -585,17 +631,19 @@ onUnmounted(() => {
         </p>
       </div>
 
-      <!-- Future feature placeholders -->
+      <!-- Live telemetry (#177) + remaining placeholder -->
       <div class="future-panels">
-        <div class="future-panel">
+        <div class="future-panel" :class="{ active: listenerCount !== null }">
           <span class="future-icon">👥</span>
-          <span class="future-label">Listener Count</span>
-          <span class="future-badge">Coming soon</span>
+          <span class="future-label">Listeners</span>
+          <span v-if="listenerCount !== null" class="metric-value">{{ listenerCount }}</span>
+          <span v-else class="future-badge">—</span>
         </div>
-        <div class="future-panel">
+        <div class="future-panel" :class="{ active: audioQuality !== null }">
           <span class="future-icon">📊</span>
           <span class="future-label">Audio Quality</span>
-          <span class="future-badge">Coming soon</span>
+          <span v-if="audioQuality" class="metric-value metric-value-sm">{{ audioQuality }}</span>
+          <span v-else class="future-badge">—</span>
         </div>
         <div class="future-panel">
           <span class="future-icon">💬</span>
@@ -1077,6 +1125,25 @@ onUnmounted(() => {
   align-items: center;
   gap: var(--spacing-xs);
   opacity: 0.6;
+}
+
+/* A panel backed by real live data — solid border, full opacity. */
+.future-panel.active {
+  opacity: 1;
+  border-style: solid;
+  border-color: var(--color-border);
+}
+
+.metric-value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+
+.metric-value-sm {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
 }
 
 .future-icon {


### PR DESCRIPTION
## What
- Backend poller (`stream_metrics.rs`) fetches Icecast `GET /status-json.xsl` every ~15s, normalizes per-mount **listeners / bitrate / samplerate / channels**, caches it in `AppState`, and serves it at **`GET /api/stream/metrics`**.
- Frontend: `streamApi.metrics()` + types; `FlowOnAir` polls while live and turns the old "Listener Count" / "Audio Quality" **placeholder panels into real data** (dash when offline).

## Why
Issue **#177** (req #5 "live metrics", Phase 4 of #164); a step toward the Hetzner migration (#194). Icecast's persistent connections give a *genuine* concurrent count that HLS structurally can't.

## How
- Handles the documented `icestats.source` **object-vs-array** quirk (one mount → object, many → array) plus the no-source and garbage-body cases.
- Status URL from `ICECAST_STATUS_URL`, else **derived** from `ICECAST_URL` host:port (`http://host:port/status-json.xsl`); poller is a **no-op** when neither is set, so it's safe before the Icecast stack exists.
- 5s request timeout; a failed poll is cached as an `online:false` snapshot — never panics, never blocks.

## Test plan
- [x] Backend unit tests: source object / array / none / garbage parse; status-URL derivation
- [x] `cargo build` + backend `cargo clippy` clean
- [x] **Validated against a real Icecast 2.4.4** `/status-json.xsl` (local harness): field shape matches, and the listener count incremented 0→1 when a client attached
- [x] Frontend `npm run build` + `npm run lint` clean
- [ ] With the Icecast stack live + `ICECAST_URL`/`ICECAST_STATUS_URL` set, broadcaster's live screen shows the real listener count + quality

## Risk
**Low.** Purely additive: new route + a background task that's disabled unless configured. No change to existing stream/recording paths. Frontend panels degrade to a dash when metrics are unavailable.

> Repo-wide `vue-tsc` typecheck fails **pre-existing** (no `*.vue` shim + stale `node_modules`); validated via build + lint as before.
