### PR TITLE
docs(stream): production Icecast-KH + Liquidsoap config kit (no NMS) (#173)

### DIFF
--- a/docs/stream-rework/prod/README.md
+++ b/docs/stream-rework/prod/README.md
@@ -1,0 +1,68 @@
+# Production stream stack — Icecast-KH + Liquidsoap (no NMS)
+
+Deploy-ready configs for the **greenfield #194 target**: the backend pushes audio
+into a Liquidsoap **harbor**, Liquidsoap re-emits MP3 to **Icecast-KH**. No
+NodeMediaServer, no RTMP. These are the production counterparts to the validated
+[`../local-test-harness/`](../local-test-harness/) (decision **B**), and the
+on-box steps live in [`../phase-2-icecast-runbook.md`](../phase-2-icecast-runbook.md).
+
+```
+backend ffmpeg (STREAM_OUTPUT=icecast)
+   ├─ ICECAST_URL=…@127.0.0.1:8005/test ─▶ harbor "test" ─▶ mksafe ─▶ Icecast /test.mp3  (preview)
+   └─ ICECAST_URL=…@127.0.0.1:8005/live ─▶ harbor "live" ─▶ mksafe ─▶ Icecast /live.mp3  (public)
+                                                                          │ nginx/Caddy TLS
+                                                                          ▼  listeners (incl. iOS)
+```
+
+## Files
+
+| File | Goes to | Purpose |
+|------|---------|---------|
+| `icecast.xml` | `/etc/moafunk/icecast.xml` | Icecast-KH: `/live.mp3` + `/test.mp3` mounts, port 8010 |
+| `moafunk.liq` | `/etc/moafunk/moafunk.liq` | Liquidsoap: harbor inputs → Icecast, secrets from env |
+| `stream.env.example` | `/etc/moafunk/stream.env` (filled) | harbor + Icecast passwords (Bitwarden-injected) |
+| `liquidsoap.service` | `/etc/systemd/system/` | supervises Liquidsoap (docker, `Restart=always`, mem cap) |
+| `icecast.service` | `/etc/systemd/system/` | supervises Icecast-KH (`Restart=always`, `MemoryMax`) |
+
+## Deploy (on the Hetzner box)
+
+1. Build Icecast-KH from source (runbook Step 1a) and create its user:
+   `sudo useradd --system --no-create-home --shell /usr/sbin/nologin icecast`.
+2. `sudo mkdir -p /etc/moafunk && sudo cp icecast.xml moafunk.liq /etc/moafunk/`.
+3. Create `/etc/moafunk/stream.env` from `stream.env.example` with **real**
+   passwords (Bitwarden) — `chmod 600`, owned by root. The `ICECAST_SOURCE_PASSWORD`
+   must match `<source-password>` in `icecast.xml`.
+4. `sudo cp *.service /etc/systemd/system/ && sudo systemctl daemon-reload`.
+5. `sudo systemctl enable --now icecast liquidsoap`.
+6. Point the backend at the stack (its own `.env`):
+   ```
+   STREAM_OUTPUT=icecast
+   ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@127.0.0.1:8005/live
+   ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl
+   ```
+7. TLS-front the public mount (nginx/Caddy → `127.0.0.1:8010`), e.g. `radio.live.moafunk.de`.
+
+## Validate (GET, never HEAD — Icecast 400s on HEAD)
+
+```bash
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' http://127.0.0.1:8010/live.mp3   # 200 audio/mpeg
+curl -s http://127.0.0.1:8010/status-json.xsl | jq '.icestats.source'                      # listeners, bitrate…
+```
+The backend's `/api/stream/metrics` (#177) surfaces the same numbers to the admin UI.
+
+## test → live ("go live")
+
+The broadcaster previews on `/test.mp3` (the #175 preview player), then "goes live"
+by switching the producer's target mount **test → live** (`ICECAST_URL` `.../test`
+→ `.../live` + stream restart). The recording tee is a separate ffmpeg, so the
+switch never gaps the archive.
+
+## Notes / landmines (from #173/#178)
+
+- **MP3 only** on public mounts — iOS Safari can't decode Opus/Ogg.
+- **Icecast-KH**, not stock Xiph (stock froze ~3k listeners; KH ~30k + relays for Phase 4).
+- **Liquidsoap 2.4.4** (skip 2.4.3 — shared-encoder crash).
+- **Do NOT** pair `blank.strip` with `mksafe` on one source (CPU-spike breakups). Dead-air
+  auto-fill, when added, is a fallback to a `single`/playlist — not `blank.strip`.
+- Phase 4 (#178) still to do: CDN / KH master→relay in front of the public mount
+  (~300 listeners ≈ 38 Mbps off one box), Prometheus/Grafana/Alertmanager/Blackbox.

--- a/docs/stream-rework/prod/icecast.service
+++ b/docs/stream-rework/prod/icecast.service
@@ -1,0 +1,26 @@
+# Icecast-KH audio streaming server (issue #173 / #178).
+#
+# Runs the Icecast-KH binary (built from source per the runbook) under systemd
+# with Restart=always and a hard cgroup memory cap — the SPOF/reliability
+# hardening from #178. Assumes an `icecast` user/group exists:
+#   sudo useradd --system --no-create-home --shell /usr/sbin/nologin icecast
+#
+# Install: copy to /etc/systemd/system/, place icecast.xml under /etc/moafunk/,
+# then: systemctl daemon-reload && systemctl enable --now icecast
+[Unit]
+Description=Icecast-KH audio streaming server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/icecast -c /etc/moafunk/icecast.xml
+Restart=always
+RestartSec=3
+# Reliability hardening (#178): hard memory cap (native binary → cgroup MemoryMax applies).
+MemoryMax=512M
+User=icecast
+Group=icecast
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/stream-rework/prod/icecast.xml
+++ b/docs/stream-rework/prod/icecast.xml
@@ -1,0 +1,73 @@
+<!-- Production Icecast-KH config (issue #173 / #194). Serves the public /live.mp3
+     and broadcaster-preview /test.mp3 mounts, fed by Liquidsoap (moafunk.liq).
+
+     Icecast-KH (karlheyes fork), NOT stock Xiph Icecast — stock froze ~3k
+     listeners in benchmarks, KH handles ~30k and adds the master→relay support
+     Phase 4 (#178) needs to front the public mount.
+
+     PORT 8010 (NMS, while it still exists, owns 8000). Plain HTTP here; a TLS
+     reverse proxy (nginx/Caddy) terminates HTTPS in front — the public site is
+     https, so a plain-http mount is blocked as mixed content. Bind the admin
+     interface to localhost only.
+
+     SECRETS: the CHANGE_ME_* values below are placeholders. Inject the real
+     passwords at deploy time (Bitwarden Secrets Manager, same as the backend) —
+     do NOT commit real credentials. The Liquidsoap source password here must
+     match ICECAST_SOURCE_PASSWORD in stream.env. -->
+<icecast>
+  <location>Berlin</location>
+  <admin>admin@moafunk.de</admin>
+
+  <limits>
+    <clients>350</clients>          <!-- headroom over the ~300 peak (see #168); not a load test -->
+    <sources>4</sources>
+    <queue-size>524288</queue-size>
+    <burst-on-connect>1</burst-on-connect>
+    <burst-size>65536</burst-size>  <!-- fast start; keep modest -->
+  </limits>
+
+  <authentication>
+    <!-- Liquidsoap connects as a source with this password (== ICECAST_SOURCE_PASSWORD). -->
+    <source-password>CHANGE_ME_SOURCE</source-password>
+    <relay-password>CHANGE_ME_RELAY</relay-password>   <!-- for Phase-4 KH master→relay -->
+    <admin-user>admin</admin-user>
+    <admin-password>CHANGE_ME_ADMIN</admin-password>
+  </authentication>
+
+  <!-- Single HTTP socket on 8010. Firewall it so only the TLS reverse proxy and
+       localhost reach it (the backend metrics poller hits 127.0.0.1:8010/status-json.xsl;
+       public listeners come via the proxy). Never expose 8010 to the internet directly. -->
+  <listen-socket>
+    <port>8010</port>
+  </listen-socket>
+
+  <!-- Public live mount. -->
+  <mount type="normal">
+    <mount-name>/live.mp3</mount-name>
+    <max-listeners>350</max-listeners>
+    <public>1</public>
+  </mount>
+
+  <!-- Broadcaster preview mount — kept small + unlisted. -->
+  <mount type="normal">
+    <mount-name>/test.mp3</mount-name>
+    <max-listeners>10</max-listeners>
+    <public>0</public>
+  </mount>
+
+  <fileserve>1</fileserve>
+
+  <paths>
+    <logdir>/var/log/icecast</logdir>
+    <webroot>/usr/local/share/icecast/web</webroot>
+    <adminroot>/usr/local/share/icecast/admin</adminroot>
+  </paths>
+
+  <logging>
+    <loglevel>3</loglevel>
+  </logging>
+
+  <security>
+    <chroot>0</chroot>
+  </security>
+</icecast>

--- a/docs/stream-rework/prod/liquidsoap.service
+++ b/docs/stream-rework/prod/liquidsoap.service
@@ -1,0 +1,32 @@
+# Moafunk Liquidsoap producer (issue #194 / #178).
+#
+# Runs the validated savonet image (pinned 2.4.4) so we avoid the apt-1.4.x
+# (no input.ffmpeg/harbor knobs) and opam-on-a-small-box landmines from #173.
+# systemd supervises with Restart=always; the hard memory cap is enforced via
+# docker --memory (the cgroup cap that matters for the container).
+#
+# Install: copy to /etc/systemd/system/, place moafunk.liq + stream.env under
+# /etc/moafunk/, then: systemctl daemon-reload && systemctl enable --now liquidsoap
+[Unit]
+Description=Moafunk Liquidsoap producer (harbor -> Icecast)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=/etc/moafunk/stream.env
+# --network host: harbor :8005 is reachable by the backend on localhost, and
+# Liquidsoap reaches Icecast on 127.0.0.1:8010.
+ExecStartPre=-/usr/bin/docker rm -f moafunk-liquidsoap
+ExecStart=/usr/bin/docker run --rm --name moafunk-liquidsoap \
+  --network host \
+  --memory 512m --memory-swap 512m \
+  --env-file /etc/moafunk/stream.env \
+  -v /etc/moafunk/moafunk.liq:/moafunk.liq:ro \
+  savonet/liquidsoap:v2.4.4 liquidsoap /moafunk.liq
+ExecStop=/usr/bin/docker stop moafunk-liquidsoap
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/stream-rework/prod/moafunk.liq
+++ b/docs/stream-rework/prod/moafunk.liq
@@ -1,0 +1,62 @@
+# Production Liquidsoap producer — issue #194 decision (B), no NMS.
+#
+# The backend ffmpeg (STREAM_OUTPUT=icecast) pushes MP3 into Liquidsoap's HARBOR
+# (Icecast SOURCE protocol); Liquidsoap re-emits to Icecast-KH. Two independent
+# chains give the #173 "separate /test and /live mounts with separate creds":
+#
+#   backend (ICECAST_URL=…/test) ─▶ harbor "test" :8005 ─▶ mksafe ─▶ Icecast /test.mp3   (preview)
+#   backend (ICECAST_URL=…/live) ─▶ harbor "live" :8005 ─▶ mksafe ─▶ Icecast /live.mp3   (public)
+#
+# "Go live" is the broadcaster switching the producer's target mount test→live
+# (an ICECAST_URL change + stream restart). The recording tee is a separate
+# ffmpeg, so it is never disturbed by the switch.
+#
+# Validated chain shape: see ../local-test-harness/ (harbor rehearsal). Pin
+# Liquidsoap 2.4.4 in prod (skip 2.4.3 — shared-encoder crash); the
+# harbor/mksafe/%mp3 syntax here is stable across 2.x.
+#
+# Secrets come from the environment (see stream.env.example) — never hard-code.
+
+log.level := 3
+
+# --- credentials (injected via the systemd EnvironmentFile) -------------------
+harbor_test_pw = environment.get("HARBOR_TEST_PASSWORD")
+harbor_live_pw = environment.get("HARBOR_LIVE_PASSWORD")
+ice_source_pw  = environment.get("ICECAST_SOURCE_PASSWORD")
+harbor_port    = int_of_string(default=8005, environment.get("HARBOR_PORT"))
+ice_host       = "127.0.0.1"
+ice_port       = int_of_string(default=8010, environment.get("ICECAST_PORT"))
+
+# MP3 only on the public mounts — iOS Safari can't decode Opus/Ogg (would
+# silently lock out every iPhone). 128 kbps matches the validated harness.
+enc = %mp3(bitrate=128, samplerate=44100, stereo=true)
+
+# --- preview chain: harbor "test" → Icecast /test.mp3 -------------------------
+# mksafe serves silence (never 404) until the broadcaster connects.
+# NOTE: do NOT add blank.strip on a source wrapped in mksafe (CPU-spike breakups,
+# liquidsoap #3439/#3474). Dead-air auto-fill would be a fallback to a `single`
+# track, not blank.strip+mksafe — left out until a fallback asset exists.
+test_src = mksafe(input.harbor("test", port=harbor_port, password=harbor_test_pw))
+output.icecast(
+  enc,
+  host=ice_host, port=ice_port, password=ice_source_pw,
+  mount="/test.mp3",
+  name="Moafunk (test)",
+  description="Broadcaster preview mount",
+  genre="radio",
+  public=false,
+  test_src
+)
+
+# --- public chain: harbor "live" → Icecast /live.mp3 --------------------------
+live_src = mksafe(input.harbor("live", port=harbor_port, password=harbor_live_pw))
+output.icecast(
+  enc,
+  host=ice_host, port=ice_port, password=ice_source_pw,
+  mount="/live.mp3",
+  name="Moafunk",
+  description="Moafunk live radio",
+  genre="radio",
+  public=true,
+  live_src
+)

--- a/docs/stream-rework/prod/stream.env.example
+++ b/docs/stream-rework/prod/stream.env.example
@@ -1,0 +1,21 @@
+# Stream stack secrets/config — consumed by liquidsoap.service (moafunk.liq reads
+# these via environment.get). Inject the real values at deploy time from Bitwarden
+# Secrets Manager (the same source the backend uses); do NOT commit real secrets.
+#
+# Deploy as /etc/moafunk/stream.env (chmod 600, owned by root).
+
+# Liquidsoap harbor (the backend pushes its MP3 source here).
+HARBOR_PORT=8005
+HARBOR_TEST_PASSWORD=CHANGE_ME_HARBOR_TEST
+HARBOR_LIVE_PASSWORD=CHANGE_ME_HARBOR_LIVE
+
+# Icecast (Liquidsoap connects as a source). ICECAST_SOURCE_PASSWORD MUST equal
+# <source-password> in icecast.xml.
+ICECAST_PORT=8010
+ICECAST_SOURCE_PASSWORD=CHANGE_ME_SOURCE
+
+# ── Backend side (set these in the BACKEND .env, not here) ───────────────────
+# The backend pushes to the Liquidsoap harbor and reads Icecast stats directly:
+#   STREAM_OUTPUT=icecast
+#   ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@127.0.0.1:8005/live   # or /test before go-live
+#   ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl   # explicit: can't be derived (harbor port != Icecast port)


### PR DESCRIPTION
## What
Deploy-ready production configs for the greenfield #194 target (decision **B**): backend → Liquidsoap **harbor** → **Icecast-KH**, no NMS, no RTMP. The production counterparts to the validated `local-test-harness/`.

New `docs/stream-rework/prod/`:
- **`moafunk.liq`** — harbor `test`/`live` inputs → `mksafe` → Icecast `/test.mp3` + `/live.mp3` (separate creds per #173); secrets from env.
- **`icecast.xml`** — Icecast-KH, port 8010, public `/live.mp3` + preview `/test.mp3`, placeholder creds.
- **`liquidsoap.service` / `icecast.service`** — systemd units, `Restart=always` + hard memory cap (#178); Liquidsoap pinned 2.4.4.
- **`stream.env.example`** + **`README.md`** — deploy steps, backend wiring, the test→live switch.

## Why
Issue **#173** (Phase 2 stack) — turns the proven harness into something the operator can actually stand up on the Hetzner box (Phase B of #194). Purely documentation/config; no runtime code.

## How
Honors the catalogued landmines: MP3-only public mounts (iOS), Icecast-KH not stock, Liquidsoap 2.4.4 (skip 2.4.3), and **never** `blank.strip`+`mksafe` on one source. Secrets are placeholders, injected via Bitwarden at deploy.

## Test plan
- [x] `liquidsoap --check` passes (savonet image)
- [x] `icecast.xml` well-formed (`xmllint`)
- [ ] Apply on the real box and run the README validation (Phase B)

## Risk
**None to running systems** — additive docs/config only; nothing references or deploys these yet.
