### PR TITLE
fix(infra): attach Prometheus to the backend network on every start

### DIFF
--- a/docs/stream-rework/prod/monitoring/README.md
+++ b/docs/stream-rework/prod/monitoring/README.md
@@ -116,7 +116,10 @@ a stuck recorder leaves the live mount healthy while the **archive** breaks:
 
 Prometheus scrapes `unheard-api:8000` **directly over the backend's docker network**
 (joined as the external `backend` network — set `BACKEND_NETWORK` if its name isn't
-`unheard-backend_default`). The backend publishes only on the host's `127.0.0.1:8000`,
+`unheard-backend_default`). Compose v2.24.6 on the box doesn't reliably attach the
+container to that pre-existing external net on recreate, so `monitoring.service` has
+an idempotent `ExecStartPost` that `docker network connect`s Prometheus to it on
+every start. The backend publishes only on the host's `127.0.0.1:8000`,
 and `/metrics` is `404`'d on the public nginx vhost, so it's never reachable from the
 internet. All recording alerts are `increase()`-based, so they stay silent until the
 backend is on this box; `BackendMetricsDown` (`up == 0`) is expected to fire pre-cutover.

--- a/docs/stream-rework/prod/monitoring/monitoring.service
+++ b/docs/stream-rework/prod/monitoring/monitoring.service
@@ -18,12 +18,21 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/etc/moafunk/monitoring
+# Make BACKEND_NETWORK (and the rest) available to ExecStartPost. Optional ('-')
+# so a missing env file doesn't block start.
+EnvironmentFile=-/etc/moafunk/monitoring/monitoring.env
 # Re-render the alertmanager config from the template each start (picks up token
 # rotations in monitoring.env). envsubst ships in gettext-base.
 ExecStartPre=/bin/bash -c 'set -a; . monitoring.env; set +a; envsubst < alertmanager/alertmanager.yml.tmpl > alertmanager/alertmanager.yml'
 # mon-compose.sh resolves `docker compose` (v2 plugin) OR the standalone
 # `docker-compose` binary — the box may have either. See the script header.
 ExecStart=/etc/moafunk/monitoring/mon-compose.sh --env-file monitoring.env -f docker-compose.monitoring.yml up -d
+# docker-compose v2.24.6 sometimes fails to attach a service to a pre-existing
+# EXTERNAL network on recreate (verified: prometheus landed only on the project
+# default net → 'lookup unheard-api: server misbehaving'). Connect it explicitly
+# every start; idempotent (no-op if already attached), live-attach needs no
+# Prometheus restart. Runs on deploys AND reboots.
+ExecStartPost=/bin/bash -c 'cid=$(docker ps -q -f name=moafunk-monitoring-prometheus | head -1); [ -n "$cid" ] && docker network connect "${BACKEND_NETWORK:-unheard-backend_default}" "$cid" 2>/dev/null; true'
 ExecStop=/etc/moafunk/monitoring/mon-compose.sh -f docker-compose.monitoring.yml down
 
 [Install]


### PR DESCRIPTION
## What
Add an idempotent `ExecStartPost` to `monitoring.service` that `docker network connect`s the Prometheus container to the backend network (`${BACKEND_NETWORK:-unheard-backend_default}`) on every start, plus `EnvironmentFile=-` to source `monitoring.env`.

## Why
`up{job="backend"}=0` after a monitoring redeploy: on-box diagnosis showed Prometheus's scrape failing with `lookup unheard-api … server misbehaving`, and `docker inspect` confirmed the recreated Prometheus container was attached **only** to `moafunk-monitoring_default`, not the pre-existing external `unheard-backend_default` — even though `docker-compose config` resolves both networks correctly. It's a docker-compose v2.24.6 runtime quirk (doesn't attach a service to a pre-existing external net on recreate). The backend recording-durability scrape was therefore blind.

## How
`ExecStartPost` runs after `up -d` on every unit start (deploys *and* reboots), connects Prometheus to the backend net, and is a no-op if already attached (`2>/dev/null; true`). Live-attach adds the interface + DNS without restarting Prometheus, so the next scrape resolves `unheard-api`.

## Test plan
- [x] `bash -n` on the ExecStartPost one-liner
- [ ] Redeploy → `bash /tmp/mon-check.sh` shows `up{job="backend"}=1`; `docker inspect` shows prometheus on both nets

## Risk
**Low.** Unit-only; additive/idempotent; no app or prod change. Rollback: `systemctl disable --now monitoring`.
