### PR TITLE
feat(recording): auto-archive streamed broadcasts to moafunk-prod/shows

### DIFF
--- a/backend/src/audio.rs
+++ b/backend/src/audio.rs
@@ -3,7 +3,7 @@
 //! This module provides functions to convert audio files to MP3 format using ffmpeg.
 
 use crate::{config::Config, AppError, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
 /// Supported audio file extensions that can be converted to MP3.
@@ -127,6 +127,53 @@ pub async fn convert_to_mp3(
     );
 
     Ok(mp3_data)
+}
+
+/// Transcode an on-disk audio file to a temporary MP3 file and return its path.
+///
+/// Unlike [`convert_to_mp3`] (which works on in-memory bytes), this streams
+/// file→file through ffmpeg, so a multi-hour show never doubles in RAM. Uses the
+/// same LAME settings (`ffmpeg_mp3_bitrate`/`ffmpeg_mp3_sample_rate`). The caller
+/// owns the returned temp file and must delete it after use.
+pub async fn convert_file_to_mp3(input_path: &Path, config: &Config) -> Result<PathBuf> {
+    let input_str = input_path
+        .to_str()
+        .ok_or_else(|| AppError::Internal("Invalid input path encoding".to_string()))?;
+    let output_path =
+        std::env::temp_dir().join(format!("shows_archive_{}.mp3", uuid::Uuid::new_v4()));
+    let sample_rate_str = config.ffmpeg_mp3_sample_rate.to_string();
+
+    let output = Command::new("ffmpeg")
+        .args([
+            "-i",
+            input_str,
+            "-vn",
+            "-acodec",
+            "libmp3lame",
+            "-ab",
+            &config.ffmpeg_mp3_bitrate,
+            "-ar",
+            &sample_rate_str,
+            "-y",
+            output_path.to_str().unwrap(),
+        ])
+        .output()
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!("Failed to run ffmpeg (is it installed?): {}", e))
+        })?;
+
+    if !output.status.success() {
+        let _ = tokio::fs::remove_file(&output_path).await;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::error!("ffmpeg file conversion failed: {}", stderr);
+        return Err(AppError::Internal(format!(
+            "Audio conversion failed: {}",
+            stderr.lines().last().unwrap_or("Unknown error")
+        )));
+    }
+
+    Ok(output_path)
 }
 
 /// Get the duration of an audio file in milliseconds using ffprobe.

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -511,6 +511,25 @@ async fn upload_artifact_and_record(
         }
     }
 
+    // Auto-publish the streamed broadcast to the curated shows archive
+    // (moafunk-prod/shows/{type}/{date}-{title}/…mp3). Best-effort convenience
+    // copy — any failure is logged but never fails the recording (the raw capture
+    // in `r2_bucket_name` stays the system of record). Skip known-bad captures so a
+    // truncated/failed show never lands in the public archive. Must run before the
+    // cleanup below, which deletes the local artifact we transcode from.
+    if incomplete {
+        tracing::warn!(
+            "Skipping shows-archive publish for show {} — recording marked incomplete",
+            show_id
+        );
+    } else if let Err(e) = publish_stream_to_shows_archive(state, show_id, artifact_path).await {
+        tracing::error!(
+            "Failed to publish streamed show {} to shows archive: {}",
+            show_id,
+            e
+        );
+    }
+
     // Verify-before-delete: only remove the local artifact once R2 confirms the
     // object landed intact (size match). On a mismatch we keep it for recovery.
     if size_verified {
@@ -1423,17 +1442,10 @@ async fn run_finalize(
 
     send_progress_msg(sender, FinalizeProgress::uploading(100, "Upload complete")).await;
 
-    // Also publish the finalized MP3 to the curated shows-archive bucket
-    // (moafunk-prod/shows/{type}/{date}-{title}/…mp3). Best-effort: the primary
-    // upload above is the system of record, so a failure here is logged but must
-    // not fail the finalize.
-    if let Err(e) = publish_to_shows_archive(state, show_id, &output_path).await {
-        tracing::error!(
-            "Failed to publish finalized recording for show {} to shows archive: {}",
-            show_id,
-            e
-        );
-    }
+    // Note: the curated shows archive (moafunk-prod/shows/…) is populated from the
+    // *streamed broadcast* on stream-end (see `publish_stream_to_shows_archive`),
+    // NOT from this UNHEARD multi-track merge. UNHEARD finalize stays out of the
+    // shows archive — its `final.mp3` lives only under `recordings/…` above.
 
     // =========================================================================
     // Cleanup: Delete checkpoint and temp files
@@ -1448,14 +1460,20 @@ async fn run_finalize(
     Ok(final_key)
 }
 
-/// Publish the finalized `final.mp3` to the curated shows-archive bucket under a
-/// human-friendly `shows/{type}/{date}-{title}/…mp3` key (see
-/// [`storage::build_show_archive_key`]). Streams the file straight from disk so a
-/// large show never doubles in memory. Called best-effort from [`run_finalize`].
-async fn publish_to_shows_archive(
+/// Transcode a streamed broadcast to MP3 and publish it to the curated
+/// shows-archive bucket (`r2_shows_bucket_name`) under a human-friendly
+/// `shows/{type}/{date}-{title}/…mp3` key (see [`storage::build_show_archive_key`]).
+///
+/// The recorded artifact is whatever the browser captured (WebM/Opus), so it is
+/// transcoded to MP3 first. The transcode runs file→file and the MP3 is streamed
+/// to R2 via `ByteStream::from_path`, so a multi-hour show never doubles in
+/// memory. Called best-effort from [`upload_artifact_and_record`] when a streamed
+/// show ends — a failure here never affects the raw capture (the system of record
+/// under `recordings/…`).
+async fn publish_stream_to_shows_archive(
     state: &Arc<AppState>,
     show_id: i64,
-    final_path: &std::path::Path,
+    artifact_path: &Path,
 ) -> Result<()> {
     let show: models::Show = sqlx::query_as("SELECT * FROM shows WHERE id = ?")
         .bind(show_id)
@@ -1465,25 +1483,39 @@ async fn publish_to_shows_archive(
 
     let key = storage::build_show_archive_key(&show.show_type, &show.title, &show.date);
 
-    let body = aws_sdk_s3::primitives::ByteStream::from_path(final_path)
-        .await
-        .map_err(|e| {
-            AppError::Internal(format!("Failed to open final.mp3 for shows upload: {}", e))
-        })?;
+    // Transcode the captured broadcast (WebM/Opus) to a temp MP3 on disk.
+    let mp3_path = audio::convert_file_to_mp3(artifact_path, &state.config).await?;
 
-    state
-        .s3_client
-        .put_object()
-        .bucket(&state.config.r2_shows_bucket_name)
-        .key(&key)
-        .body(body)
-        .content_type("audio/mpeg")
-        .send()
-        .await
-        .map_err(|e| AppError::Storage(format!("Failed to upload to shows archive: {}", e)))?;
+    // Upload, then always clean up the temp MP3 regardless of upload outcome.
+    let upload = async {
+        let body = aws_sdk_s3::primitives::ByteStream::from_path(&mp3_path)
+            .await
+            .map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to open transcoded mp3 for shows upload: {}",
+                    e
+                ))
+            })?;
+
+        state
+            .s3_client
+            .put_object()
+            .bucket(&state.config.r2_shows_bucket_name)
+            .key(&key)
+            .body(body)
+            .content_type("audio/mpeg")
+            .send()
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to upload to shows archive: {}", e)))?;
+        Ok::<(), AppError>(())
+    }
+    .await;
+
+    let _ = tokio::fs::remove_file(&mp3_path).await;
+    upload?;
 
     tracing::info!(
-        "Published finalized recording for show {} to shows archive: {}/{}",
+        "Published streamed show {} to shows archive: {}/{}",
         show_id,
         state.config.r2_shows_bucket_name,
         key


### PR DESCRIPTION
## What
- Auto-archive every **streamed show** to `moafunk-prod/shows/{type}/{date}-{title}/…mp3` on stream-end — no manual finalize needed.
- New `audio::convert_file_to_mp3` (file→file ffmpeg, streamed to R2 via `ByteStream::from_path`) transcodes the captured WebM/Opus → MP3.
- New `recording::publish_stream_to_shows_archive`, called best-effort from `upload_artifact_and_record` (the auto path: explicit stop, grace-finalize on disconnect, orphan recovery).
- **Remove** the shows-archive publish from `run_finalize` — the UNHEARD multi-track manual finalize no longer writes to `moafunk-prod`.

## Why
The first cut hooked the archive into `run_finalize` (the UNHEARD finalize-WS merge, which needs an admin to click "Finalize"). A plain streamed show never reaches it, so `moafunk-prod` stayed empty after a real broadcast. The shows archive is the **streamed-broadcast** archive and must populate automatically; UNHEARD is a separate pipeline and stays out of it.

## How
- Publish runs after the DB version row, **before** the local-artifact cleanup, so it can transcode straight off disk.
- Best-effort: logs `tracing::error!` and never fails the recording (raw capture under `recordings/` stays the system of record).
- **Skips** captures flagged `incomplete` (R2 size mismatch / suspiciously short) so a truncated show never lands in the public archive.
- Applies to all `show_type`s.

## Test plan
- [x] `cargo build`, `cargo clippy` (no new warnings), `cargo test build_show_archive_key`.
- [ ] E2E: stream a short show → stop → confirm an object at `moafunk-prod/shows/{type}/{date}-{title}/{date}-{title}.mp3`.
- [ ] Confirm the R2 access key can write `moafunk-prod` (else logs show `Failed to publish streamed show … to shows archive`; recording still succeeds).

## Risk
Medium — touches the recording finalize path, but the change is additive best-effort on the auto path + removal of a best-effort block on the manual path. `gitnexus detect_changes` confirmed the footprint is exactly the streamed-stop and UNHEARD-finalize flows, nothing else. Rollback: revert the commit (the raw capture in `recordings/` is unaffected).
