### PR TITLE
feat(stream): env-flippable Icecast public player (#176)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,6 +6,15 @@ VITE_STREAM_FLV_URL=https://stream.moafunk.de/live/stream-io.flv
 # Icecast /test mount for the broadcaster preview player (#175). Leave empty
 # until the Phase-2 Icecast stack is live (then e.g. https://radio.live.moafunk.de/test.mp3).
 VITE_STREAM_ICECAST_TEST_URL=
+# Public Icecast /live.mp3 mount (#176). When set, the public player streams
+# this single MP3 mount via native <audio> on all platforms instead of the NMS
+# HLS/FLV pair above. Leave empty until cutover (then e.g.
+# https://radio.live.moafunk.de/live.mp3). Flip = env-only, no code deploy.
+VITE_STREAM_ICECAST_URL=
+# Backend on-air endpoint for live detection in Icecast mode (the mksafe mount
+# is always up, so we ask the backend). Empty → HEAD-poll VITE_STREAM_HLS_URL.
+# Set together with VITE_STREAM_ICECAST_URL, e.g. https://admin.live.moafunk.de/api/stream/status
+VITE_STREAM_STATUS_URL=
 
 # Analytics Configuration
 VITE_ANALYTICS_DOMAIN=live.moafunk.de

--- a/frontend/src/__tests__/streamDetector.test.ts
+++ b/frontend/src/__tests__/streamDetector.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { checkStreamStatus, checkBackendLive } from '../streamDetector';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(impl: () => Promise<Partial<Response>> | Partial<Response>) {
+  vi.stubGlobal('fetch', vi.fn(impl as unknown as typeof fetch));
+}
+
+describe('checkStreamStatus (legacy NMS HEAD poll)', () => {
+  it('is live on HTTP 200', async () => {
+    mockFetch(() => ({ status: 200 }));
+    expect(await checkStreamStatus('https://stream/x.m3u8')).toBe(true);
+  });
+
+  it('is offline on non-200', async () => {
+    mockFetch(() => ({ status: 404 }));
+    expect(await checkStreamStatus('https://stream/x.m3u8')).toBe(false);
+  });
+
+  it('is offline when fetch rejects', async () => {
+    mockFetch(() => Promise.reject(new Error('network')));
+    expect(await checkStreamStatus('https://stream/x.m3u8')).toBe(false);
+  });
+});
+
+describe('checkBackendLive (Icecast mode, backend /api/stream/status)', () => {
+  it('is live only when { active: true }', async () => {
+    mockFetch(() => ({ ok: true, json: () => Promise.resolve({ active: true }) }));
+    expect(await checkBackendLive('https://admin/api/stream/status')).toBe(true);
+  });
+
+  it('is offline when { active: false }', async () => {
+    mockFetch(() => ({ ok: true, json: () => Promise.resolve({ active: false }) }));
+    expect(await checkBackendLive('https://admin/api/stream/status')).toBe(false);
+  });
+
+  it('is offline when active is missing', async () => {
+    mockFetch(() => ({ ok: true, json: () => Promise.resolve({ recording: true }) }));
+    expect(await checkBackendLive('https://admin/api/stream/status')).toBe(false);
+  });
+
+  it('is offline on a non-ok response (no JSON parse)', async () => {
+    const json = vi.fn();
+    mockFetch(() => ({ ok: false, json }));
+    expect(await checkBackendLive('https://admin/api/stream/status')).toBe(false);
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it('is offline when fetch rejects', async () => {
+    mockFetch(() => Promise.reject(new Error('network')));
+    expect(await checkBackendLive('https://admin/api/stream/status')).toBe(false);
+  });
+});

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -9,6 +9,16 @@ export const config = {
     // Icecast `/test` mount for the broadcaster preview player (#175). Empty by
     // default → the preview stays hidden until the Phase-2 Icecast stack is live.
     icecastTestUrl: import.meta.env.VITE_STREAM_ICECAST_TEST_URL || '',
+    // Public Icecast `/live.mp3` mount (#176). When set, the public player
+    // streams this single MP3 mount via native <audio> on every platform
+    // (iOS + desktop) instead of the legacy NMS HLS/FLV pair below. Empty →
+    // the NMS HLS/FLV path stays active, so this is a no-op env flip.
+    icecast: import.meta.env.VITE_STREAM_ICECAST_URL || '',
+    // Backend on-air endpoint (`GET /api/stream/status` → { active }). The
+    // authoritative live signal: the Icecast mount is mksafe-backed and thus
+    // always up, so mount presence can't tell "show live" from "dead air".
+    // Empty → fall back to a HEAD poll of `hls` (legacy NMS behaviour).
+    statusUrl: import.meta.env.VITE_STREAM_STATUS_URL || '',
   },
   analytics: {
     domain: import.meta.env.VITE_ANALYTICS_DOMAIN || 'live.moafunk.de',

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,13 @@
 import { config } from './config';
-import { checkStreamStatus } from './streamDetector';
+import { checkStreamStatus, checkBackendLive } from './streamDetector';
 import { initializePlayer, updateLiveStatus, destroyPlayer, restartPlayer } from './player';
+
+// Liveness signal: in Icecast mode the mount is always up (mksafe), so ask the
+// backend's authoritative on-air endpoint; otherwise HEAD-poll the NMS HLS mount.
+const isLive = (): Promise<boolean> =>
+  config.stream.statusUrl
+    ? checkBackendLive(config.stream.statusUrl)
+    : checkStreamStatus(config.stream.hls);
 
 // Only initialize if we're on a page with a player
 const hasPlayer = document.getElementById('player') || document.getElementById('videoElement');
@@ -9,7 +16,7 @@ if (hasPlayer) {
   let wasLive = false;
 
   // Initial check + player init
-  checkStreamStatus(config.stream.hls).then((live) => {
+  isLive().then((live) => {
     wasLive = live;
     updateLiveStatus(live);
     if (live) {
@@ -19,7 +26,7 @@ if (hasPlayer) {
 
   // Poll stream status every 8 seconds to detect live↔offline transitions
   setInterval(async () => {
-    const live = await checkStreamStatus(config.stream.hls);
+    const live = await isLive();
 
     if (live && !wasLive) {
       // Transition: offline → live

--- a/frontend/src/player.ts
+++ b/frontend/src/player.ts
@@ -11,6 +11,20 @@ let flvPlayer: ReturnType<typeof flvjs.createPlayer> | null = null;
  * Initializes the appropriate video player based on platform
  */
 export function initializePlayer(): void {
+  if (config.stream.icecast) {
+    // Icecast mode (#176): one MP3 mount via native <audio>, works on every
+    // platform (iOS + desktop), so no flv.js / HLS branch is needed.
+    console.log('Icecast mode - using native <audio> MP3 player');
+    video = document.getElementById('player') as HTMLMediaElement;
+    if (video) {
+      video.addEventListener('error', () => {
+        console.log('Icecast stream error - stream may be offline');
+      });
+      video.src = config.stream.icecast;
+    }
+    return;
+  }
+
   if (isIOSDevice()) {
     console.log('Detected iOS - using native HLS player');
     video = document.getElementById('player') as HTMLMediaElement;
@@ -73,8 +87,9 @@ export function destroyPlayer(): void {
 
   if (video) {
     video.pause();
-    // For HLS (iOS), clear the source
-    if (isIOSDevice()) {
+    // For HLS (iOS) and Icecast (<audio>), clear the source so we don't hold
+    // the connection / play dead air after the show ends.
+    if (isIOSDevice() || config.stream.icecast) {
       video.removeAttribute('src');
       video.load();
     }

--- a/frontend/src/streamDetector.ts
+++ b/frontend/src/streamDetector.ts
@@ -2,12 +2,16 @@
  * Detects if the current platform is iOS
  */
 export function isIOSDevice(): boolean {
-  const platform = (navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform || navigator?.platform || 'unknown';
+  const platform =
+    (navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform ||
+    navigator?.platform ||
+    'unknown';
   return /iPhone|iPod|iPad/.test(platform);
 }
 
 /**
- * Checks if the stream is currently live by making a HEAD request
+ * Checks if the stream is currently live by making a HEAD request.
+ * Used for the legacy NMS path (HLS mount exists only while broadcasting).
  */
 export async function checkStreamStatus(url: string): Promise<boolean> {
   try {
@@ -15,6 +19,27 @@ export async function checkStreamStatus(url: string): Promise<boolean> {
     return response.status === 200;
   } catch (error) {
     console.error('Stream status check error:', error);
+    return false;
+  }
+}
+
+/**
+ * Checks live status via the backend's authoritative on-air endpoint
+ * (`GET /api/stream/status` → `{ active: boolean }`).
+ *
+ * Required in Icecast mode: the public mount is mksafe-backed and therefore
+ * always up (serves silence between shows), so — unlike the NMS HLS mount —
+ * its existence can't distinguish "live" from "dead air". The backend knows
+ * the real state because the broadcaster streams in over its WebSocket.
+ */
+export async function checkBackendLive(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: 'GET' });
+    if (!response.ok) return false;
+    const data = (await response.json()) as { active?: boolean };
+    return data.active === true;
+  } catch (error) {
+    console.error('Backend stream status check error:', error);
     return false;
   }
 }


### PR DESCRIPTION
## What
- Opt-in **Icecast** path for the public player, switchable by env var (no code deploy).
- `VITE_STREAM_ICECAST_URL` set → stream the single `/live.mp3` mount via native `<audio>` on **all** platforms (iOS + desktop), bypassing the NMS HLS + flv.js split.
- `VITE_STREAM_STATUS_URL` → live detection via the backend's authoritative `GET /api/stream/status` `{ active }`.
- Unit tests for both detectors; both new vars documented in `.env.example`.

## Why
Phase-3 cutover (#176, umbrella #194) requires flipping the public site from the NMS relay to the new Icecast/Liquidsoap mount **as an env change during a show, not a redeploy**, with instant rollback. Empty vars = current NMS HLS/FLV behaviour, so this is a **no-op until the env is set** — safe to merge now.

## How
- `config.stream.icecast` / `config.stream.statusUrl` added (default `''`).
- `player.ts`: Icecast branch drives the existing `#player` `<audio>` element for every platform; clears `src` on offline so it doesn't hold the connection / play dead air.
- `main.ts`: `isLive()` selects backend-status poll (Icecast) vs legacy HLS HEAD poll.
- **Why a backend status poll, not the mount itself:** the public mount is `mksafe`-backed (always up, serves silence between shows), so — unlike the NMS HLS mount — its presence can't tell "live" from "dead air". The backend knows because the broadcaster streams in over its WebSocket. CORS is already `Any`, so the GitHub-Pages origin can call it.

## Test plan
- [x] `vitest run` — 8/8 (checkStreamStatus + checkBackendLive: live/offline/missing/non-ok/reject)
- [x] `eslint` clean, `npm run build` green
- [ ] Post-merge, with Icecast stack up: set both vars → desktop + iPhone Safari play `/live.mp3`; "Live now/Off air" tracks the backend on-air state; going off-air stops playback

## Risk
**Low.** Frontend-only, fully behind empty-by-default env vars (no behaviour change until cutover). Rollback = unset the vars (or revert). Repo-wide `vue-tsc` typecheck is pre-existing-broken on a clean tree; validated via `build` + `lint` per project note.
