### PR TITLE
fix(frontend): drop stale static NMS HLS source from the player

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -37,12 +37,11 @@
 
       <!-- PLAY BUTTON -->
       <video id="videoElement" class="video-element"></video>
-      <audio id="player">
-        <source
-          src="https://stream.moafunk.de/live/stream-io/index.m3u8"
-          type="application/x-mpegURL"
-        />
-      </audio>
+      <!-- No static <source>: player.ts sets the source dynamically when a show
+           goes live (Icecast /live.mp3, or NMS HLS/FLV in legacy mode). A static
+           source made the browser probe the now-retired NMS on every load and spam
+           the console with x-mpegURL decode errors. -->
+      <audio id="player"></audio>
       <div class="actions">
         <button id="btn-play" class="btn" onclick="play()"></button>
         <script type="module" src="/main.ts"></script>


### PR DESCRIPTION
## What
Remove the hardcoded `<source src=.../stream-io/index.m3u8 type=application/x-mpegURL>` from `<audio id=player>`.

## Why
On the public page console: `no decoder for application/x-mpegURL` + failed media load on **every** page load. The static source points at the **retired NMS**; `player.ts` already sets the audio src dynamically (Icecast `/live.mp3`, or NMS HLS/FLV in legacy mode), so the static one was dead weight that just probed dead infra and spammed the console. (The page itself was fine — 'Off air' was correct, no show was live.)

## Test plan
- [x] build + 45 tests pass
- [ ] After deploy: public page console is clean off-air; player still plays /live.mp3 when a show is live

## Risk
Minimal — JS owns the source in every mode; removing the unused static fallback changes no playback path.