### PR TITLE
feat(stream): wire public Icecast stream URLs from repo Variables

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -92,6 +92,18 @@ jobs:
 
       - name: Build website
         run: npm run build
+        env:
+          # Public stream flip (#176/#194): point the public player at the
+          # Hetzner Icecast `/live.mp3` mount (TLS-fronted) + the backend on-air
+          # endpoint. Sourced from repo Variables so the cutover is a Settings
+          # change + re-run, not a code edit. UNSET = empty → config.ts falls back
+          # to the legacy NMS HLS/FLV path (no-op), so merging this is safe.
+          # To go live: set both Variables, then re-run this workflow.
+          #   VITE_STREAM_ICECAST_URL = https://admin.live.moafunk.de/live.mp3
+          #   VITE_STREAM_STATUS_URL  = https://admin.live.moafunk.de/api/stream/status
+          # Rollback: clear the Variables and re-run (NMS stays warm).
+          VITE_STREAM_ICECAST_URL: ${{ vars.VITE_STREAM_ICECAST_URL }}
+          VITE_STREAM_STATUS_URL: ${{ vars.VITE_STREAM_STATUS_URL }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -95,15 +95,18 @@ jobs:
         env:
           # Public stream flip (#176/#194): point the public player at the
           # Hetzner Icecast `/live.mp3` mount (TLS-fronted) + the backend on-air
-          # endpoint. Sourced from repo Variables so the cutover is a Settings
+          # endpoint; the `/test.mp3` var drives the admin broadcaster preview
+          # only (#175). Sourced from repo Variables so the cutover is a Settings
           # change + re-run, not a code edit. UNSET = empty → config.ts falls back
           # to the legacy NMS HLS/FLV path (no-op), so merging this is safe.
-          # To go live: set both Variables, then re-run this workflow.
-          #   VITE_STREAM_ICECAST_URL = https://admin.live.moafunk.de/live.mp3
-          #   VITE_STREAM_STATUS_URL  = https://admin.live.moafunk.de/api/stream/status
+          # To go live: set the Variables, then re-run this workflow.
+          #   VITE_STREAM_ICECAST_LIVE_URL = https://admin.live.moafunk.de/live.mp3
+          #   VITE_STREAM_STATUS_URL       = https://admin.live.moafunk.de/api/stream/status
+          #   VITE_STREAM_ICECAST_TEST_URL = https://admin.live.moafunk.de/test.mp3  (admin preview only)
           # Rollback: clear the Variables and re-run (NMS stays warm).
-          VITE_STREAM_ICECAST_URL: ${{ vars.VITE_STREAM_ICECAST_URL }}
+          VITE_STREAM_ICECAST_LIVE_URL: ${{ vars.VITE_STREAM_ICECAST_LIVE_URL }}
           VITE_STREAM_STATUS_URL: ${{ vars.VITE_STREAM_STATUS_URL }}
+          VITE_STREAM_ICECAST_TEST_URL: ${{ vars.VITE_STREAM_ICECAST_TEST_URL }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,11 +9,11 @@ VITE_STREAM_ICECAST_TEST_URL=
 # Public Icecast /live.mp3 mount (#176). When set, the public player streams
 # this single MP3 mount via native <audio> on all platforms instead of the NMS
 # HLS/FLV pair above. Leave empty until cutover (then e.g.
-# https://radio.live.moafunk.de/live.mp3). Flip = env-only, no code deploy.
-VITE_STREAM_ICECAST_URL=
+# https://admin.live.moafunk.de/live.mp3). Flip = env-only, no code deploy.
+VITE_STREAM_ICECAST_LIVE_URL=
 # Backend on-air endpoint for live detection in Icecast mode (the mksafe mount
 # is always up, so we ask the backend). Empty → HEAD-poll VITE_STREAM_HLS_URL.
-# Set together with VITE_STREAM_ICECAST_URL, e.g. https://admin.live.moafunk.de/api/stream/status
+# Set together with VITE_STREAM_ICECAST_LIVE_URL, e.g. https://admin.live.moafunk.de/api/stream/status
 VITE_STREAM_STATUS_URL=
 
 # Analytics Configuration

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -13,7 +13,7 @@ export const config = {
     // streams this single MP3 mount via native <audio> on every platform
     // (iOS + desktop) instead of the legacy NMS HLS/FLV pair below. Empty →
     // the NMS HLS/FLV path stays active, so this is a no-op env flip.
-    icecast: import.meta.env.VITE_STREAM_ICECAST_URL || '',
+    icecast: import.meta.env.VITE_STREAM_ICECAST_LIVE_URL || '',
     // Backend on-air endpoint (`GET /api/stream/status` → { active }). The
     // authoritative live signal: the Icecast mount is mksafe-backed and thus
     // always up, so mount presence can't tell "show live" from "dead air".


### PR DESCRIPTION
## What
- Inject `VITE_STREAM_ICECAST_URL` + `VITE_STREAM_STATUS_URL` into the `npm run build` step from **GitHub repo Variables**.

## Why
Final step of the #194 cutover: point the public player at the Hetzner Icecast `/live.mp3` mount (TLS-fronted via the box nginx) and the backend on-air endpoint. Sourcing from repo Variables makes the actual go-live a Settings change + workflow re-run rather than a code edit, and clearing the Variables instantly rolls back to NMS.

## How
`config.ts` already falls back to the legacy NMS HLS/FLV URLs when these are empty (#176, merged). With the Variables unset, the build is byte-identical to today — **merging this PR changes nothing**. Going live = set both Variables in Settings → Variables, then re-run FRONTEND workflow.

## Test plan
- [ ] Merge (no-op). Then set the two repo Variables, re-run FRONTEND.
- [ ] During a live broadcast: public page plays `https://admin.live.moafunk.de/live.mp3` on desktop + iOS; on-air indicator reflects `/api/stream/status`.
- [ ] Rollback rehearsal: clear Variables, re-run → back to NMS.

## Risk
Low. No-op until repo Variables are set; the go-live + rollback are both just Variable changes + a Pages rebuild. NMS stays warm.
