### PR TITLE
fix(recording): basenames in concat list so finalize works with a relative recordings dir

### DIFF
--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -589,11 +589,25 @@ fn is_segment_file(path: &Path) -> bool {
 }
 
 /// Build an FFmpeg concat-demuxer list from ordered segment paths.
-/// Paths are app-controlled (`seg_%05d.ts`), so no quote-escaping is needed.
+///
+/// Entries are written as **basenames**, not full paths. The list file is created
+/// inside the same `.segs/` directory as the segments, and FFmpeg's concat demuxer
+/// resolves relative entries against the *list file's own directory* — not the
+/// process CWD. Emitting a full relative path (e.g. `./data/…/x.segs/seg_0.ts`)
+/// therefore doubles the prefix (`./data/…/x.segs/./data/…/x.segs/seg_0.ts`) and
+/// fails with "No such file or directory" whenever the recordings dir is relative
+/// — which it is in production (`./data/recordings-temp`). Basenames resolve
+/// correctly whether the segment dir is absolute or relative.
+///
+/// Segment names are app-controlled (`seg_%05d.ts`), so no quote-escaping is needed.
 fn build_concat_list(segments: &[PathBuf]) -> String {
     let mut list = String::new();
     for seg in segments {
-        list.push_str(&format!("file '{}'\n", seg.to_string_lossy()));
+        let name = seg
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_else(|| seg.to_string_lossy());
+        list.push_str(&format!("file '{}'\n", name));
     }
     list
 }
@@ -731,9 +745,35 @@ mod tests {
             PathBuf::from("/r/seg_00002.ts"),
         ];
         let list = build_concat_list(&segs);
+        // Entries are basenames (resolved against the list file's own dir), ordered + quoted.
         assert_eq!(
             list,
-            "file '/r/seg_00000.ts'\nfile '/r/seg_00001.ts'\nfile '/r/seg_00002.ts'\n"
+            "file 'seg_00000.ts'\nfile 'seg_00001.ts'\nfile 'seg_00002.ts'\n"
+        );
+    }
+
+    /// Regression for the lost recording on the Hetzner box (2026-06-19): ffmpeg's
+    /// concat demuxer resolves relative entries against the list file's directory.
+    /// With the production-relative recordings dir (`./data/recordings-temp`),
+    /// emitting full paths doubled the prefix → concat failed "No such file or
+    /// directory" → the recording (system of record) was lost. Entries MUST be bare
+    /// basenames regardless of how deep or relative the segment dir is.
+    #[test]
+    fn concat_list_entries_are_basenames_for_relative_dirs() {
+        let segs = vec![
+            PathBuf::from(
+                "./data/recordings-temp/recording_23_2026-06-19T20-53-03.segs/seg_00000.ts",
+            ),
+            PathBuf::from(
+                "./data/recordings-temp/recording_23_2026-06-19T20-53-03.segs/seg_00001.ts",
+            ),
+        ];
+        let list = build_concat_list(&segs);
+        assert_eq!(list, "file 'seg_00000.ts'\nfile 'seg_00001.ts'\n");
+        // No path separators — else ffmpeg doubles the path against the list dir.
+        assert!(
+            !list.contains('/'),
+            "concat entries must be basenames, got: {list:?}"
         );
     }
 


### PR DESCRIPTION
## What
- `build_concat_list` now emits segment **basenames** in `concat_list.txt` instead of full paths.
- Updates the existing test and adds a regression test (`concat_list_entries_are_basenames_for_relative_dirs`).

## Why
First real broadcast-driven recording on the Hetzner box was **lost**: finalize failed with
`concat ffmpeg failed: ./data/…/recording_23_….segs/concat_list.txt: No such file or directory`.

ffmpeg's concat demuxer resolves relative entries **against the list file's own directory**, not the
process CWD. The list lives inside the `.segs/` dir, so a full *relative* path (prod uses
`./data/recordings-temp`) doubled the prefix → ffmpeg couldn't open the segments → concat failed →
0-byte artifact → R2 multipart `complete` failed. Recording is the system of record, so this is a
durability bug. It never showed on Lightsail/in tests because the unit tests build the `.segs` dir
under an **absolute** tempdir, where resolution happens to work.

## How
Basenames resolve correctly whether the segment dir is absolute or relative, since the list file is
always written alongside the segments.

## Test plan
- [x] `cargo test concat_list` — updated + new regression test pass
- [ ] Redeploy backend to box (`stream_output=icecast`) and re-soak: broadcast → recording finalizes → lands in R2 with checksum verify

## Risk
Low. Pure string-format change in one helper; reused by both live finalize and startup orphan recovery.
Rollback = revert. No schema/API change.
