### PR TITLE
feat(frontend): auto-update public page to the latest deploy

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,17 @@
 import { config } from './config';
 import { checkStreamStatus, checkBackendLive } from './streamDetector';
 import { initializePlayer, updateLiveStatus, destroyPlayer, restartPlayer } from './player';
+import { startVersionWatcher } from './versionWatcher';
+
+// Pull stale clients onto the latest deploy without a manual refresh, but never
+// reload while audio is actively playing (would cut a live show). Runs on every
+// public page load.
+const isAudioPlaying = (): boolean =>
+  ['player', 'videoElement'].some((id) => {
+    const el = document.getElementById(id) as HTMLMediaElement | null;
+    return !!el && !el.paused && !el.ended && el.readyState > 2;
+  });
+startVersionWatcher({ isPlaying: isAudioPlaying });
 
 // Liveness signal: in Icecast mode the mount is always up (mksafe), so ask the
 // backend's authoritative on-air endpoint; otherwise HEAD-poll the NMS HLS mount.

--- a/frontend/src/versionWatcher.ts
+++ b/frontend/src/versionWatcher.ts
@@ -1,0 +1,78 @@
+/**
+ * Keep public clients on the latest deploy without a manual hard refresh.
+ *
+ * GitHub Pages serves index.html with a 10-minute cache and we can't set headers,
+ * so a returning visitor (or an already-open tab) can keep running an old bundle —
+ * which, after the Icecast cutover, polls the dead NMS mount and never shows a live
+ * show. To fix that going forward, the build stamps a `/version.json` with a build
+ * id; the running page polls it and reloads when it changes. A plain
+ * `location.reload()` forces the browser to revalidate index.html, so the client
+ * lands on the new bundle.
+ *
+ * Playback-aware: never reload while audio is actively playing — that would cut a
+ * live listen (and autoplay policies wouldn't resume it). The reload is deferred to
+ * the next poll where playback is idle, which is exactly the "off air / not
+ * listening" state where staleness actually matters.
+ */
+
+declare const __BUILD_ID__: string;
+
+/** Build id baked in at build time via Vite `define`; `'dev'` when unset (tests/dev). */
+export function currentBuildId(): string {
+  return typeof __BUILD_ID__ !== 'undefined' ? __BUILD_ID__ : 'dev';
+}
+
+/**
+ * Pure decision: reload only when the deployed build differs from ours AND audio
+ * isn't actively playing. Missing `latest` (failed or absent fetch) never reloads.
+ */
+export function shouldReload(
+  current: string,
+  latest: string | null | undefined,
+  isPlaying: boolean
+): boolean {
+  if (!latest) return false;
+  if (latest === current) return false;
+  return !isPlaying;
+}
+
+export interface VersionWatcherOptions {
+  /** True while a live listen is in progress — defers the reload so we don't cut it. */
+  isPlaying: () => boolean;
+  /** Poll cadence in ms (default 60s). */
+  intervalMs?: number;
+  /** Injectable for tests. */
+  reload?: () => void;
+  /** Injectable for tests. */
+  fetchVersion?: () => Promise<string | null>;
+}
+
+/** Fetch the deployed build id from /version.json, cache-busted; null on any error. */
+async function defaultFetchVersion(): Promise<string | null> {
+  try {
+    const res = await fetch(`/version.json?v=${Date.now()}`, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { hash?: string };
+    return data.hash ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start polling for new deploys; reload when one lands and playback is idle.
+ * Returns the interval handle (so callers/tests can clear it).
+ */
+export function startVersionWatcher(opts: VersionWatcherOptions): ReturnType<typeof setInterval> {
+  const intervalMs = opts.intervalMs ?? 60_000;
+  const reload = opts.reload ?? (() => location.reload());
+  const fetchVersion = opts.fetchVersion ?? defaultFetchVersion;
+  const current = currentBuildId();
+
+  return setInterval(async () => {
+    const latest = await fetchVersion();
+    if (shouldReload(current, latest, opts.isPlaying())) {
+      reload();
+    }
+  }, intervalMs);
+}

--- a/frontend/tests/versionWatcher.test.ts
+++ b/frontend/tests/versionWatcher.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shouldReload, startVersionWatcher } from '../src/versionWatcher';
+
+describe('shouldReload', () => {
+  it('reloads when the deployed build changed and audio is idle', () => {
+    expect(shouldReload('abc123', 'def456', false)).toBe(true);
+  });
+
+  it('defers (no reload) while audio is actively playing', () => {
+    expect(shouldReload('abc123', 'def456', true)).toBe(false);
+  });
+
+  it('does not reload when the version is unchanged', () => {
+    expect(shouldReload('abc123', 'abc123', false)).toBe(false);
+  });
+
+  it('does not reload when the latest version is missing (fetch failed)', () => {
+    expect(shouldReload('abc123', null, false)).toBe(false);
+    expect(shouldReload('abc123', undefined, false)).toBe(false);
+  });
+});
+
+describe('startVersionWatcher', () => {
+  it('reloads once a changed version is seen while idle, not before', async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    let deployed = 'build-1';
+    const fetchVersion = vi.fn(async () => deployed);
+
+    startVersionWatcher({
+      isPlaying: () => false,
+      intervalMs: 1000,
+      reload,
+      // currentBuildId() is 'dev' in tests; serve a matching id first so nothing reloads.
+      fetchVersion: async () => {
+        const v = await fetchVersion();
+        return v === 'build-1' ? 'dev' : v;
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(reload).not.toHaveBeenCalled();
+
+    deployed = 'build-2'; // a new deploy lands
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(reload).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('never reloads while playback is active even if the version changed', async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    startVersionWatcher({
+      isPlaying: () => true,
+      intervalMs: 1000,
+      reload,
+      fetchVersion: async () => 'a-different-build',
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(reload).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,43 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import { resolve } from 'path';
+import { execSync } from 'node:child_process';
 import vue from '@vitejs/plugin-vue';
 
+// A build identity that changes on every deploy. Prefer the git short SHA (stable,
+// available in CI); fall back to a build timestamp for detached/no-git builds.
+function resolveBuildId(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return `t${Date.now().toString(36)}`;
+  }
+}
+
+const BUILD_ID = resolveBuildId();
+
+// Emit /version.json so the running page can detect a new deploy and refresh
+// stale clients (GitHub Pages caches index.html for 10 min and we can't set
+// headers). See src/versionWatcher.ts.
+function emitVersionManifest(): Plugin {
+  return {
+    name: 'emit-version-json',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({ hash: BUILD_ID }),
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [vue()],
+  define: { __BUILD_ID__: JSON.stringify(BUILD_ID) },
+  plugins: [vue(), emitVersionManifest()],
   root: 'src',
   publicDir: '../public',
   build: {


### PR DESCRIPTION
## What
- Build stamps a git-SHA **build id** (Vite `define __BUILD_ID__`) and emits **`/version.json`**.
- New `src/versionWatcher.ts`: polls `/version.json` (cache-busted) every 60s and `location.reload()`s when the id changes — **never while audio is playing**.
- Wired into `main.ts` (public page). Unit tests for the pure `shouldReload` + the watcher loop.

## Why
GitHub Pages serves `index.html` with `max-age=600` and offers no header control, so returning visitors and already-open tabs keep running an old bundle. Post-cutover, the old bundle polls the dead NMS mount and shows "off air" during a live show (the incident a tester hit). `location.reload()` forces `index.html` revalidation, so the client lands on the new bundle.

## How
- No new dependency; ~80 LOC + a tiny Vite plugin.
- Playback-aware: reload deferred while `!paused && !ended` on the media element, so a live listen is never cut. Staleness only matters in the off-air/not-listening state, where it reloads silently.
- Scope: public `main.ts` page (the one with the player + the staleness risk).

## Test plan
- [x] `vitest run` — 45 pass incl. 6 new (changed/idle→reload, playing→defer, unchanged/missing→no-op, watcher loop)
- [x] build emits `dist/version.json` = `{"hash":"<sha>"}`
- [ ] After deploy: leave the page open, push a new deploy → an idle tab reloads within ~60s onto the new bundle

## Risk
Low. Doesn't retroactively fix today's already-open pre-cutover tabs (no watcher yet; they self-heal in ~10 min); from this deploy on every client carries it. Reload is gated on a version change + idle playback, so no spurious reloads.
