### PR TITLE
ci(backend): wire HARBOR_LIVE_PASSWORD UUID for the icecast flip (#176)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -295,9 +295,9 @@ jobs:
 
       # Producer flip (#176/#194): only when deploying with stream_output=icecast.
       # Kept in a separate, conditional step so the default RTMP path never needs
-      # this secret. TODO(cutover): create "HARBOR_LIVE_PASSWORD" in the Bitwarden
-      # SM project (37a9cffb-…, same as the box's /etc/moafunk/stream.env value)
-      # and paste its UUID below, replacing the placeholder.
+      # this secret. HARBOR_LIVE_PASSWORD lives in the Bitwarden SM project
+      # alongside the box's /etc/moafunk/stream.env value; keep the two in sync
+      # whenever the harbor password is rotated.
       - name: Get stream secrets from Bitwarden (icecast flip only)
         if: inputs.stream_output == 'icecast'
         uses: bitwarden/sm-action@v2
@@ -305,7 +305,7 @@ jobs:
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
-            REPLACE_WITH_HARBOR_LIVE_PASSWORD_UUID > HARBOR_LIVE_PASSWORD
+            ea873605-a662-4a0f-99a9-b46e011fc8d6 > HARBOR_LIVE_PASSWORD
 
       # Mirrors the Lightsail `deploy` job's .env generation exactly. Keep the two
       # in sync; the goal of the migration is an identical backend on Hetzner.


### PR DESCRIPTION
## What
Replace the `REPLACE_WITH_HARBOR_LIVE_PASSWORD_UUID` placeholder in the `deploy-hetzner` job with the real Bitwarden SM UUID for `HARBOR_LIVE_PASSWORD`.

## Why
The stream secrets now exist in Bitwarden SM. With the UUID wired, `deploy-hetzner` with `stream_output=icecast` can fetch the harbor password and generate `ICECAST_URL` — the producer flip is now a single dispatch with no further setup.

## How
- The fetch stays in the conditional `if: inputs.stream_output == 'icecast'` step, so the **default RTMP deploy never touches it**.
- UUIDs are identifiers (not secrets) — same pattern as the existing secret UUIDs in this file.

## Test plan
- [x] YAML parses
- [ ] Dispatch `deploy_hetzner=true stream_output=icecast` → `.env` has `ICECAST_URL=…@host.docker.internal:8005/live` with the real password

## Risk
**Low.** Manual `workflow_dispatch` path only; default RTMP unaffected. Merging this triggers the push-deploy to Lightsail (brief prod backend restart), but the change itself is inert there.
