### PR TITLE
ci(infra): one-dispatch deploy for the #178 observability stack

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         description: "Deploy to Hetzner (greenfield #194; manual only, restarts containers)"
         default: false
+      deploy_monitoring:
+        type: boolean
+        description: "Deploy the #178 observability stack (Prometheus/Alertmanager/Grafana) to the Hetzner box"
+        default: false
       build:
         type: boolean
         description: "Build & push image to GHCR"
@@ -419,6 +423,52 @@ jobs:
           INIT_DB="${{ inputs.init_db && '1' || '0' }}" \
           RUN_TESTS="${{ inputs.run_tests == false && '0' || '1' }}" \
           ./backend/scripts/deploy_hetzner.sh
+
+  deploy-monitoring:
+    # Deploy the #178 observability stack to the Hetzner box (manual only).
+    # Additive + reversible: never touches the backend, the stream stack, or DNS.
+    # Secrets come from Bitwarden, same as the other deploy jobs. Grafana's admin
+    # password defaults to 'admin' (UI is 127.0.0.1-only, SSH-tunnelled) — set
+    # GRAFANA_ADMIN_PASSWORD in /etc/moafunk/monitoring/monitoring.env to harden.
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_monitoring == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get secrets from Bitwarden
+        uses: bitwarden/sm-action@v2
+        id: bitwarden-secrets
+        with:
+          access_token: ${{ secrets.BW_ACCESS_TOKEN }}
+          secrets: |
+            546972ad-7db9-4525-8d30-b46e00f8802a > HETZNER_IP
+            32944dfd-70f2-4f57-8274-b46e00f77c41 > HETZNER_SSH_KEY
+            2470e0a8-7e96-4113-9931-b3ed0180cf59 > TELEGRAM_BOT_TOKEN
+            3d3c982b-6933-4c23-bb11-b3ee000687d6 > TELEGRAM_ADMIN_CHAT_ID
+
+      - name: Setup SSH key
+        env:
+          HETZNER_IP: ${{ steps.bitwarden-secrets.outputs.HETZNER_IP }}
+          HETZNER_SSH_KEY: ${{ steps.bitwarden-secrets.outputs.HETZNER_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$HETZNER_SSH_KEY" > ~/.ssh/hetzner.pem
+          chmod 600 ~/.ssh/hetzner.pem
+          ssh-keyscan -H "$HETZNER_IP" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy observability stack
+        env:
+          IP: ${{ steps.bitwarden-secrets.outputs.HETZNER_IP }}
+          TELEGRAM_BOT_TOKEN: ${{ steps.bitwarden-secrets.outputs.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_ADMIN_CHAT_ID: ${{ steps.bitwarden-secrets.outputs.TELEGRAM_ADMIN_CHAT_ID }}
+        run: |
+          IP="$IP" \
+          SSH_KEY=~/.ssh/hetzner.pem \
+          TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+          TELEGRAM_ADMIN_CHAT_ID="$TELEGRAM_ADMIN_CHAT_ID" \
+          ./backend/scripts/deploy_monitoring.sh
 
   sync-scripts:
     # Sync backup/r2/db scripts to Lightsail without a full deploy.

--- a/backend/scripts/deploy_monitoring.sh
+++ b/backend/scripts/deploy_monitoring.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Deploy the stream observability stack (#178) to the Hetzner box.
+#
+# Ships docs/stream-rework/prod/monitoring/ to /etc/moafunk/monitoring, writes
+# monitoring.env from the passed-in secrets, installs the systemd unit, and
+# (re)starts it. The unit renders alertmanager.yml via envsubst and runs
+# `docker compose up -d` (Prometheus/Alertmanager/Blackbox/icecast_exporter/
+# Grafana). All UIs bind to 127.0.0.1 on the box — reach them via SSH tunnel.
+#
+# This is additive and safe to re-run: it never touches the backend, the stream
+# stack, or DNS. Idempotent — a second run just re-syncs config and restarts.
+#
+# Requirements (local/runner): ssh + scp. The box must already run docker and
+# the backend (the `backend` docker network must exist — see BACKEND_NETWORK).
+#
+# Driven by the `deploy-monitoring` CI job (secrets from Bitwarden), or run
+# locally:
+#   IP=1.2.3.4 SSH_KEY=~/.ssh/hetzner.pem \
+#   TELEGRAM_BOT_TOKEN=... TELEGRAM_ADMIN_CHAT_ID=... \
+#   ./backend/scripts/deploy_monitoring.sh
+set -euo pipefail
+
+IP="${IP:?IP is required (Hetzner box public IP)}"
+SSH_KEY="${SSH_KEY:?SSH_KEY is required (path to the private key)}"
+SSH_USER="${SSH_USER:-root}"
+REMOTE_DIR="${REMOTE_DIR:-/etc/moafunk/monitoring}"
+
+# Monitoring config inputs (all but the Telegram pair have safe defaults).
+TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN is required}"
+TELEGRAM_ADMIN_CHAT_ID="${TELEGRAM_ADMIN_CHAT_ID:?TELEGRAM_ADMIN_CHAT_ID is required}"
+ICECAST_STATUS_URI="${ICECAST_STATUS_URI:-http://host.docker.internal:8010/status-json.xsl}"
+BACKEND_NETWORK="${BACKEND_NETWORK:-unheard-backend_default}"
+# Grafana is localhost-only (SSH tunnel); default kept weak deliberately — set
+# GRAFANA_ADMIN_PASSWORD to override. Grafana is the least-sensitive component.
+GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
+SSH_HOST="$SSH_USER@$IP"
+SSH_OPTS=(-i "$SSH_KEY" -o StrictHostKeyChecking=accept-new)
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+LOCAL_MON_DIR="$REPO_ROOT/docs/stream-rework/prod/monitoring"
+
+if [[ ! -f "$LOCAL_MON_DIR/docker-compose.monitoring.yml" ]]; then
+  echo "ERROR: monitoring dir not found at $LOCAL_MON_DIR" >&2
+  exit 1
+fi
+
+echo "==> Deploying observability stack to $SSH_HOST:$REMOTE_DIR"
+
+# 1. Ship the config tree to a staging dir (scp -r preserves the layout).
+ssh "${SSH_OPTS[@]}" "$SSH_HOST" "rm -rf /tmp/moafunk-monitoring && mkdir -p /tmp/moafunk-monitoring"
+scp "${SSH_OPTS[@]}" -r "$LOCAL_MON_DIR/." "$SSH_HOST:/tmp/moafunk-monitoring/" >/dev/null
+
+# 2. Install: move into place, write env (chmod 600), enable the unit. The env
+#    values are piped over stdin (never on the command line / process list).
+printf '%s\n' \
+  "TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN" \
+  "TELEGRAM_ADMIN_CHAT_ID=$TELEGRAM_ADMIN_CHAT_ID" \
+  "ICECAST_STATUS_URI=$ICECAST_STATUS_URI" \
+  "BACKEND_NETWORK=$BACKEND_NETWORK" \
+  "GRAFANA_ADMIN_PASSWORD=$GRAFANA_ADMIN_PASSWORD" \
+  | ssh "${SSH_OPTS[@]}" "$SSH_HOST" \
+      "REMOTE_DIR='$REMOTE_DIR' bash -s" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+# Capture the env piped on stdin before anything else reads it.
+ENV_CONTENT="$(cat)"
+
+sudo mkdir -p "$REMOTE_DIR"
+# Sync config (preserve the gitignored monitoring.env / rendered alertmanager.yml
+# across redeploys by writing env separately below; --delete would wipe them, so
+# copy without deleting and let the env write be authoritative).
+sudo cp -r /tmp/moafunk-monitoring/. "$REMOTE_DIR/"
+rm -rf /tmp/moafunk-monitoring
+
+# Write monitoring.env (root:600 — holds the Telegram token).
+printf '%s\n' "$ENV_CONTENT" | sudo tee "$REMOTE_DIR/monitoring.env" >/dev/null
+sudo chmod 600 "$REMOTE_DIR/monitoring.env"
+
+# Verify the backend network exists (Prometheus joins it to scrape unheard-api).
+BACKEND_NET="$(grep -E '^BACKEND_NETWORK=' "$REMOTE_DIR/monitoring.env" | cut -d= -f2-)"
+if ! sudo docker network inspect "$BACKEND_NET" >/dev/null 2>&1; then
+  echo "WARNING: docker network '$BACKEND_NET' not found — Prometheus 'backend' job"
+  echo "         will fail to start until the backend compose is up. Existing nets:"
+  sudo docker network ls --format '  {{.Name}}'
+fi
+
+# Install / refresh the systemd unit and (re)start.
+sudo cp "$REMOTE_DIR/monitoring.service" /etc/systemd/system/monitoring.service
+sudo systemctl daemon-reload
+sudo systemctl enable monitoring >/dev/null 2>&1 || true
+sudo systemctl restart monitoring
+
+echo "==> monitoring.service started; containers:"
+sleep 5
+sudo docker compose -f "$REMOTE_DIR/docker-compose.monitoring.yml" ps || true
+REMOTE_SCRIPT
+
+# 3. Smoke-check Prometheus readiness over the localhost-bound port.
+echo "==> Checking Prometheus readiness (localhost:9090 on the box)"
+if ssh "${SSH_OPTS[@]}" "$SSH_HOST" \
+     "curl -fsS --max-time 5 http://127.0.0.1:9090/-/ready >/dev/null"; then
+  echo "==> Prometheus is ready."
+else
+  echo "WARNING: Prometheus not ready yet — check 'journalctl -u monitoring' and"
+  echo "         'docker compose -f $REMOTE_DIR/docker-compose.monitoring.yml logs' on the box."
+fi
+
+echo "==> Done. Tunnel to view UIs, e.g.:"
+echo "    ssh -i <key> -L 9090:localhost:9090 -L 3000:localhost:3000 $SSH_HOST"

--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -26,9 +26,27 @@ present and `< 1`, so the rule fires forever. "stream-down" and "zero-listeners"
 are deliberately **separate** alerts; absence uses `absent()` / `up == 0`. (That
 `or vector(0)` trick is only for Grafana panels.)
 
-## Deploy (on the box)
+## Deploy
 
 > Runs upstream images (`prom/*`, `markuslindenberg/icecast_exporter`, `grafana/grafana`).
+
+### Via CI (preferred — no manual SSH)
+
+Run the **backend** workflow with `deploy_monitoring=true` (manual dispatch). It pulls
+`TELEGRAM_*` + the box IP/SSH key from Bitwarden and runs `backend/scripts/deploy_monitoring.sh`,
+which ships this dir to `/etc/moafunk/monitoring`, writes `monitoring.env`, and starts the
+systemd unit. Additive + reversible — never touches the backend, stream stack, or DNS.
+
+```bash
+gh workflow run backend.yml -f deploy_monitoring=true
+```
+
+Grafana's admin password defaults to `admin` (UI is `127.0.0.1`-only, SSH-tunnelled). To
+harden, set `GRAFANA_ADMIN_PASSWORD` in `/etc/moafunk/monitoring/monitoring.env` and
+`systemctl restart monitoring`.
+
+### Manually (on the box)
+
 > Place this dir at `/etc/moafunk/monitoring`.
 
 ```bash


### PR DESCRIPTION
## What
- New `deploy-monitoring` job in `backend.yml` (manual `workflow_dispatch -f deploy_monitoring=true`).
- New `backend/scripts/deploy_monitoring.sh` — ships the #178 stack to the box, writes `monitoring.env`, installs the systemd unit, restarts, smoke-checks Prometheus.
- README: documents the CI deploy path (preferred) alongside the manual one.

## Why
The #178 observability stack (PR #206) had **no deploy path** — it required hand-SSHing to the box. This makes it deploy the same Bitwarden-keyed CI way as the backend (`deploy-hetzner`), so Phase B observability is a one-click dispatch.

## How
- Fetches `HETZNER_IP`/`HETZNER_SSH_KEY` + `TELEGRAM_BOT_TOKEN`/`TELEGRAM_ADMIN_CHAT_ID` from Bitwarden SM (same UUIDs as the existing jobs).
- `deploy_monitoring.sh` mirrors `deploy_hetzner.sh`'s scp + `ssh … bash -s` pattern: stages config to `/tmp`, `cp -r` into `/etc/moafunk/monitoring` (no `--delete`, preserves the gitignored rendered `alertmanager.yml`), writes `monitoring.env` root:600 from stdin (token never on the process list), installs/enables the unit, restarts, then checks `127.0.0.1:9090/-/ready`.
- Warns if the `backend` docker network is missing (Prometheus joins it to scrape `unheard-api:8000`).

## Test plan
- [x] `bash -n` syntax clean; `backend.yml` YAML valid
- [ ] Dispatch `deploy_monitoring=true` → containers up; `curl localhost:9146/metrics | grep ^icecast_` to reconcile metric names; `up{job="backend"}==1` (backend already redeployed with `/metrics`)
- [ ] Tunnel Grafana/Prometheus and confirm targets healthy

## Risk
**Low.** Additive, reversible, manual-only; never touches the backend, stream stack, or DNS. Runs upstream exporter images on the box (Phase B observability, authorised). Rollback: `systemctl disable --now monitoring`. First run must reconcile `icecast_*` metric names (per the README) and confirm `BACKEND_NETWORK` = `unheard-backend_default`.
