### PR TITLE
fix(stream): allow admin.live backend origin in CSP connect-src

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -24,7 +24,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="connect-src 'self' https://stream.moafunk.de https://plausible.moafunk.de/api/event;"
+      content="connect-src 'self' https://admin.live.moafunk.de https://stream.moafunk.de https://plausible.moafunk.de/api/event;"
     />
   </head>
   <body>


### PR DESCRIPTION
## What
Add `https://admin.live.moafunk.de` to the public page's CSP `connect-src`.

## Why
Console on the live public page: CSP blocked `fetch(https://admin.live.moafunk.de/api/stream/status)` → `checkBackendLive()` threw NetworkError → page stayed 'Off air' during a live show, and the player fell back to the now-dead NMS HLS source. The audio mount itself plays (no media-src/default-src restricts it); only the status fetch was blocked.

## Test plan
- [x] build + 39 tests pass
- [ ] After deploy: with a show live, public page flips to 'Live now' and plays `/live.mp3`

## Risk
Minimal — widens connect-src by one trusted origin.