### PR TITLE
ci(backend): read Hetzner IP + SSH key from Bitwarden (#194)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -247,10 +247,10 @@ jobs:
   deploy-hetzner:
     # Greenfield Hetzner deploy (#194 Phase B). MANUAL ONLY — never runs on push,
     # so the Lightsail `deploy` job stays the automatic prod path until cutover.
-    # IP + SSH key come from GitHub repo secrets (Settings → Secrets → Actions):
-    # HETZNER_IP, HETZNER_SSH_KEY. App secrets are reused from Bitwarden.
-    # The generated .env mirrors the Lightsail one — the producer stays on RTMP;
-    # flipping to Icecast (STREAM_OUTPUT/ICECAST_URL) is a deliberate later step.
+    # Everything (incl. the box IP + SSH key) comes from Bitwarden SM — single
+    # source of truth, same as the rest of CI. The generated .env mirrors the
+    # Lightsail one — the producer stays on RTMP; flipping to Icecast
+    # (STREAM_OUTPUT/ICECAST_URL) is a deliberate later step.
     if: github.event_name == 'workflow_dispatch' && inputs.deploy_hetzner == true
     needs: build-and-push
     runs-on: ubuntu-latest
@@ -259,22 +259,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify Hetzner secrets are configured
-        env:
-          HETZNER_IP: ${{ secrets.HETZNER_IP }}
-          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
-        run: |
-          if [[ -z "$HETZNER_IP" || -z "$HETZNER_SSH_KEY" ]]; then
-            echo "::error::Set the HETZNER_IP and HETZNER_SSH_KEY repo secrets (Settings → Secrets → Actions) before deploying."
-            exit 1
-          fi
-
       - name: Get secrets from Bitwarden
         uses: bitwarden/sm-action@v2
         id: bitwarden-secrets
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
+            546972ad-7db9-4525-8d30-b46e00f8802a > HETZNER_IP
+            32944dfd-70f2-4f57-8274-b46e00f77c41 > HETZNER_SSH_KEY
             780bf50d-98fd-4bd4-b470-b3e701001e63 > GHCR_DEPLOY_TOKEN
             41363d58-f866-4c70-b8e6-b3e70100636b > GHCR_USERNAME
             eeda2f4a-6fb9-470d-a909-b3ec01488545 > SECRET_KEY
@@ -359,8 +351,8 @@ jobs:
 
       - name: Setup SSH key
         env:
-          HETZNER_IP: ${{ secrets.HETZNER_IP }}
-          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HETZNER_IP: ${{ steps.bitwarden-secrets.outputs.HETZNER_IP }}
+          HETZNER_SSH_KEY: ${{ steps.bitwarden-secrets.outputs.HETZNER_SSH_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner.pem
@@ -371,7 +363,7 @@ jobs:
         env:
           GHCR_TOKEN: ${{ steps.bitwarden-secrets.outputs.GHCR_DEPLOY_TOKEN }}
           GHCR_USER: ${{ steps.bitwarden-secrets.outputs.GHCR_USERNAME || github.repository_owner }}
-          HETZNER_IP: ${{ secrets.HETZNER_IP }}
+          HETZNER_IP: ${{ steps.bitwarden-secrets.outputs.HETZNER_IP }}
         run: |
           echo "$GHCR_TOKEN" > /tmp/ghcr-token.key
 

--- a/docs/stream-rework/backend-hetzner-migration.md
+++ b/docs/stream-rework/backend-hetzner-migration.md
@@ -108,13 +108,14 @@ window short and ideally outside a live show.
 ## CI note
 `.github/workflows/backend.yml` auto-deploys to Lightsail on push (Bitwarden
 `LIGHTSAIL_IP`/`LIGHTSAIL_SSH_KEY`). A **manual** `deploy-hetzner` job is also
-wired: it runs `deploy_hetzner.sh` with the same Bitwarden app secrets and the
-same generated `.env`, but reads the box's IP + SSH key from the **GitHub repo
-secrets** `HETZNER_IP` and `HETZNER_SSH_KEY` (Settings → Secrets → Actions).
+wired: it runs `deploy_hetzner.sh` with the same generated `.env`, reading
+everything — including the box's `HETZNER_IP` and `HETZNER_SSH_KEY` — from
+**Bitwarden Secrets Manager** (single source of truth, same project as the app
+secrets).
 
-To deploy to Hetzner: set those two repo secrets, then run the workflow via
-**Actions → Run workflow** with `deploy_hetzner=true` (first run: also
-`setup_nginx=true`, `init_db=true`). It never runs on push, so Lightsail stays
+To deploy to Hetzner: ensure `HETZNER_IP`/`HETZNER_SSH_KEY` exist in the SM
+project, then run the workflow via **Actions → Run workflow** with
+`deploy_hetzner=true` (first run: also `setup_nginx=true`, `init_db=true`). It never runs on push, so Lightsail stays
 the automatic prod path until the DNS cutover. The generated `.env` mirrors
 Lightsail's — the producer stays on RTMP; flipping to Icecast
 (`STREAM_OUTPUT=icecast`, `ICECAST_URL`, `ICECAST_STATUS_URL`) is a deliberate


### PR DESCRIPTION
## What
Move `HETZNER_IP` / `HETZNER_SSH_KEY` into the **Bitwarden SM** block of the manual `deploy-hetzner` job (same project `37a9cffb…` as the app secrets), instead of GitHub repo secrets.

## Why
Single source of truth for all CI secrets (consistent with the rest of the workflow). Follows from wiring the box's real secrets after provisioning.

## How
- Add the two UUIDs to the `sm-action` `secrets:` block.
- Switch the SSH-setup + deploy steps to `steps.bitwarden-secrets.outputs.HETZNER_*`.
- Drop the now-unneeded GitHub-repo-secret guard step.
- Migration doc CI note updated.

## Test plan
- [x] `backend.yml` parses as valid YAML
- [ ] Run **Actions → Run workflow** `deploy_hetzner=true` (Phase B) — the box is provisioned (178.104.160.103) and the secrets exist in SM

## Risk
**Low / none to prod.** Manual-only job; Lightsail auto-deploy untouched. Cleanup: the GitHub `HETZNER_IP` repo secret will be deleted after merge.