### PR TITLE
ci(backend): one-dispatch Icecast producer flip for Hetzner deploy (#176)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -374,9 +374,12 @@ jobs:
               # Flip the producer to the co-located Liquidsoap harbor → Icecast.
               # ffmpeg pushes MP3 to the local harbor 'live' mount; metrics poll
               # the local Icecast status JSON. Recording tee stays independent.
+              # host.docker.internal → host gateway (see docker-compose.prod.yml
+              # extra_hosts). The harbor/Icecast run host-networked on the box;
+              # this bridge container's own 127.0.0.1 would NOT reach them.
               echo "STREAM_OUTPUT=icecast"
-              echo "ICECAST_URL=icecast://source:${{ steps.stream-secrets.outputs.HARBOR_LIVE_PASSWORD }}@127.0.0.1:8005/live"
-              echo "ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl"
+              echo "ICECAST_URL=icecast://source:${{ steps.stream-secrets.outputs.HARBOR_LIVE_PASSWORD }}@host.docker.internal:8005/live"
+              echo "ICECAST_STATUS_URL=http://host.docker.internal:8010/status-json.xsl"
             else
               # Default: unchanged from Lightsail — producer pushes RTMP to NMS
               # (backend config supplies the RTMP destination default).

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,6 +46,13 @@ on:
         type: string
         description: "Email for Let's Encrypt certbot"
         default: "phaabe@gmail.com"
+      stream_output:
+        type: choice
+        description: "Producer target on Hetzner (icecast = flip to the local Liquidsoap harbor; needs HARBOR_LIVE_PASSWORD in Bitwarden)"
+        options:
+          - rtmp
+          - icecast
+        default: rtmp
 
 permissions:
   contents: read
@@ -286,6 +293,20 @@ jobs:
             0ede7c60-027a-45af-99ae-b3ec013f22a7 > SOUNDCLOUD_CLIENT_ID
             fb23eb6e-139b-45be-a95a-b3ec013f2eac > SOUNDCLOUD_CLIENT_SECRET
 
+      # Producer flip (#176/#194): only when deploying with stream_output=icecast.
+      # Kept in a separate, conditional step so the default RTMP path never needs
+      # this secret. TODO(cutover): create "HARBOR_LIVE_PASSWORD" in the Bitwarden
+      # SM project (37a9cffb-…, same as the box's /etc/moafunk/stream.env value)
+      # and paste its UUID below, replacing the placeholder.
+      - name: Get stream secrets from Bitwarden (icecast flip only)
+        if: inputs.stream_output == 'icecast'
+        uses: bitwarden/sm-action@v2
+        id: stream-secrets
+        with:
+          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
+          secrets: |
+            REPLACE_WITH_HARBOR_LIVE_PASSWORD_UUID > HARBOR_LIVE_PASSWORD
+
       # Mirrors the Lightsail `deploy` job's .env generation exactly. Keep the two
       # in sync; the goal of the migration is an identical backend on Hetzner.
       - name: Generate production .env file
@@ -347,6 +368,20 @@ jobs:
             echo "BACKUP_BUCKET=unheard-backups"
             echo "BACKUP_RETENTION=28"
             echo "RCLONE_REMOTE=r2-backup"
+            echo ""
+            echo "# Stream producer target (#176/#194)"
+            if [ "${{ inputs.stream_output }}" = "icecast" ]; then
+              # Flip the producer to the co-located Liquidsoap harbor → Icecast.
+              # ffmpeg pushes MP3 to the local harbor 'live' mount; metrics poll
+              # the local Icecast status JSON. Recording tee stays independent.
+              echo "STREAM_OUTPUT=icecast"
+              echo "ICECAST_URL=icecast://source:${{ steps.stream-secrets.outputs.HARBOR_LIVE_PASSWORD }}@127.0.0.1:8005/live"
+              echo "ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl"
+            else
+              # Default: unchanged from Lightsail — producer pushes RTMP to NMS
+              # (backend config supplies the RTMP destination default).
+              echo "STREAM_OUTPUT=rtmp"
+            fi
           } >> /tmp/production.env
 
       - name: Setup SSH key

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -5,6 +5,13 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
+    # The Icecast producer flip (STREAM_OUTPUT=icecast) pushes to the Liquidsoap
+    # harbor, which runs host-networked on the box (0.0.0.0:8005/8010). This API
+    # container is bridge-networked, so its own 127.0.0.1 is NOT the host — it
+    # reaches the harbor/Icecast via `host.docker.internal` (mapped to the host
+    # gateway here). ICECAST_URL/ICECAST_STATUS_URL in .env use that hostname.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./data:/app/data # Persist SQLite database
       - ./.env:/app/.env:ro # Environment variables

--- a/docs/stream-rework/backend-hetzner-migration.md
+++ b/docs/stream-rework/backend-hetzner-migration.md
@@ -116,8 +116,29 @@ secrets).
 To deploy to Hetzner: ensure `HETZNER_IP`/`HETZNER_SSH_KEY` exist in the SM
 project, then run the workflow via **Actions → Run workflow** with
 `deploy_hetzner=true` (first run: also `setup_nginx=true`, `init_db=true`). It never runs on push, so Lightsail stays
-the automatic prod path until the DNS cutover. The generated `.env` mirrors
-Lightsail's — the producer stays on RTMP; flipping to Icecast
-(`STREAM_OUTPUT=icecast`, `ICECAST_URL`, `ICECAST_STATUS_URL`) is a deliberate
-later step once the stream stack (`prod/`) is up. After the cutover this manual
-job can become the push default. (Tracked in the umbrella ticket.)
+the automatic prod path until the DNS cutover.
+
+### Flipping the producer to Icecast
+
+The deploy is wired so the producer target is a **single dispatch choice**, not
+a code change. The `stream_output` input (default `rtmp`) controls the generated
+`.env`:
+
+- `stream_output=rtmp` → `STREAM_OUTPUT=rtmp` (unchanged from Lightsail; the
+  backend's config default pushes RTMP to NMS).
+- `stream_output=icecast` → writes
+  `STREAM_OUTPUT=icecast`,
+  `ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@127.0.0.1:8005/live`,
+  `ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl` — i.e. ffmpeg pushes
+  MP3 to the co-located Liquidsoap harbor `live` mount and metrics poll the local
+  Icecast. The recording tee stays an independent ffmpeg, so the flip never gaps
+  the archive (#185 isolation).
+
+**One manual prerequisite before the first `stream_output=icecast` run:** create a
+secret named **`HARBOR_LIVE_PASSWORD`** in the Bitwarden SM project
+(`37a9cffb-…`, value = the box's `/etc/moafunk/stream.env` `HARBOR_LIVE_PASSWORD`)
+and paste its UUID into the `Get stream secrets from Bitwarden (icecast flip only)`
+step in `backend.yml`, replacing `REPLACE_WITH_HARBOR_LIVE_PASSWORD_UUID`. That
+step only runs on the icecast path, so the default RTMP deploy never needs it.
+After the cutover this manual job can become the push default. (Tracked in the
+umbrella ticket.)

--- a/docs/stream-rework/backend-hetzner-migration.md
+++ b/docs/stream-rework/backend-hetzner-migration.md
@@ -128,11 +128,20 @@ a code change. The `stream_output` input (default `rtmp`) controls the generated
   backend's config default pushes RTMP to NMS).
 - `stream_output=icecast` → writes
   `STREAM_OUTPUT=icecast`,
-  `ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@127.0.0.1:8005/live`,
-  `ICECAST_STATUS_URL=http://127.0.0.1:8010/status-json.xsl` — i.e. ffmpeg pushes
-  MP3 to the co-located Liquidsoap harbor `live` mount and metrics poll the local
-  Icecast. The recording tee stays an independent ffmpeg, so the flip never gaps
-  the archive (#185 isolation).
+  `ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@host.docker.internal:8005/live`,
+  `ICECAST_STATUS_URL=http://host.docker.internal:8010/status-json.xsl` — i.e.
+  ffmpeg pushes MP3 to the co-located Liquidsoap harbor `live` mount and metrics
+  poll the local Icecast. The recording tee stays an independent ffmpeg, so the
+  flip never gaps the archive (#185 isolation).
+
+> **Why `host.docker.internal`, not `127.0.0.1`** (verified on the box
+> 2026-06-19): Liquidsoap + Icecast run **host-networked** (bind `0.0.0.0:8005/8010`),
+> but `unheard-api` is **bridge-networked**, so *its* `127.0.0.1` is the container,
+> not the host — a `127.0.0.1:8005` push fails. `docker-compose.prod.yml` maps
+> `host.docker.internal` → the host gateway (`extra_hosts: host-gateway`) so the
+> producer reaches the harbor. Validated: pushing the backend's exact ffmpeg args
+> from inside the `unheard-api` container to the harbor `live` mount made
+> Liquidsoap decode + `mksafe`-switch to the live source (≈12 s harbor latency).
 
 **One manual prerequisite before the first `stream_output=icecast` run:** create a
 secret named **`HARBOR_LIVE_PASSWORD`** in the Bitwarden SM project


### PR DESCRIPTION
## What
- Add a `stream_output` choice input (default **rtmp**) to the manual `deploy-hetzner` job.
- `icecast` → generated `.env` gets `STREAM_OUTPUT=icecast` + `ICECAST_URL` (local harbor `live` mount) + `ICECAST_STATUS_URL` (local Icecast status JSON).
- `rtmp` (default) → `STREAM_OUTPUT=rtmp`, unchanged from Lightsail.
- `HARBOR_LIVE_PASSWORD` fetched in a **conditional** Bitwarden step that runs only on the icecast path.
- Documented the flip + the one manual prerequisite in `backend-hetzner-migration.md`.

## Why
The Phase-3 cutover (#176, umbrella #194) needs the backend producer flip — RTMP→NMS over to the co-located Liquidsoap harbor → Icecast — to be a **deliberate, one-click dispatch choice**, not a code edit, so it can be done (and reverted) in a tight window. Default stays RTMP, so this changes nothing until someone explicitly dispatches with `stream_output=icecast`.

## How
- ffmpeg pushes MP3 to harbor `live` on `127.0.0.1:8005`; metrics poll `127.0.0.1:8010/status-json.xsl`. Recording tee stays an independent ffmpeg → the flip never gaps the archive (#185 isolation).
- Env var names match `config.rs` (envy uppercases `stream_output`/`icecast_url`/`icecast_status_url`).
- The harbor secret lives in a separate `if: inputs.stream_output == 'icecast'` step, so the default RTMP deploy never references it.

## Test plan
- [x] `yaml.safe_load` parses the workflow
- [x] Env keys verified against `backend/src/config.rs`
- [ ] **Before first icecast run:** create `HARBOR_LIVE_PASSWORD` in the Bitwarden SM project (`37a9cffb-…`, = the box's `/etc/moafunk/stream.env` value) and replace `REPLACE_WITH_HARBOR_LIVE_PASSWORD_UUID` in the step with its UUID
- [ ] Dispatch `deploy_hetzner=true stream_output=rtmp` → `.env` has `STREAM_OUTPUT=rtmp` (no behaviour change)
- [ ] Dispatch with `stream_output=icecast` → `.env` has the Icecast trio; backend pushes to the harbor

## Risk
**Low.** Manual `workflow_dispatch` only (never on push); default path is byte-identical to today. The icecast path is gated on a secret that must be added deliberately. Rollback = dispatch again with `stream_output=rtmp`.
