### PR TITLE
fix(stream): match AudioContext rate to capture device, not forced 48k

### DIFF
--- a/frontend/src/admin/composables/useAudioCapture.ts
+++ b/frontend/src/admin/composables/useAudioCapture.ts
@@ -10,6 +10,22 @@ export interface UseAudioCaptureOptions {
   onError?: (error: string) => void;
 }
 
+/**
+ * Pick AudioContext options that match the capture device's real sample rate.
+ *
+ * Pro interfaces (e.g. Allen & Heath Xone:23C) run at 96/44.1 kHz and ignore the
+ * 48 kHz getUserMedia hint. Firefox refuses to `createMediaStreamSource` when the
+ * context's sample rate differs from the stream's ("Connecting AudioNodes from
+ * AudioContexts with different sample-rate is currently not supported"); Chrome
+ * silently resamples, which is why it only breaks on some machines/browsers.
+ * Building the context at the track's actual rate works on both. Returns
+ * `undefined` (→ default context) when the rate is unknown.
+ */
+export function audioContextOptionsForStream(stream: MediaStream): AudioContextOptions | undefined {
+  const rate = stream.getAudioTracks()[0]?.getSettings().sampleRate;
+  return rate ? { sampleRate: rate } : undefined;
+}
+
 // ─── Singleton state (shared across components / route navigations) ─────────
 const devices = ref<AudioDevice[]>([]);
 const selectedDeviceId = ref<string>('');
@@ -159,7 +175,7 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
     // Clean up previous audio context
     cleanupAudioProcessing();
 
-    audioContext = new AudioContext({ sampleRate: 48000 });
+    audioContext = new AudioContext(audioContextOptionsForStream(stream));
     sourceNode = audioContext.createMediaStreamSource(stream);
     gainNode = audioContext.createGain();
     destinationNode = audioContext.createMediaStreamDestination();

--- a/frontend/tests/useAudioCapture.test.ts
+++ b/frontend/tests/useAudioCapture.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { audioContextOptionsForStream } from '../src/admin/composables/useAudioCapture';
+
+/** Minimal MediaStream stub exposing just the audio-track sample rate. */
+function streamWithRate(rate: number | undefined): MediaStream {
+  return {
+    getAudioTracks: () => [{ getSettings: () => (rate === undefined ? {} : { sampleRate: rate }) }],
+  } as unknown as MediaStream;
+}
+
+describe('audioContextOptionsForStream', () => {
+  it('matches the context to a 96 kHz pro interface (Xone:23C)', () => {
+    expect(audioContextOptionsForStream(streamWithRate(96000))).toEqual({
+      sampleRate: 96000,
+    });
+  });
+
+  it('matches the context to a 44.1 kHz device', () => {
+    expect(audioContextOptionsForStream(streamWithRate(44100))).toEqual({
+      sampleRate: 44100,
+    });
+  });
+
+  it('falls back to the default context when the rate is unknown', () => {
+    expect(audioContextOptionsForStream(streamWithRate(undefined))).toBeUndefined();
+  });
+
+  it('falls back to the default context when there is no audio track', () => {
+    const empty = { getAudioTracks: () => [] } as unknown as MediaStream;
+    expect(audioContextOptionsForStream(empty)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
- Build the capture `AudioContext` at the device's **actual** sample rate instead of a hardcoded 48 kHz.
- Add `audioContextOptionsForStream()` helper (reads `track.getSettings().sampleRate`, falls back to a default context when unknown).
- Unit tests for 96 kHz / 44.1 kHz / unknown / no-track.

## Why
Hosts on pro interfaces (e.g. Allen & Heath **Xone:23C** @ 96 kHz) couldn't start a stream in **Firefox**: the wizard threw `AudioContext.createMediaStreamSource: Connecting AudioNodes from AudioContexts with different sample-rate is currently not supported`. Forcing the context to 48 kHz while the device delivers 96 kHz is the mismatch. Chrome silently resamples, so it only broke on some machines/browsers.

## How
`new AudioContext(audioContextOptionsForStream(stream))` — the context now matches the stream, so `createMediaStreamSource` succeeds on both Firefox and Chrome. WebM/Opus output is unaffected (Opus is always 48 kHz internally; the container is self-describing, so no backend change).

## Test plan
- [x] `npx vitest run` — 49 passed (4 new)
- [ ] Firefox + Xone:23C (96 kHz): select input → no console error → Start Test records & round-trips
- [ ] Chrome regression: capture + test still works

## Risk
Low. Single composable, behaviour-preserving for matched-rate devices; only changes the previously-broken mismatch path. Rollback = revert.
