### PR TITLE
feat(recording): expose Prometheus /metrics for recording durability (#178)

### DIFF
--- a/backend/scripts/deploy_hetzner.sh
+++ b/backend/scripts/deploy_hetzner.sh
@@ -390,6 +390,13 @@ server {
 
   client_max_body_size 260m;
 
+  # The backend's Prometheus endpoint is unauthenticated and meant for the
+  # local monitoring stack only (scraped container-to-container, not via nginx).
+  # Never expose it on the public vhost.
+  location = /metrics {
+    return 404;
+  }
+
   location / {
     proxy_pass http://127.0.0.1:8000;
     proxy_http_version 1.1;

--- a/backend/scripts/deploy_lightsail.sh
+++ b/backend/scripts/deploy_lightsail.sh
@@ -404,6 +404,12 @@ server {
 
   client_max_body_size 260m;
 
+  # The backend's Prometheus endpoint is unauthenticated and meant for a local
+  # monitoring stack only — never expose it on the public vhost.
+  location = /metrics {
+    return 404;
+  }
+
   location / {
     proxy_pass http://127.0.0.1:8000;
     proxy_http_version 1.1;

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -409,7 +409,10 @@ async fn upload_artifact_and_record(
         "audio/webm",
     )
     .await
-    .map_err(|e| AppError::Storage(format!("Failed to upload raw recording: {}", e)))?;
+    .map_err(|e| {
+        crate::metrics::inc_recording_r2_upload_failure();
+        AppError::Storage(format!("Failed to upload raw recording: {}", e))
+    })?;
 
     // Verify before delete: HEAD the object and confirm the size matches, and
     // sanity-check the duration against the scheduled show length (a recorder
@@ -427,6 +430,7 @@ async fn upload_artifact_and_record(
             local_size, remote_size
         );
         tracing::error!("{}", msg);
+        crate::metrics::inc_recording_size_mismatch();
         failure_reason.get_or_insert(msg);
     }
     if let Some(short) = detect_short_recording(state, show_id, local_duration_ms).await {
@@ -435,6 +439,9 @@ async fn upload_artifact_and_record(
     }
 
     let incomplete = failure_reason.is_some();
+    if incomplete {
+        crate::metrics::inc_recording_incomplete();
+    }
     tracing::info!(
         "Uploaded raw recording to {} ({} bytes, size_verified={}, duration_ms={:?})",
         raw_key,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,6 +7,7 @@ mod error;
 mod handlers;
 mod image_overlay;
 mod instagram;
+mod metrics;
 mod models;
 mod pdf;
 mod recording;
@@ -106,6 +107,31 @@ async fn stream_status_handler(State(state): State<Arc<AppState>>) -> impl IntoR
 async fn stream_metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let metrics = state.stream_metrics.read().await.clone();
     axum::Json(metrics)
+}
+
+/// Prometheus text-format metrics (#178). Exposes backend-internal recording/
+/// upload durability counters plus live stream/recording state and the cached
+/// Icecast snapshot. Unauthenticated by design — scraped only over the box's
+/// loopback by the local Prometheus; never expose this port publicly.
+async fn metrics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let snapshot = state.stream_metrics.read().await.clone();
+    let stream_active = state.stream_state.lock().await.is_active();
+    let recording_active = state.recording_manager.lock().await.is_recording();
+    let body = metrics::render(
+        &snapshot,
+        &metrics::Gauges {
+            stream_active,
+            recording_active,
+        },
+        chrono::Utc::now().timestamp_millis(),
+    );
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
 }
 
 async fn stream_stop_handler(
@@ -631,6 +657,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/stream/status", get(stream_status_handler))
         .route("/api/stream/metrics", get(stream_metrics_handler))
+        .route("/metrics", get(metrics_handler))
         .route("/api/stream/stop", post(stream_stop_handler))
         // Recording API for show recording with timecoded track markers
         .route("/api/recording/start", post(recording_start_handler))

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,0 +1,339 @@
+//! Prometheus text-format metrics (`GET /metrics`, issue #178).
+//!
+//! The external observability stack (Blackbox + `icecast_exporter`) can see the
+//! public mount and listener counts, but it is **blind to backend-internal
+//! durability failures**: a recorder whose tee queue overflowed, a segment
+//! concat that failed, or an R2 upload that never landed all leave the live
+//! mount looking perfectly healthy. This endpoint exposes those signals as
+//! Prometheus counters so #178 can alert on a *stuck recording*, not just a dead
+//! stream.
+//!
+//! Counters are process-global atomics (incremented at the failure sites, which
+//! don't all hold `AppState`); gauges are rendered from the live stream/recording
+//! state and the cached Icecast snapshot at scrape time.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
+
+use crate::stream_metrics::StreamMetrics;
+
+/// Process-global monotonic counters. One instance, lazily initialized.
+#[derive(Default)]
+pub struct Counters {
+    /// Tee chunks dropped because the recording queue was full (recorder/disk
+    /// too slow). Each increment means the archive for that show is incomplete.
+    pub recording_tee_dropped_total: AtomicU64,
+    /// The recording writer task stopped mid-stream (channel closed) → archive
+    /// abandoned for the rest of the show.
+    pub recording_writer_stopped_total: AtomicU64,
+    /// Segment concat (finalize) failed — segments exist on disk but the final
+    /// artifact could not be assembled.
+    pub recording_segment_concat_failures_total: AtomicU64,
+    /// A recording multipart upload to R2 failed (and was aborted). The local
+    /// file is kept (never deleted unverified).
+    pub recording_r2_upload_failures_total: AtomicU64,
+    /// Verify-before-delete found a local/remote size mismatch after upload.
+    pub recording_size_mismatch_total: AtomicU64,
+    /// A finalized recording was flagged incomplete for any reason (overflow,
+    /// concat failure, size mismatch, short duration).
+    pub recording_incomplete_total: AtomicU64,
+}
+
+static COUNTERS: LazyLock<Counters> = LazyLock::new(Counters::default);
+
+/// Access the process-global counters (mainly for tests/rendering).
+pub fn counters() -> &'static Counters {
+    &COUNTERS
+}
+
+// Named increment helpers — call these from the failure sites.
+pub fn inc_recording_tee_dropped() {
+    COUNTERS
+        .recording_tee_dropped_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+pub fn inc_recording_writer_stopped() {
+    COUNTERS
+        .recording_writer_stopped_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+pub fn inc_recording_segment_concat_failure() {
+    COUNTERS
+        .recording_segment_concat_failures_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+pub fn inc_recording_r2_upload_failure() {
+    COUNTERS
+        .recording_r2_upload_failures_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+pub fn inc_recording_size_mismatch() {
+    COUNTERS
+        .recording_size_mismatch_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+pub fn inc_recording_incomplete() {
+    COUNTERS
+        .recording_incomplete_total
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Live runtime state captured at scrape time for the gauge metrics.
+pub struct Gauges {
+    pub stream_active: bool,
+    pub recording_active: bool,
+}
+
+/// Escape a Prometheus label value (`\`, `"`, and newlines per the exposition
+/// format spec). Mount paths are tame, but escape defensively.
+fn escape_label(v: &str) -> String {
+    v.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+fn bool_gauge(out: &mut String, name: &str, help: &str, value: bool) {
+    out.push_str(&format!("# HELP {name} {help}\n# TYPE {name} gauge\n"));
+    out.push_str(&format!("{name} {}\n", if value { 1 } else { 0 }));
+}
+
+fn counter_line(out: &mut String, name: &str, help: &str, value: u64) {
+    out.push_str(&format!("# HELP {name} {help}\n# TYPE {name} counter\n"));
+    out.push_str(&format!("{name} {value}\n"));
+}
+
+/// Render the Prometheus exposition body. `now_ms` lets the poll-age gauge be
+/// computed deterministically (and tested).
+pub fn render(metrics: &StreamMetrics, gauges: &Gauges, now_ms: i64) -> String {
+    let c = counters();
+    let mut out = String::with_capacity(2048);
+
+    // ── Backend-internal durability counters (the point of this endpoint) ──
+    counter_line(
+        &mut out,
+        "moafunk_recording_tee_dropped_total",
+        "Recording tee chunks dropped due to a full queue (archive incomplete).",
+        c.recording_tee_dropped_total.load(Ordering::Relaxed),
+    );
+    counter_line(
+        &mut out,
+        "moafunk_recording_writer_stopped_total",
+        "Recording writer task stopped mid-stream (archive abandoned).",
+        c.recording_writer_stopped_total.load(Ordering::Relaxed),
+    );
+    counter_line(
+        &mut out,
+        "moafunk_recording_segment_concat_failures_total",
+        "Recording segment concat (finalize) failures.",
+        c.recording_segment_concat_failures_total
+            .load(Ordering::Relaxed),
+    );
+    counter_line(
+        &mut out,
+        "moafunk_recording_r2_upload_failures_total",
+        "Recording multipart uploads to R2 that failed and were aborted.",
+        c.recording_r2_upload_failures_total.load(Ordering::Relaxed),
+    );
+    counter_line(
+        &mut out,
+        "moafunk_recording_size_mismatch_total",
+        "Recording uploads where the verified remote size did not match local.",
+        c.recording_size_mismatch_total.load(Ordering::Relaxed),
+    );
+    counter_line(
+        &mut out,
+        "moafunk_recording_incomplete_total",
+        "Finalized recordings flagged incomplete for any reason.",
+        c.recording_incomplete_total.load(Ordering::Relaxed),
+    );
+
+    // ── Live state gauges ──
+    bool_gauge(
+        &mut out,
+        "moafunk_stream_active",
+        "1 when a live broadcast is currently being ingested.",
+        gauges.stream_active,
+    );
+    bool_gauge(
+        &mut out,
+        "moafunk_recording_active",
+        "1 when a recording session is currently active.",
+        gauges.recording_active,
+    );
+
+    // ── Icecast snapshot (mirrors the cached /api/stream/metrics poll) ──
+    bool_gauge(
+        &mut out,
+        "moafunk_icecast_online",
+        "1 when the last Icecast poll succeeded with at least one source connected.",
+        metrics.online,
+    );
+    out.push_str(
+        "# HELP moafunk_icecast_listeners Total listeners across all mounts (last poll).\n",
+    );
+    out.push_str("# TYPE moafunk_icecast_listeners gauge\n");
+    out.push_str(&format!(
+        "moafunk_icecast_listeners {}\n",
+        metrics.total_listeners
+    ));
+
+    // Per-mount listeners + bitrate, labeled by mount path.
+    if !metrics.mounts.is_empty() {
+        out.push_str(
+            "# HELP moafunk_icecast_mount_listeners Listeners on a single Icecast mount.\n",
+        );
+        out.push_str("# TYPE moafunk_icecast_mount_listeners gauge\n");
+        for m in &metrics.mounts {
+            out.push_str(&format!(
+                "moafunk_icecast_mount_listeners{{mount=\"{}\"}} {}\n",
+                escape_label(&m.mount),
+                m.listeners
+            ));
+        }
+        out.push_str(
+            "# HELP moafunk_icecast_mount_bitrate_kbps Source bitrate on a single Icecast mount.\n",
+        );
+        out.push_str("# TYPE moafunk_icecast_mount_bitrate_kbps gauge\n");
+        for m in &metrics.mounts {
+            if let Some(br) = m.bitrate {
+                out.push_str(&format!(
+                    "moafunk_icecast_mount_bitrate_kbps{{mount=\"{}\"}} {}\n",
+                    escape_label(&m.mount),
+                    br
+                ));
+            }
+        }
+    }
+
+    // Seconds since the last successful Icecast poll (-1 if never polled). Lets
+    // an alert catch a wedged poller distinct from a dead mount.
+    let poll_age = metrics
+        .polled_at_ms
+        .map(|t| ((now_ms - t).max(0) as f64) / 1000.0)
+        .unwrap_or(-1.0);
+    out.push_str(
+        "# HELP moafunk_icecast_last_poll_age_seconds Seconds since the last successful Icecast poll (-1 if never).\n",
+    );
+    out.push_str("# TYPE moafunk_icecast_last_poll_age_seconds gauge\n");
+    out.push_str(&format!(
+        "moafunk_icecast_last_poll_age_seconds {poll_age}\n"
+    ));
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream_metrics::{MountMetrics, StreamMetrics};
+
+    fn sample_metrics() -> StreamMetrics {
+        StreamMetrics {
+            online: true,
+            total_listeners: 12,
+            mounts: vec![
+                MountMetrics {
+                    mount: "/live.mp3".to_string(),
+                    listeners: 7,
+                    listener_peak: Some(20),
+                    bitrate: Some(128),
+                    samplerate: Some(44100),
+                    channels: Some(2),
+                    server_name: Some("Moafunk".to_string()),
+                },
+                MountMetrics {
+                    mount: "/test.mp3".to_string(),
+                    listeners: 5,
+                    listener_peak: None,
+                    bitrate: None,
+                    samplerate: None,
+                    channels: None,
+                    server_name: None,
+                },
+            ],
+            polled_at_ms: Some(1_000_000),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn render_emits_help_type_and_values() {
+        let m = sample_metrics();
+        let g = Gauges {
+            stream_active: true,
+            recording_active: false,
+        };
+        let out = render(&m, &g, 1_005_000); // 5s after the poll
+
+        // Every metric carries HELP + TYPE.
+        assert!(out.contains("# TYPE moafunk_recording_tee_dropped_total counter"));
+        assert!(out.contains("# TYPE moafunk_stream_active gauge"));
+        assert!(out.contains("# TYPE moafunk_icecast_mount_listeners gauge"));
+
+        // Gauges reflect the inputs.
+        assert!(out.contains("\nmoafunk_stream_active 1\n"));
+        assert!(out.contains("\nmoafunk_recording_active 0\n"));
+        assert!(out.contains("\nmoafunk_icecast_online 1\n"));
+        assert!(out.contains("\nmoafunk_icecast_listeners 12\n"));
+
+        // Per-mount labeled series.
+        assert!(out.contains("moafunk_icecast_mount_listeners{mount=\"/live.mp3\"} 7"));
+        assert!(out.contains("moafunk_icecast_mount_listeners{mount=\"/test.mp3\"} 5"));
+        assert!(out.contains("moafunk_icecast_mount_bitrate_kbps{mount=\"/live.mp3\"} 128"));
+        // No bitrate on /test.mp3 → no series for it.
+        assert!(!out.contains("moafunk_icecast_mount_bitrate_kbps{mount=\"/test.mp3\"}"));
+
+        // Poll age = 5s.
+        assert!(out.contains("moafunk_icecast_last_poll_age_seconds 5\n"));
+    }
+
+    #[test]
+    fn never_polled_reports_negative_age_and_offline() {
+        let m = StreamMetrics::default(); // online=false, no polled_at_ms
+        let g = Gauges {
+            stream_active: false,
+            recording_active: false,
+        };
+        let out = render(&m, &g, 9_999);
+        assert!(out.contains("\nmoafunk_icecast_online 0\n"));
+        assert!(out.contains("moafunk_icecast_last_poll_age_seconds -1\n"));
+        // No mounts → no per-mount series emitted.
+        assert!(!out.contains("moafunk_icecast_mount_listeners{"));
+    }
+
+    #[test]
+    fn counters_increment_and_render() {
+        // Snapshot the baseline (other tests share the process-global counters).
+        let before = counters()
+            .recording_tee_dropped_total
+            .load(Ordering::Relaxed);
+        inc_recording_tee_dropped();
+        inc_recording_tee_dropped();
+        let after = counters()
+            .recording_tee_dropped_total
+            .load(Ordering::Relaxed);
+        assert_eq!(after, before + 2);
+
+        let out = render(
+            &StreamMetrics::default(),
+            &Gauges {
+                stream_active: false,
+                recording_active: false,
+            },
+            0,
+        );
+        // The rendered counter line is present and parseable.
+        let line = out
+            .lines()
+            .find(|l| l.starts_with("moafunk_recording_tee_dropped_total "))
+            .expect("counter line present");
+        let val: u64 = line.rsplit(' ').next().unwrap().parse().unwrap();
+        assert_eq!(val, after);
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        assert_eq!(escape_label("/live.mp3"), "/live.mp3");
+        assert_eq!(escape_label(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+}

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -296,12 +296,14 @@ impl StreamState {
                     tracing::error!(
                         "Recording tee queue full — dropping chunk (recorder/disk too slow); archive will be incomplete"
                     );
+                    crate::metrics::inc_recording_tee_dropped();
                     self.recording_failed.get_or_insert_with(|| {
                         "recording queue overflow (recorder/disk too slow)".to_string()
                     });
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
                     tracing::error!("Recording writer task stopped — recording abandoned");
+                    crate::metrics::inc_recording_writer_stopped();
                     self.recording_failed
                         .get_or_insert_with(|| "recording writer stopped".to_string());
                     self.recording_tx = None;
@@ -448,6 +450,7 @@ impl StreamState {
         if let (Some(ref dir), Some(ref out)) = (&seg_dir, &path) {
             if let Err(e) = concat_segments(dir, out).await {
                 tracing::error!("Failed to concat recording segments: {}", e);
+                crate::metrics::inc_recording_segment_concat_failure();
                 self.recording_failed = Some(format!("Segment concat failed: {}", e));
             } else {
                 tracing::info!("Concatenated recording segments into {:?}", out);

--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -63,11 +63,30 @@ UIs (localhost only) — reach via SSH tunnel, e.g.
 - **systemd `Restart=always` + memory cap** for Liquidsoap and Icecast-KH: in
   `../liquidsoap.service` / `../icecast.service` (docker `--memory`).
 
+## Backend recording-durability metrics (`backend` scrape job)
+
+The backend exposes a Prometheus `/metrics` endpoint (port 8000, localhost-only by
+deployment) with `moafunk_*` counters/gauges the Icecast/Blackbox probes can't see —
+a stuck recorder leaves the live mount healthy while the **archive** breaks:
+
+| Metric | Type | Alert |
+|--------|------|-------|
+| `moafunk_recording_tee_dropped_total` | counter | `RecordingTeeDropping` (chunks dropped now → archive corrupting) |
+| `moafunk_recording_incomplete_total` | counter | `RecordingFinalizedIncomplete` |
+| `moafunk_recording_r2_upload_failures_total` | counter | `RecordingR2UploadFailing` |
+| `moafunk_recording_{writer_stopped,segment_concat_failures,size_mismatch}_total` | counter | (detail for the above) |
+| `moafunk_stream_active` / `moafunk_recording_active` | gauge | live state |
+| `moafunk_icecast_*` | gauge | mirrors the cached `/api/stream/metrics` poll |
+
+Prometheus scrapes `unheard-api:8000` **directly over the backend's docker network**
+(joined as the external `backend` network — set `BACKEND_NETWORK` if its name isn't
+`unheard-backend_default`). The backend publishes only on the host's `127.0.0.1:8000`,
+and `/metrics` is `404`'d on the public nginx vhost, so it's never reachable from the
+internet. All recording alerts are `increase()`-based, so they stay silent until the
+backend is on this box; `BackendMetricsDown` (`up == 0`) is expected to fire pre-cutover.
+
 ## TODO / follow-ups (out of scope here)
 
-- **Backend Prometheus metrics**: the backend exposes only `GET /api/stream/metrics`
-  (JSON). For recording-failure alerts (`r2_upload_failures_total`, tee restarts,
-  byte-rate stalls) it needs a `/metrics` endpoint — a separate backend change.
 - **Dead-air / silence (EBU-R128) probe**: byte/listener metrics look nominal
   during silence; add a loudness tap for true dead-air alerting.
 - **SPOF / CDN**: put a CDN or Icecast-KH master→relay in front of the public

--- a/docs/stream-rework/prod/monitoring/docker-compose.monitoring.yml
+++ b/docs/stream-rework/prod/monitoring/docker-compose.monitoring.yml
@@ -31,6 +31,10 @@ services:
     ports:
       - "127.0.0.1:9090:9090"   # UI/API — localhost only
     extra_hosts: *host-gw
+    # Also join the backend's network so Prometheus can scrape unheard-api:8000
+    # directly (the backend publishes only on the host's 127.0.0.1, unreachable
+    # via host-gateway; and /metrics is 404'd on the public nginx vhost).
+    networks: [default, backend]
     depends_on: [icecast-exporter, blackbox-exporter, alertmanager]
 
   alertmanager:
@@ -74,6 +78,16 @@ services:
     ports:
       - "127.0.0.1:3000:3000"   # localhost only; tunnel via SSH to view
     depends_on: [prometheus]
+
+networks:
+  default:
+  # The backend compose project's default network, joined so Prometheus can
+  # reach unheard-api:8000 directly. The name is `<backend-project>_default`
+  # (verify on the box with `docker network ls` — typically
+  # `unheard-backend_default`); override via ${BACKEND_NETWORK} if it differs.
+  backend:
+    external: true
+    name: ${BACKEND_NETWORK:-unheard-backend_default}
 
 volumes:
   prom-data:

--- a/docs/stream-rework/prod/monitoring/monitoring.env.example
+++ b/docs/stream-rework/prod/monitoring/monitoring.env.example
@@ -10,3 +10,7 @@ ICECAST_STATUS_URI=http://host.docker.internal:8010/status-json.xsl
 
 # Grafana admin password (UI bound to 127.0.0.1; reach via SSH tunnel).
 GRAFANA_ADMIN_PASSWORD=
+
+# Name of the backend compose project's docker network, joined so Prometheus can
+# scrape unheard-api:8000 directly. Verify on the box: `docker network ls`.
+BACKEND_NETWORK=unheard-backend_default

--- a/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
@@ -23,6 +23,17 @@ scrape_configs:
     static_configs:
       - targets: ["icecast-exporter:9146"]
 
+  # Backend-internal recording/upload durability metrics (#178). The backend
+  # publishes only on the host's 127.0.0.1:8000 (unreachable via host-gateway)
+  # and /metrics is 404'd on the public nginx vhost, so Prometheus scrapes the
+  # container directly over the shared backend network (see compose `networks`).
+  # These moafunk_* counters catch a stuck/failed recorder — invisible to the
+  # Icecast/Blackbox probes, which only see the live mount. Activates post-
+  # cutover, once the backend runs on this box (pre-cutover the target is down).
+  - job_name: backend
+    static_configs:
+      - targets: ["unheard-api:8000"]
+
   # Synthetic probe of the PUBLIC stream mount — independent of server metrics,
   # so it catches "listeners can't reach the stream" even if the box looks fine.
   # GET (never HEAD — Icecast 400s on HEAD); see blackbox.yml module icecast_mp3.

--- a/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
@@ -70,3 +70,50 @@ groups:
         annotations:
           summary: "No stream listeners for 1h"
           description: "sum(icecast_listeners) == 0 for 1h. Informational — expected between shows; investigate only if a show is scheduled. (VERIFY metric name on deploy.)"
+
+  - name: recording-durability
+    # Backend-internal recording/upload health (moafunk_* from the `backend` job,
+    # see prometheus.yml). The recording is the system of record; these failures
+    # are INVISIBLE to the Icecast/Blackbox probes — the live mount stays healthy
+    # while the archive silently breaks. All increase()-based, so they stay quiet
+    # until the backend is scraped (no false fire pre-cutover).
+    rules:
+      # Chunks being dropped right now → recorder/disk can't keep up; the archive
+      # for the show in progress is being corrupted. Actionable mid-show.
+      - alert: RecordingTeeDropping
+        expr: increase(moafunk_recording_tee_dropped_total[5m]) > 0
+        for: 0m
+        labels: { severity: warning }
+        annotations:
+          summary: "Recording tee dropping chunks"
+          description: "moafunk_recording_tee_dropped_total increased in the last 5m — the recorder/disk is too slow and the in-progress archive is incomplete."
+
+      # A finalized recording was flagged incomplete (overflow, concat failure,
+      # size mismatch, or short duration). One page per occurrence.
+      - alert: RecordingFinalizedIncomplete
+        expr: increase(moafunk_recording_incomplete_total[15m]) > 0
+        for: 0m
+        labels: { severity: warning }
+        annotations:
+          summary: "A recording finalized incomplete"
+          description: "moafunk_recording_incomplete_total increased — check moafunk_recording_{segment_concat_failures,size_mismatch}_total and the recording logs. Live stream is unaffected; the archive is at risk."
+
+      # R2 uploads of recordings are failing — the local file is kept, but the
+      # archive isn't durable until this clears.
+      - alert: RecordingR2UploadFailing
+        expr: increase(moafunk_recording_r2_upload_failures_total[1h]) > 0
+        for: 0m
+        labels: { severity: warning }
+        annotations:
+          summary: "Recording upload to R2 failing"
+          description: "moafunk_recording_r2_upload_failures_total increased in the last hour — recordings are not reaching R2; local copies are retained pending retry."
+
+      # The backend (stream ingest + recorder) stopped being scraped. Meaningful
+      # only once the backend runs on this box (post-cutover).
+      - alert: BackendMetricsDown
+        expr: up{job="backend"} == 0
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "Backend /metrics scrape down"
+          description: "Prometheus cannot scrape the backend `/metrics` for 10m — recording-durability alerting is blind. (Expected pre-cutover; investigate once the backend is on this box.)"


### PR DESCRIPTION
## What
- Add a Prometheus text-format endpoint **`GET /metrics`** on the backend (hand-rolled, no new crate).
- New `backend/src/metrics.rs`: process-global atomic counters + `render()`, unit-tested.
- Increment counters at the recording failure sites: tee chunk drop / writer stop, segment concat failure, R2 upload failure, verify-before-delete size mismatch, finalized-incomplete.
- Gauges for live `stream_active` / `recording_active` and the cached Icecast snapshot (`moafunk_icecast_*`).
- Wire the (already-merged) #178 monitoring stack to it: a `backend` scrape job against `unheard-api:8000` over the shared backend docker network, plus **4 recording-durability alerts**.
- **404 `/metrics` on the public nginx vhost** — the endpoint is unauthenticated and internal-only.

## Why
The external probes (Blackbox + `icecast_exporter`) can see the public mount and listener counts, but they are **blind to backend-internal durability failures**. A recorder whose tee queue overflowed, a failed segment concat, or an R2 upload that never landed all leave the live mount looking perfectly healthy while the **archive** (the system of record) silently breaks. This closes the backend-`/metrics` TODO from the #178 README so the stack can alert on a *stuck recording*, not just a dead stream.

## How
- Counters are a global `LazyLock<Counters>` of `AtomicU64` (the failure sites in `stream_bridge.rs` / `storage`-path don't hold `AppState`), incremented via named `inc_*` helpers.
- The handler reads the live `stream_state` / `recording_manager` and the cached `StreamMetrics`, then renders text exposition (HELP/TYPE + escaped mount labels).
- Backend binds `127.0.0.1:8000` only, so Prometheus scrapes the container **directly** over the backend's docker network (external `backend` network, name overridable via `BACKEND_NETWORK`) — never through nginx, never public.

## Test plan
- [x] `cargo build` / `cargo clippy` clean (pre-existing warnings only)
- [x] `cargo test` — 4 new metrics tests pass; only the pre-existing `video::tests::test_brightness_analysis` fails (env: host lacks ffmpeg, fails on clean tree too)
- [x] `promtool check rules` → 9 rules OK; `promtool check config` → valid
- [x] All edited YAML validated
- [ ] On first deploy: `curl localhost:8000/metrics` shows `moafunk_*`; confirm `/metrics` is 404 on the public vhost; `up{job="backend"}` is `1` once the backend is on the box

## Risk
**Low.** Additive endpoint + counters; no behavior change to streaming/recording. The monitoring wiring only takes effect on the (gated) box deploy. The one judgment call — scraping over a shared docker network whose name (`unheard-backend_default`) must match — is documented and overridable; `BackendMetricsDown` is expected to fire until the backend lands on the box. Rollback = revert; nothing external is touched by merging.
