### PR TITLE
fix(infra): resolve docker compose vs docker-compose for #178 stack

### DIFF
--- a/backend/scripts/deploy_monitoring.sh
+++ b/backend/scripts/deploy_monitoring.sh
@@ -87,25 +87,50 @@ if ! sudo docker network inspect "$BACKEND_NET" >/dev/null 2>&1; then
   sudo docker network ls --format '  {{.Name}}'
 fi
 
-# Install / refresh the systemd unit and (re)start.
+# Install / refresh the systemd unit and (re)start. The unit calls
+# mon-compose.sh (resolves `docker compose` vs `docker-compose`) — make it
+# executable before starting.
+sudo chmod +x "$REMOTE_DIR/mon-compose.sh"
 sudo cp "$REMOTE_DIR/monitoring.service" /etc/systemd/system/monitoring.service
 sudo systemctl daemon-reload
 sudo systemctl enable monitoring >/dev/null 2>&1 || true
-sudo systemctl restart monitoring
 
-echo "==> monitoring.service started; containers:"
+# Fail loudly if the unit doesn't come up — a green deploy must mean a running
+# stack (the previous version's readiness check was non-fatal and hid a failure).
+if ! sudo systemctl restart monitoring; then
+  echo "ERROR: 'systemctl restart monitoring' failed. Recent journal:" >&2
+  sudo journalctl -u monitoring -n 40 --no-pager >&2 || true
+  exit 1
+fi
+if ! sudo systemctl is-active --quiet monitoring; then
+  echo "ERROR: monitoring.service is not active after restart. Status + journal:" >&2
+  sudo systemctl status monitoring --no-pager >&2 || true
+  sudo journalctl -u monitoring -n 40 --no-pager >&2 || true
+  exit 1
+fi
+
+echo "==> monitoring.service active; containers:"
 sleep 5
-sudo docker compose -f "$REMOTE_DIR/docker-compose.monitoring.yml" ps || true
+sudo "$REMOTE_DIR/mon-compose.sh" -f "$REMOTE_DIR/docker-compose.monitoring.yml" ps || true
 REMOTE_SCRIPT
 
-# 3. Smoke-check Prometheus readiness over the localhost-bound port.
-echo "==> Checking Prometheus readiness (localhost:9090 on the box)"
-if ssh "${SSH_OPTS[@]}" "$SSH_HOST" \
-     "curl -fsS --max-time 5 http://127.0.0.1:9090/-/ready >/dev/null"; then
+# 3. Smoke-check Prometheus readiness over the localhost-bound port. Retry for
+#    up to 60s — on a first deploy the upstream images are still being pulled.
+echo "==> Waiting for Prometheus readiness (localhost:9090 on the box, up to 60s)"
+ready=0
+for _ in $(seq 1 12); do
+  if ssh "${SSH_OPTS[@]}" "$SSH_HOST" \
+       "curl -fsS --max-time 5 http://127.0.0.1:9090/-/ready >/dev/null 2>&1"; then
+    ready=1
+    break
+  fi
+  sleep 5
+done
+if [[ "$ready" == 1 ]]; then
   echo "==> Prometheus is ready."
 else
-  echo "WARNING: Prometheus not ready yet — check 'journalctl -u monitoring' and"
-  echo "         'docker compose -f $REMOTE_DIR/docker-compose.monitoring.yml logs' on the box."
+  echo "WARNING: Prometheus not ready after 60s — check 'journalctl -u monitoring' and"
+  echo "         'mon-compose.sh -f $REMOTE_DIR/docker-compose.monitoring.yml logs' on the box."
 fi
 
 echo "==> Done. Tunnel to view UIs, e.g.:"

--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -52,9 +52,14 @@ harden, set `GRAFANA_ADMIN_PASSWORD` in `/etc/moafunk/monitoring/monitoring.env`
 ```bash
 cd /etc/moafunk/monitoring
 cp monitoring.env.example monitoring.env      # fill TELEGRAM_*, GRAFANA_* from Bitwarden
+chmod +x mon-compose.sh                       # unit calls it to resolve docker compose vs docker-compose
 cp monitoring.service /etc/systemd/system/
 systemctl daemon-reload && systemctl enable --now monitoring   # renders alertmanager.yml + compose up
 ```
+
+> The box may have only the standalone `docker-compose` binary (no `docker compose`
+> v2 plugin). `monitoring.service` calls `mon-compose.sh`, which resolves whichever
+> is present — so don't hardcode `docker compose` in the unit.
 
 ## Verify (FIRST DEPLOY — reconcile metric names)
 

--- a/docs/stream-rework/prod/monitoring/mon-compose.sh
+++ b/docs/stream-rework/prod/monitoring/mon-compose.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Resolve Docker Compose and exec it with the given args.
+#
+# The Hetzner box may have EITHER the v2 plugin (`docker compose`) OR only the
+# standalone `docker-compose` binary (deploy_hetzner.sh installs whichever it
+# can; this box has only the standalone v2.24.6 binary). monitoring.service
+# calls this wrapper instead of hardcoding one form, so the unit works on either.
+set -euo pipefail
+
+if docker compose version >/dev/null 2>&1; then
+  exec docker compose "$@"
+elif command -v docker-compose >/dev/null 2>&1; then
+  exec docker-compose "$@"
+else
+  echo "mon-compose: no Docker Compose found (neither 'docker compose' plugin nor 'docker-compose')" >&2
+  exit 1
+fi

--- a/docs/stream-rework/prod/monitoring/monitoring.service
+++ b/docs/stream-rework/prod/monitoring/monitoring.service
@@ -21,8 +21,10 @@ WorkingDirectory=/etc/moafunk/monitoring
 # Re-render the alertmanager config from the template each start (picks up token
 # rotations in monitoring.env). envsubst ships in gettext-base.
 ExecStartPre=/bin/bash -c 'set -a; . monitoring.env; set +a; envsubst < alertmanager/alertmanager.yml.tmpl > alertmanager/alertmanager.yml'
-ExecStart=/usr/bin/docker compose --env-file monitoring.env -f docker-compose.monitoring.yml up -d
-ExecStop=/usr/bin/docker compose -f docker-compose.monitoring.yml down
+# mon-compose.sh resolves `docker compose` (v2 plugin) OR the standalone
+# `docker-compose` binary — the box may have either. See the script header.
+ExecStart=/etc/moafunk/monitoring/mon-compose.sh --env-file monitoring.env -f docker-compose.monitoring.yml up -d
+ExecStop=/etc/moafunk/monitoring/mon-compose.sh -f docker-compose.monitoring.yml down
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## What
- Add `mon-compose.sh` — resolves `docker compose` (v2 plugin) **or** the standalone `docker-compose` binary — and have `monitoring.service` call it instead of hardcoding `docker compose`.
- Harden `deploy_monitoring.sh`: `chmod +x` the wrapper; **fail the deploy (dump `journalctl`)** if the unit isn't active after restart; retry Prometheus readiness for 60s; use the wrapper for the `ps` check.

## Why
First #178 deploy (PR #208) reported success but **nothing came up**. The box has only the standalone `docker-compose` v2.24.6 binary, not the `docker compose` plugin (`docker: unknown command: docker compose`), so the unit's hardcoded `ExecStart=/usr/bin/docker compose …` failed → `systemctl is-active monitoring` = `inactive`. The deploy still went green because the readiness probe was non-fatal — so the deploy lied. This fixes both: the invocation and the false-green.

## How
- `deploy_hetzner.sh` already proves the box may have either Compose form; the wrapper applies the same resolution at unit-exec time (where systemd can't do shell detection).
- The unit calls `/etc/moafunk/monitoring/mon-compose.sh` for `up -d` / `down`; the deploy script makes it executable and now gates on `is-active`, dumping the journal and `exit 1` on failure.

## Test plan
- [x] `bash -n` clean on both scripts
- [ ] Re-dispatch `deploy_monitoring=true` → job stays green only if the unit is active; containers `Up`; `curl localhost:9146/metrics | grep ^icecast_`; `up{job="backend"}==1`

## Risk
**Low.** Additive wrapper + stricter deploy gating; no behavior change on a box that does have the v2 plugin (`docker compose` branch still taken first). Rollback: `systemctl disable --now monitoring`.
