### PR TITLE
feat(stream): TLS-front Icecast /live.mp3 + status-json via box nginx

### DIFF
--- a/backend/scripts/deploy_hetzner.sh
+++ b/backend/scripts/deploy_hetzner.sh
@@ -397,6 +397,34 @@ server {
     return 404;
   }
 
+  # --- Icecast public mounts (Liquidsoap -> Icecast-KH, host-networked :8010) ---
+  # TLS-front the public audio mount + status JSON so the HTTPS frontend can play
+  # them without mixed-content (plain http://...:8010 is blocked from an https page).
+  # Continuous stream: buffering MUST be off, long read timeout. CORS so the
+  # cross-origin public site can fetch the status JSON for listener counts.
+  location = /live.mp3 {
+    proxy_pass http://127.0.0.1:8010/live.mp3;
+    proxy_http_version 1.1;
+    proxy_buffering off;
+    proxy_set_header Host \$host;
+    proxy_read_timeout 3600s;
+    add_header Access-Control-Allow-Origin "*" always;
+  }
+  location = /test.mp3 {
+    proxy_pass http://127.0.0.1:8010/test.mp3;
+    proxy_http_version 1.1;
+    proxy_buffering off;
+    proxy_set_header Host \$host;
+    proxy_read_timeout 3600s;
+    add_header Access-Control-Allow-Origin "*" always;
+  }
+  location = /status-json.xsl {
+    proxy_pass http://127.0.0.1:8010/status-json.xsl;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    add_header Access-Control-Allow-Origin "*" always;
+  }
+
   location / {
     proxy_pass http://127.0.0.1:8000;
     proxy_http_version 1.1;


### PR DESCRIPTION
## What
- Add nginx `location` blocks on the box's `admin.live.moafunk.de` vhost that TLS-front the Icecast mounts: `/live.mp3`, `/test.mp3`, `/status-json.xsl` → `proxy_pass http://127.0.0.1:8010`.
- `proxy_buffering off` + `proxy_read_timeout 3600s` for the continuous stream; permissive CORS header for the cross-origin status fetch.

## Why
The public site is HTTPS (GitHub Pages). It can't play the plain `http://…:8010/live.mp3` mount (mixed-content) or `fetch()` the status JSON cross-origin without CORS. TLS-fronting via the already-cert'd box nginx gives the frontend an `https://admin.live.moafunk.de/live.mp3` URL to flip to (final step of the #194 cutover).

## How
The blocks live in the `deploy_hetzner.sh` nginx template so they survive vhost regeneration on each `setup_nginx` deploy; certbot re-applies SSL to the block. Hetzner-only — Lightsail has no Icecast.

## Test plan
- [x] `bash -n` syntax check
- [ ] Deploy `deploy_hetzner=true setup_nginx=true stream_output=icecast`; then `curl -fsS https://admin.live.moafunk.de/status-json.xsl` (200 + CORS header) and play `https://admin.live.moafunk.de/live.mp3` during a broadcast

## Risk
Low. Additive location blocks on the existing vhost; does not touch `location /` (admin/API) or the live audio path. Rollback = revert + redeploy.
