### PR TITLE
fix(stream): drop duplicate CORS header on Icecast mp3 mounts

### DIFF
--- a/backend/scripts/deploy_hetzner.sh
+++ b/backend/scripts/deploy_hetzner.sh
@@ -408,6 +408,10 @@ server {
     proxy_buffering off;
     proxy_set_header Host \$host;
     proxy_read_timeout 3600s;
+    # Icecast-KH already emits its own Access-Control-Allow-Origin on the audio
+    # mounts; hide it so our single permissive value isn't a duplicate (two ACAO
+    # headers are invalid for CORS-enforced fetchers).
+    proxy_hide_header Access-Control-Allow-Origin;
     add_header Access-Control-Allow-Origin "*" always;
   }
   location = /test.mp3 {
@@ -416,6 +420,7 @@ server {
     proxy_buffering off;
     proxy_set_header Host \$host;
     proxy_read_timeout 3600s;
+    proxy_hide_header Access-Control-Allow-Origin;
     add_header Access-Control-Allow-Origin "*" always;
   }
   location = /status-json.xsl {


### PR DESCRIPTION
## What
`proxy_hide_header Access-Control-Allow-Origin` on the `/live.mp3` + `/test.mp3` nginx blocks so KH's own ACAO isn't duplicated by our `add_header`.

## Why
Both mounts returned **two** `Access-Control-Allow-Origin` headers (KH's `https://live.moafunk.de` + our `*`) — invalid for CORS-enforced fetchers. Harmless for the current no-`crossorigin` `<audio>`, but cleaned up. `/status-json.xsl` keeps its header (KH sends none there).

## Test plan
- [x] bash -n
- [ ] On next deploy_hetzner: `curl -D- /live.mp3` shows exactly one ACAO

## Risk
Minimal, nginx-only. Applies on the next deploy_hetzner run (NOT mid-show — a full deploy restarts unheard-api).