### PR TITLE
feat(infra): stream observability stack — Prometheus/Alertmanager/Blackbox (#178)

### DIFF
--- a/docs/stream-rework/prod/monitoring/.gitignore
+++ b/docs/stream-rework/prod/monitoring/.gitignore
@@ -1,0 +1,3 @@
+# Deploy-time secrets — never commit
+monitoring.env
+alertmanager/alertmanager.yml

--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -1,0 +1,76 @@
+# Stream observability stack (issue #178, Phase 4 of #164)
+
+Prometheus + Alertmanager + Blackbox + `icecast_exporter` (+ Grafana), supervised
+by systemd via docker compose. Monitors the Icecast-KH/Liquidsoap stack and pages
+to the project Telegram bot. **All UIs/metrics ports bind to `127.0.0.1`** — never
+exposed publicly.
+
+```
+blackbox ── GET /live.mp3 (synthetic "can listeners reach the stream?") ─┐
+icecast_exporter ── Icecast /status-json.xsl (listeners, sources) ───────┤─▶ Prometheus ─▶ Alertmanager ─▶ Telegram
+                                                                          │        └─▶ Grafana (127.0.0.1:3000)
+```
+
+## What it alerts on (and the #178 landmine)
+
+| Alert | Expr (severity) | Meaning |
+|-------|-----------------|---------|
+| `StreamProbeDown` | `probe_success{job="blackbox_stream"} == 0` for 5m (**critical**) | public mount unreachable — the canonical "stream down" |
+| `IcecastExporterDown` | `up{job="icecast"} == 0` for 5m (**critical**) | Icecast/exporter scrape failing |
+| `IcecastNoSource` | `icecast_sources == 0` for 10m (**critical**) | Liquidsoap stopped feeding Icecast |
+| `StreamZeroListenersProlonged` | `sum(icecast_listeners) == 0` for 1h (**info**) | informational only (normal between shows) |
+| `StreamProbeAbsent` | `absent(probe_success{...})` for 10m (**warning**) | monitoring itself is broken |
+
+**Never** write `... or on() vector(0)` in an alert expr — `vector(0)` is always
+present and `< 1`, so the rule fires forever. "stream-down" and "zero-listeners"
+are deliberately **separate** alerts; absence uses `absent()` / `up == 0`. (That
+`or vector(0)` trick is only for Grafana panels.)
+
+## Deploy (on the box)
+
+> Runs upstream images (`prom/*`, `markuslindenberg/icecast_exporter`, `grafana/grafana`).
+> Place this dir at `/etc/moafunk/monitoring`.
+
+```bash
+cd /etc/moafunk/monitoring
+cp monitoring.env.example monitoring.env      # fill TELEGRAM_*, GRAFANA_* from Bitwarden
+cp monitoring.service /etc/systemd/system/
+systemctl daemon-reload && systemctl enable --now monitoring   # renders alertmanager.yml + compose up
+```
+
+## Verify (FIRST DEPLOY — reconcile metric names)
+
+`icecast_exporter` metric names can differ by version. After it's up:
+
+```bash
+curl -s localhost:9146/metrics | grep ^icecast_      # confirm icecast_sources / icecast_listeners
+curl -s 'localhost:9090/api/v1/rules' | jq '.. .health? // empty' | sort -u   # all "ok"
+curl -s localhost:9090/api/v1/query?query=probe_success | jq '.data.result'   # blackbox probing the mount
+```
+
+If the exporter's names differ from `icecast_sources` / `icecast_listeners`,
+update `prometheus/rules/stream-alerts.yml` (the `StreamProbeDown` alert needs no
+change — it's blackbox-based). Then `systemctl reload`/restart `monitoring`.
+
+Test the page path: `systemctl stop liquidsoap` (or block the mount) → after 5m
+`StreamProbeDown` should fire exactly once to Telegram; restart → it resolves.
+
+UIs (localhost only) — reach via SSH tunnel, e.g.
+`ssh -L 9090:localhost:9090 -L 3000:localhost:3000 root@<box>`.
+
+## Already done elsewhere (don't duplicate)
+
+- **systemd `Restart=always` + memory cap** for Liquidsoap and Icecast-KH: in
+  `../liquidsoap.service` / `../icecast.service` (docker `--memory`).
+
+## TODO / follow-ups (out of scope here)
+
+- **Backend Prometheus metrics**: the backend exposes only `GET /api/stream/metrics`
+  (JSON). For recording-failure alerts (`r2_upload_failures_total`, tee restarts,
+  byte-rate stalls) it needs a `/metrics` endpoint — a separate backend change.
+- **Dead-air / silence (EBU-R128) probe**: byte/listener metrics look nominal
+  during silence; add a loudness tap for true dead-air alerting.
+- **SPOF / CDN**: put a CDN or Icecast-KH master→relay in front of the public
+  mount (~300 listeners ≈ 38 Mbps off one box). Higher-leverage, bigger change.
+- **"show-scheduled" signal** to gate `StreamZeroListenersProlonged` so it only
+  matters when a show is on the calendar.

--- a/docs/stream-rework/prod/monitoring/alertmanager/alertmanager.yml.tmpl
+++ b/docs/stream-rework/prod/monitoring/alertmanager/alertmanager.yml.tmpl
@@ -1,0 +1,38 @@
+# Alertmanager config TEMPLATE (#178) — delivers to the project Telegram bot.
+# Alertmanager does NOT expand env vars, so render this to alertmanager.yml at
+# deploy:  set -a; . monitoring.env; set +a; envsubst < alertmanager.yml.tmpl > alertmanager.yml
+# The rendered alertmanager.yml contains the bot token → it is gitignored.
+# Token + chat id reuse the project bot (Bitwarden: TELEGRAM_BOT_TOKEN/TELEGRAM_ADMIN_CHAT_ID).
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: telegram
+  group_by: ["alertname"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  routes:
+    # Info-level (e.g. prolonged zero-listeners) → still Telegram but rarely repeats.
+    - matchers: ['severity = "info"']
+      receiver: telegram
+      repeat_interval: 24h
+
+receivers:
+  - name: telegram
+    telegram_configs:
+      - bot_token: "${TELEGRAM_BOT_TOKEN}"
+        chat_id: ${TELEGRAM_ADMIN_CHAT_ID}
+        parse_mode: HTML
+        send_resolved: true
+        message: |
+          <b>{{ .Status | toUpper }}</b> {{ .CommonLabels.alertname }} ({{ .CommonLabels.severity }})
+          {{ range .Alerts }}{{ .Annotations.summary }}
+          {{ .Annotations.description }}
+          {{ end }}
+
+inhibit_rules:
+  # If the stream is down, don't also page about zero listeners.
+  - source_matchers: ['alertname = "StreamProbeDown"']
+    target_matchers: ['alertname = "StreamZeroListenersProlonged"']
+    equal: ["instance"]

--- a/docs/stream-rework/prod/monitoring/blackbox/blackbox.yml
+++ b/docs/stream-rework/prod/monitoring/blackbox/blackbox.yml
@@ -1,0 +1,16 @@
+# Blackbox exporter modules (#178).
+modules:
+  # Probe an Icecast MP3 mount. MUST use GET — Icecast answers HEAD with 400,
+  # which would make the probe permanently fail. A live mount returns 200 with
+  # an audio/mpeg body; we accept 200 and the mpeg content-type.
+  icecast_mp3:
+    prober: http
+    timeout: 8s
+    http:
+      method: GET
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      fail_if_not_ssl: false   # local mount is plain http; public probe is https
+      preferred_ip_protocol: ip4
+      # Don't pull the whole stream — a short read is enough to confirm 200.
+      no_follow_redirects: false

--- a/docs/stream-rework/prod/monitoring/docker-compose.monitoring.yml
+++ b/docs/stream-rework/prod/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,81 @@
+# Observability stack for the stream (issue #178, Phase 4 of #164).
+#
+# Prometheus + Alertmanager + Blackbox + icecast_exporter (+ optional Grafana),
+# all on a private bridge net. UIs bind to 127.0.0.1 ONLY — never expose these
+# publicly (admin/metrics ports are not authenticated for the internet).
+#
+# The exporters reach the host-networked stream stack (Icecast :8010, the public
+# mount) via host.docker.internal. Inter-service scrapes use compose DNS.
+#
+# Deploy (on the box):
+#   cp monitoring.env.example monitoring.env   # fill Telegram + stream URL
+#   docker compose --env-file monitoring.env -f docker-compose.monitoring.yml up -d
+# (or via monitoring.service). First run: verify icecast_* metric names at
+#   curl -s localhost:9146/metrics | grep ^icecast_
+# and reconcile prometheus/rules/stream-alerts.yml if they differ.
+name: moafunk-monitoring
+
+x-extra-hosts: &host-gw
+  - "host.docker.internal:host-gateway"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=30d
+    volumes:
+      - ./prometheus:/etc/prometheus:ro
+      - prom-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"   # UI/API — localhost only
+    extra_hosts: *host-gw
+    depends_on: [icecast-exporter, blackbox-exporter, alertmanager]
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+    # alertmanager.yml is rendered from alertmanager.yml.tmpl at deploy (envsubst
+    # injects the Telegram token) and is gitignored. See README.
+    volumes:
+      - ./alertmanager:/etc/alertmanager:ro
+      - am-data:/alertmanager
+    ports:
+      - "127.0.0.1:9093:9093"
+
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/blackbox/blackbox.yml
+    volumes:
+      - ./blackbox:/etc/blackbox:ro
+    extra_hosts: *host-gw     # so it can probe the local mount pre-cutover
+
+  icecast-exporter:
+    image: markuslindenberg/icecast_exporter:latest
+    restart: unless-stopped
+    command:
+      - -icecast.scrape-uri=${ICECAST_STATUS_URI:-http://host.docker.internal:8010/status-json.xsl}
+    extra_hosts: *host-gw     # reach the host-networked Icecast on :8010
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"   # localhost only; tunnel via SSH to view
+    depends_on: [prometheus]
+
+volumes:
+  prom-data:
+  am-data:
+  grafana-data:

--- a/docs/stream-rework/prod/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/docs/stream-rework/prod/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+# Grafana auto-provisioned Prometheus datasource (#178).
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docs/stream-rework/prod/monitoring/monitoring.env.example
+++ b/docs/stream-rework/prod/monitoring/monitoring.env.example
@@ -1,0 +1,12 @@
+# Copy to monitoring.env (gitignored) and fill. Used by docker compose --env-file
+# and by the alertmanager template render (envsubst). Source from Bitwarden SM.
+
+# Telegram alert delivery — reuse the project bot (same as the backend).
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ADMIN_CHAT_ID=
+
+# Icecast status URI the exporter scrapes (host-net Icecast on the box).
+ICECAST_STATUS_URI=http://host.docker.internal:8010/status-json.xsl
+
+# Grafana admin password (UI bound to 127.0.0.1; reach via SSH tunnel).
+GRAFANA_ADMIN_PASSWORD=

--- a/docs/stream-rework/prod/monitoring/monitoring.service
+++ b/docs/stream-rework/prod/monitoring/monitoring.service
@@ -1,0 +1,28 @@
+# Stream observability stack (#178) — Prometheus/Alertmanager/Blackbox/
+# icecast_exporter/Grafana via docker compose, supervised by systemd.
+#
+# Install (on the box), assuming this dir lives at /etc/moafunk/monitoring:
+#   cd /etc/moafunk/monitoring
+#   cp monitoring.env.example monitoring.env   # fill from Bitwarden
+#   set -a; . monitoring.env; set +a
+#   envsubst < alertmanager/alertmanager.yml.tmpl > alertmanager/alertmanager.yml
+#   cp monitoring.service /etc/systemd/system/
+#   systemctl daemon-reload && systemctl enable --now monitoring
+[Unit]
+Description=Moafunk stream observability stack (Prometheus/Alertmanager/Blackbox)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=/etc/moafunk/monitoring
+# Re-render the alertmanager config from the template each start (picks up token
+# rotations in monitoring.env). envsubst ships in gettext-base.
+ExecStartPre=/bin/bash -c 'set -a; . monitoring.env; set +a; envsubst < alertmanager/alertmanager.yml.tmpl > alertmanager/alertmanager.yml'
+ExecStart=/usr/bin/docker compose --env-file monitoring.env -f docker-compose.monitoring.yml up -d
+ExecStop=/usr/bin/docker compose -f docker-compose.monitoring.yml down
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,46 @@
+# Prometheus config for the stream observability stack (#178).
+# Scrapes: icecast_exporter (Icecast stats), blackbox (synthetic stream probe),
+# and itself. All metrics/admin ports are localhost-bound (see compose).
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Icecast stats via markuslindenberg/icecast_exporter (icecast_* metrics).
+  - job_name: icecast
+    static_configs:
+      - targets: ["icecast-exporter:9146"]
+
+  # Synthetic probe of the PUBLIC stream mount — independent of server metrics,
+  # so it catches "listeners can't reach the stream" even if the box looks fine.
+  # GET (never HEAD — Icecast 400s on HEAD); see blackbox.yml module icecast_mp3.
+  # Prometheus does NOT expand env vars in this file — edit the target directly.
+  # Pre-cutover: the local mount (below). Post-cutover: change to the public TLS
+  # URL, e.g. https://radio.live.moafunk.de/live.mp3 (then the probe is truly
+  # end-to-end through the proxy).
+  - job_name: blackbox_stream
+    metrics_path: /probe
+    params:
+      module: [icecast_mp3]
+    static_configs:
+      - targets:
+          - http://host.docker.internal:8010/live.mp3
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
@@ -1,0 +1,72 @@
+# Stream alert rules (#178).
+#
+# DESIGN NOTE (the #178 landmine): NEVER write `... or on() vector(0)` inside an
+# alert expression. `vector(0)` is always present and compares `< 1`, so such a
+# rule fires PERMANENTLY. That trick is for Grafana *panels* (to show 0 when no
+# data), not for alerts. Here "stream-down" and "zero-listeners" are kept as
+# SEPARATE alerts, and absence is handled with `absent()` / `up == 0`, never
+# `or vector(0)`.
+#
+# "stream-down" is intentionally driven by the Blackbox probe (probe_success),
+# which is exporter-agnostic and certain — it fires regardless of the icecast_*
+# metric names. The icecast_*-based rules are best-effort detail; VERIFY their
+# metric names against `curl localhost:9146/metrics | grep ^icecast_` on first
+# deploy and adjust if the exporter names differ.
+groups:
+  - name: stream-availability
+    rules:
+      # The canonical "stream is down" alert: the public mount is unreachable.
+      # Independent of server-side metrics — proves listeners can't get audio.
+      - alert: StreamProbeDown
+        expr: probe_success{job="blackbox_stream"} == 0
+        for: 5m
+        labels: { severity: critical }
+        annotations:
+          summary: "Public stream mount unreachable"
+          description: "Blackbox GET probe of {{ $labels.instance }} has failed for 5m. Listeners cannot reach the stream."
+
+      # The Blackbox probe target itself stopped being scraped (Prometheus can't
+      # even run the probe) — distinct from the probe failing.
+      - alert: StreamProbeAbsent
+        expr: absent(probe_success{job="blackbox_stream"})
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "Stream probe metric absent"
+          description: "No probe_success samples for blackbox_stream — Blackbox/Prometheus scrape is broken; stream health is unknown."
+
+  - name: icecast-source
+    rules:
+      # Icecast stats scrape is down (exporter unreachable or Icecast dead).
+      - alert: IcecastExporterDown
+        expr: up{job="icecast"} == 0
+        for: 5m
+        labels: { severity: critical }
+        annotations:
+          summary: "Icecast exporter/scrape down"
+          description: "Prometheus cannot scrape icecast_exporter for 5m — Icecast may be down or the exporter cannot reach it."
+
+      # No source connected to Icecast. With mksafe the Liquidsoap source is
+      # always connected, so 0 sources means Liquidsoap died → real outage.
+      # VERIFY metric name on deploy (icecast_sources is the expected name).
+      - alert: IcecastNoSource
+        expr: icecast_sources == 0
+        for: 10m
+        labels: { severity: critical }
+        annotations:
+          summary: "No source connected to Icecast"
+          description: "icecast_sources == 0 for 10m — Liquidsoap is not feeding Icecast (mksafe should keep a source connected at all times)."
+
+  - name: stream-listeners
+    rules:
+      # SEPARATE, low-severity, slow alert — NOT coupled to stream-down. Because
+      # mksafe keeps the mount up during dead air, 0 listeners is normal between
+      # shows; this is informational. Gate it on a "show-scheduled" signal once
+      # the backend exposes one (TODO #178). Kept long (1h) to avoid noise.
+      - alert: StreamZeroListenersProlonged
+        expr: sum(icecast_listeners) == 0
+        for: 1h
+        labels: { severity: info }
+        annotations:
+          summary: "No stream listeners for 1h"
+          description: "sum(icecast_listeners) == 0 for 1h. Informational — expected between shows; investigate only if a show is scheduled. (VERIFY metric name on deploy.)"


### PR DESCRIPTION
## What
Phase-4 observability for the stream stack (#178), as a systemd-supervised docker compose under `docs/stream-rework/prod/monitoring/`:
- **Prometheus** + **Alertmanager** + **Blackbox** + **`icecast_exporter`** + **Grafana** (provisioned Prometheus datasource).
- Alert rules: `StreamProbeDown` (blackbox), `IcecastExporterDown`, `IcecastNoSource`, `StreamZeroListenersProlonged` (info), `StreamProbeAbsent`.
- Alertmanager → the project Telegram bot.

## Why
Phase 4 of #164: monitoring + alerting + SPOF hardening. The blackbox probe gives a server-independent "can listeners reach the stream?" signal — the canonical stream-down alert.

## Key design points
- **All UIs/metrics bind `127.0.0.1`** — never public (reach via SSH tunnel).
- **No `or on() vector(0)`** in any alert (that fires forever — Grafana-panel-only trick). Stream-down and zero-listeners are **separate** alerts; absence via `absent()`/`up==0`.
- Blackbox probes with **GET** (Icecast 400s on HEAD).
- Telegram token injected via `envsubst` at deploy; rendered `alertmanager.yml` is **gitignored**.
- Reliability hardening (`Restart=always` + `--memory`) already shipped in the `liquidsoap`/`icecast` service units.

## Test plan
- [x] All YAML valid; alert rules structurally checked; no `or vector(0)` anti-pattern
- [ ] **On first box deploy:** `promtool`/`/api/v1/rules` health=ok; reconcile `icecast_*` metric names (`curl :9146/metrics`); blackbox `probe_success` present; stop Liquidsoap → exactly one `StreamProbeDown` to Telegram, resolves on restart

## Risk
**Low / not yet deployed.** Repo config only. Deploying runs upstream images (`prom/*`, `markuslindenberg/icecast_exporter`, `grafana/grafana`) on the box — a deliberate step needing a go-ahead. Follow-ups noted in the README (backend `/metrics`, EBU-R128 dead-air probe, CDN/relay SPOF).
