### PR TITLE
fix(infra): reconcile #178 probe + alerts with the live exporter

### DIFF
--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -6,18 +6,23 @@ to the project Telegram bot. **All UIs/metrics ports bind to `127.0.0.1`** — n
 exposed publicly.
 
 ```
-blackbox ── GET /live.mp3 (synthetic "can listeners reach the stream?") ─┐
-icecast_exporter ── Icecast /status-json.xsl (listeners, sources) ───────┤─▶ Prometheus ─▶ Alertmanager ─▶ Telegram
+blackbox ── GET /status-json.xsl (synthetic "is Icecast reachable?") ────┐
+icecast_exporter ── Icecast /status-json.xsl (per-mount listeners) ──────┤─▶ Prometheus ─▶ Alertmanager ─▶ Telegram
                                                                           │        └─▶ Grafana (127.0.0.1:3000)
 ```
+
+> Blackbox probes the **status endpoint**, not the audio mount: a live MP3 mount
+> is an infinite stream and blackbox reads the body to EOF, so probing `/live.mp3`
+> always times out (verified). "Is the live source actually feeding?" is covered
+> by `IcecastNoLiveSource` (the per-mount `icecast_listeners` series disappears).
 
 ## What it alerts on (and the #178 landmine)
 
 | Alert | Expr (severity) | Meaning |
 |-------|-----------------|---------|
-| `StreamProbeDown` | `probe_success{job="blackbox_stream"} == 0` for 5m (**critical**) | public mount unreachable — the canonical "stream down" |
+| `StreamProbeDown` | `probe_success{job="blackbox_stream"} == 0` for 5m (**critical**) | Icecast status endpoint unreachable — canonical "server down" |
 | `IcecastExporterDown` | `up{job="icecast"} == 0` for 5m (**critical**) | Icecast/exporter scrape failing |
-| `IcecastNoSource` | `icecast_sources == 0` for 10m (**critical**) | Liquidsoap stopped feeding Icecast |
+| `IcecastNoLiveSource` | `absent(icecast_listeners{listenurl=~".*/live.mp3"})` for 10m (**critical**) | Liquidsoap stopped feeding the live mount |
 | `StreamZeroListenersProlonged` | `sum(icecast_listeners) == 0` for 1h (**info**) | informational only (normal between shows) |
 | `StreamProbeAbsent` | `absent(probe_success{...})` for 10m (**warning**) | monitoring itself is broken |
 
@@ -61,22 +66,30 @@ systemctl daemon-reload && systemctl enable --now monitoring   # renders alertma
 > v2 plugin). `monitoring.service` calls `mon-compose.sh`, which resolves whichever
 > is present — so don't hardcode `docker compose` in the unit.
 
-## Verify (FIRST DEPLOY — reconcile metric names)
+## Verify
 
-`icecast_exporter` metric names can differ by version. After it's up:
+Metric names were reconciled against the live exporter on 2026-06-19 (the
+`icecast-exporter`/`blackbox` ports are NOT host-published — query via Prometheus,
+not `localhost:9146`/`:9115`):
 
 ```bash
-curl -s localhost:9146/metrics | grep ^icecast_      # confirm icecast_sources / icecast_listeners
-curl -s 'localhost:9090/api/v1/rules' | jq '.. .health? // empty' | sort -u   # all "ok"
-curl -s localhost:9090/api/v1/query?query=probe_success | jq '.data.result'   # blackbox probing the mount
+# All targets healthy (prometheus, icecast, backend, blackbox_stream → up==1):
+curl -s 'localhost:9090/api/v1/query?query=up' | jq -r '.data.result[]|"\(.metric.job)=\(.value[1])"'
+# Blackbox status probe succeeds (was 0 while probing the audio mount):
+curl -s 'localhost:9090/api/v1/query?query=probe_success' | jq '.data.result[].value[1]'
+# Live source present (per-mount series; this is what IcecastNoLiveSource watches):
+curl -s 'localhost:9090/api/v1/query?query=icecast_listeners' | jq -r '.data.result[].metric.listenurl'
+# All rules healthy:
+curl -s 'localhost:9090/api/v1/rules' | jq '[..|.health?//empty]|unique'
 ```
 
-If the exporter's names differ from `icecast_sources` / `icecast_listeners`,
-update `prometheus/rules/stream-alerts.yml` (the `StreamProbeDown` alert needs no
-change — it's blackbox-based). Then `systemctl reload`/restart `monitoring`.
+The exporter emits per-mount `icecast_listeners{listenurl=…}` + `icecast_up`, but
+**no `icecast_sources`** — hence `IcecastNoLiveSource` keys off the per-mount
+series existing. The Blackbox probe targets the **status endpoint** (finite),
+never the audio mount (infinite stream → body-read timeout).
 
-Test the page path: `systemctl stop liquidsoap` (or block the mount) → after 5m
-`StreamProbeDown` should fire exactly once to Telegram; restart → it resolves.
+Test the page path: `systemctl stop liquidsoap` (or block Icecast) → after 5m
+`StreamProbeDown`/`IcecastNoLiveSource` fire to Telegram; restart → they resolve.
 
 UIs (localhost only) — reach via SSH tunnel, e.g.
 `ssh -L 9090:localhost:9090 -L 3000:localhost:3000 root@<box>`.

--- a/docs/stream-rework/prod/monitoring/blackbox/blackbox.yml
+++ b/docs/stream-rework/prod/monitoring/blackbox/blackbox.yml
@@ -1,16 +1,17 @@
 # Blackbox exporter modules (#178).
 modules:
-  # Probe an Icecast MP3 mount. MUST use GET — Icecast answers HEAD with 400,
-  # which would make the probe permanently fail. A live mount returns 200 with
-  # an audio/mpeg body; we accept 200 and the mpeg content-type.
-  icecast_mp3:
+  # Probe the Icecast STATUS endpoint (/status-json.xsl), not an audio mount.
+  # MUST use GET (Icecast answers HEAD with 400). Do NOT point this at a live
+  # MP3 mount: that body is an infinite stream and blackbox reads the body to
+  # EOF, so the probe always hits `timeout` and fails (we verified 200 HTTP/1.1
+  # but probe_duration == timeout). The status endpoint returns a finite 200.
+  icecast_http:
     prober: http
     timeout: 8s
     http:
       method: GET
-      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_http_versions: ["HTTP/1.0", "HTTP/1.1", "HTTP/2.0"]
       valid_status_codes: [200]
-      fail_if_not_ssl: false   # local mount is plain http; public probe is https
+      fail_if_not_ssl: false   # local endpoint is plain http; public probe is https
       preferred_ip_protocol: ip4
-      # Don't pull the whole stream — a short read is enough to confirm 200.
       no_follow_redirects: false

--- a/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/prometheus.yml
@@ -34,20 +34,25 @@ scrape_configs:
     static_configs:
       - targets: ["unheard-api:8000"]
 
-  # Synthetic probe of the PUBLIC stream mount — independent of server metrics,
-  # so it catches "listeners can't reach the stream" even if the box looks fine.
-  # GET (never HEAD — Icecast 400s on HEAD); see blackbox.yml module icecast_mp3.
-  # Prometheus does NOT expand env vars in this file — edit the target directly.
-  # Pre-cutover: the local mount (below). Post-cutover: change to the public TLS
-  # URL, e.g. https://radio.live.moafunk.de/live.mp3 (then the probe is truly
-  # end-to-end through the proxy).
+  # Synthetic probe that Icecast is reachable and serving — independent of the
+  # exporter, so it catches "the server is unreachable" even if scrapes look ok.
+  # We probe the STATUS endpoint (/status-json.xsl), NOT the audio mount: a live
+  # MP3 mount is an infinite stream, and blackbox's HTTP prober reads the body to
+  # EOF — so probing /live.mp3 always hits the module timeout and fails (verified:
+  # 200 HTTP/1.1 but probe_duration == timeout). The status endpoint returns a
+  # finite 200. "Is the live SOURCE actually feeding?" is covered separately by
+  # the IcecastNoLiveSource alert (per-mount icecast_listeners series presence).
+  # GET (never HEAD — Icecast 400s on HEAD); see blackbox.yml module icecast_http.
+  # Prometheus does NOT expand env vars here — edit the target directly. Post-
+  # cutover, point this at the publicly-reachable status/health URL (a finite
+  # endpoint — never the raw mount).
   - job_name: blackbox_stream
     metrics_path: /probe
     params:
-      module: [icecast_mp3]
+      module: [icecast_http]
     static_configs:
       - targets:
-          - http://host.docker.internal:8010/live.mp3
+          - http://host.docker.internal:8010/status-json.xsl
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
+++ b/docs/stream-rework/prod/monitoring/prometheus/rules/stream-alerts.yml
@@ -7,23 +7,27 @@
 # SEPARATE alerts, and absence is handled with `absent()` / `up == 0`, never
 # `or vector(0)`.
 #
-# "stream-down" is intentionally driven by the Blackbox probe (probe_success),
-# which is exporter-agnostic and certain — it fires regardless of the icecast_*
-# metric names. The icecast_*-based rules are best-effort detail; VERIFY their
-# metric names against `curl localhost:9146/metrics | grep ^icecast_` on first
-# deploy and adjust if the exporter names differ.
+# "stream-down" is driven by the Blackbox probe (probe_success) of the Icecast
+# STATUS endpoint — exporter-agnostic and certain. (We do NOT probe the audio
+# mount: it's an infinite stream that times out blackbox's body read.) The
+# icecast_*-based rules are detail. Metric names were reconciled against the
+# live exporter (markuslindenberg/icecast_exporter) on 2026-06-19: it emits
+# per-mount `icecast_listeners{listenurl=...}` (one series per connected source)
+# and `icecast_up`, but NO `icecast_sources` — so source presence is detected
+# via the per-mount series existing, not a source count.
 groups:
   - name: stream-availability
     rules:
-      # The canonical "stream is down" alert: the public mount is unreachable.
-      # Independent of server-side metrics — proves listeners can't get audio.
+      # The canonical "Icecast is down" alert: the status endpoint is unreachable.
+      # Independent of the exporter — if this fails, listeners can't reach the
+      # server at all. (Source-level "is the live mount fed?" = IcecastNoLiveSource.)
       - alert: StreamProbeDown
         expr: probe_success{job="blackbox_stream"} == 0
         for: 5m
         labels: { severity: critical }
         annotations:
-          summary: "Public stream mount unreachable"
-          description: "Blackbox GET probe of {{ $labels.instance }} has failed for 5m. Listeners cannot reach the stream."
+          summary: "Icecast unreachable (status probe failing)"
+          description: "Blackbox GET probe of {{ $labels.instance }} has failed for 5m — Icecast is unreachable; listeners cannot reach the stream."
 
       # The Blackbox probe target itself stopped being scraped (Prometheus can't
       # even run the probe) — distinct from the probe failing.
@@ -46,16 +50,18 @@ groups:
           summary: "Icecast exporter/scrape down"
           description: "Prometheus cannot scrape icecast_exporter for 5m — Icecast may be down or the exporter cannot reach it."
 
-      # No source connected to Icecast. With mksafe the Liquidsoap source is
-      # always connected, so 0 sources means Liquidsoap died → real outage.
-      # VERIFY metric name on deploy (icecast_sources is the expected name).
-      - alert: IcecastNoSource
-        expr: icecast_sources == 0
+      # The live source mount stopped feeding Icecast. The exporter emits a
+      # per-mount `icecast_listeners{listenurl=…/live.mp3}` series ONLY while a
+      # source is connected; mksafe keeps it connected at all times, so the series
+      # disappearing means Liquidsoap died → real outage. (There is no
+      # `icecast_sources` metric — absence of the per-mount series is the signal.)
+      - alert: IcecastNoLiveSource
+        expr: absent(icecast_listeners{listenurl=~".*/live.mp3"})
         for: 10m
         labels: { severity: critical }
         annotations:
-          summary: "No source connected to Icecast"
-          description: "icecast_sources == 0 for 10m — Liquidsoap is not feeding Icecast (mksafe should keep a source connected at all times)."
+          summary: "No source on the Icecast live mount"
+          description: "icecast_listeners for the /live.mp3 mount has been absent for 10m — Liquidsoap is not feeding Icecast (mksafe should keep a source connected at all times)."
 
   - name: stream-listeners
     rules:
@@ -69,7 +75,7 @@ groups:
         labels: { severity: info }
         annotations:
           summary: "No stream listeners for 1h"
-          description: "sum(icecast_listeners) == 0 for 1h. Informational — expected between shows; investigate only if a show is scheduled. (VERIFY metric name on deploy.)"
+          description: "sum(icecast_listeners) == 0 for 1h. Informational — expected between shows; investigate only if a show is scheduled."
 
   - name: recording-durability
     # Backend-internal recording/upload health (moafunk_* from the `backend` job,


### PR DESCRIPTION
## What
Reconcile the #178 Prometheus probe + alerts with what the live exporter/Icecast actually emit (found on the first real on-box deploy):
- **Blackbox**: probe `/status-json.xsl` (finite) instead of `/live.mp3` (infinite stream); module `icecast_mp3` → `icecast_http`.
- **Alerts**: `IcecastNoSource` (`icecast_sources`, which doesn't exist) → **`IcecastNoLiveSource`** = `absent(icecast_listeners{listenurl=~".*/live.mp3"})`; update `StreamProbeDown` wording.
- README diagram/table/verify steps updated to the reconciled reality.

## Why
On the box: `probe_success=0` despite `probe_http_status_code=200`, `probe_http_version=1.1`, `probe_duration_seconds=8.0` — blackbox read the infinite MP3 body to EOF and hit the timeout. And the exporter emits per-mount `icecast_listeners{listenurl=…}` + `icecast_up` but **no `icecast_sources`**, so the old `IcecastNoSource` rule was dead. (`up{job=backend}=1` already confirmed the backend `/metrics` scrape works.)

## How
- HEAD is out (Icecast 400s) and `body_size_limit` *fails* on exceed, so a finite endpoint is the only reliable blackbox target; `/status-json.xsl` returns a finite 200 (the exporter reads it fine). Source-level health moves to the per-mount-series-presence alert.

## Test plan
- [x] YAML valid; `promtool check rules` (9) + `check config` pass
- [ ] Redeploy → `probe_success=1`; `IcecastNoLiveSource` not firing (live mount present); all rules `health=ok`
- [ ] (page test) stop Liquidsoap → `StreamProbeDown`/`IcecastNoLiveSource` fire, then resolve on restart

## Risk
**Low.** Monitoring config only; additive/reversible. Rollback: `systemctl disable --now monitoring`.
