### PR TITLE
feat(stream): raise live stream to 256k by killing the double MP3 transcode

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -59,10 +59,10 @@ pub struct Config {
     // `icecast://source:hackme@127.0.0.1:8010/live.mp3`. Required when
     // stream_output = "icecast" (validated at load).
     pub icecast_url: Option<String>,
-    #[serde(default = "default_icecast_bitrate")]
-    pub icecast_bitrate: String,
-    #[serde(default = "default_icecast_sample_rate")]
-    pub icecast_sample_rate: u32,
+    // NOTE: the backend no longer transcodes on the Icecast/harbor leg — it
+    // copies the browser's Opus through untouched (`-c:a copy`). The public
+    // bitrate/sample-rate are set by Liquidsoap's `enc` in moafunk.liq, so
+    // there are deliberately no `icecast_bitrate`/`icecast_sample_rate` knobs.
     // Icecast status endpoint for the listener/quality poller (#177), e.g.
     // `http://127.0.0.1:8010/status-json.xsl`. If unset, it's derived from
     // `icecast_url` (host:port → http://host:port/status-json.xsl); if neither
@@ -168,15 +168,6 @@ fn default_rtmp_url() -> String {
 
 fn default_rtmp_stream_key() -> String {
     "stream-io".to_string()
-}
-
-fn default_icecast_bitrate() -> String {
-    // 128 kbps MP3 — the codec/bitrate validated on iOS in the Phase-2 harness.
-    "128k".to_string()
-}
-
-fn default_icecast_sample_rate() -> u32 {
-    44100
 }
 
 fn default_icecast_metrics_poll_secs() -> u64 {
@@ -297,8 +288,6 @@ impl Config {
         match self.stream_output.as_str() {
             "icecast" => PushTarget::Icecast {
                 url: self.icecast_url.clone().unwrap_or_default(),
-                bitrate: self.icecast_bitrate.clone(),
-                sample_rate: self.icecast_sample_rate,
             },
             // Default + "rtmp": validated to be the only other accepted value.
             _ => PushTarget::Rtmp {

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -33,14 +33,14 @@ pub enum PushTarget {
     /// RTMP/FLV ingest (NodeMediaServer). `destination` includes the stream key,
     /// e.g. `rtmp://stream.moafunk.de/live/stream-io`.
     Rtmp { destination: String },
-    /// Icecast mount (MP3 — the iOS-safe codec validated in the Phase-2 harness).
+    /// Icecast SOURCE / Liquidsoap harbor mount. The browser's Opus is pushed
+    /// through *without re-encoding* (`-c:a copy` into Ogg): the harbor hop is
+    /// localhost and Liquidsoap re-encodes to the public MP3 mount anyway, so
+    /// transcoding here would only add a second lossy stage. The single lossy
+    /// MP3 encode (the iOS-safe public codec) lives in `moafunk.liq`'s `enc`.
     /// `url` is the full source URL incl. credentials + mount, e.g.
-    /// `icecast://source:pw@127.0.0.1:8010/live.mp3`.
-    Icecast {
-        url: String,
-        bitrate: String,
-        sample_rate: u32,
-    },
+    /// `icecast://source:pw@127.0.0.1:8005/live`.
+    Icecast { url: String },
 }
 
 impl PushTarget {
@@ -61,25 +61,24 @@ impl PushTarget {
                 "flv".into(),
                 destination.clone(),
             ],
-            PushTarget::Icecast {
-                url,
-                bitrate,
-                sample_rate,
-            } => vec![
+            PushTarget::Icecast { url } => vec![
+                // No re-encode: copy the browser's Opus straight through and
+                // rewrap it into Ogg for the Icecast SOURCE (harbor) protocol.
+                // Liquidsoap owns the single lossy MP3 encode downstream, so the
+                // internal leg stays lossless — one fewer transcode than before.
+                //
+                // Fallback if `-c:a copy` ever streams unclean Ogg to the harbor
+                // (granulepos/timestamp issues on a live WebM/Opus source):
+                // encode lossless FLAC instead — still one lossy stage total —
+                //   "-c:a", "flac", "-content_type", "audio/ogg", "-f", "ogg".
                 "-c:a".into(),
-                "libmp3lame".into(),
-                "-b:a".into(),
-                bitrate.clone(),
-                "-ar".into(),
-                sample_rate.to_string(),
-                "-ac".into(),
-                "2".into(),
-                // Drop any video track and tag the Icecast content-type as MP3.
+                "copy".into(),
+                // Drop any video track and tag the harbor content-type as Ogg.
                 "-vn".into(),
                 "-content_type".into(),
-                "audio/mpeg".into(),
+                "audio/ogg".into(),
                 "-f".into(),
-                "mp3".into(),
+                "ogg".into(),
                 url.clone(),
             ],
         }
@@ -89,7 +88,7 @@ impl PushTarget {
     pub fn redacted(&self) -> String {
         match self {
             PushTarget::Rtmp { destination } => destination.clone(),
-            PushTarget::Icecast { url, .. } => redact_icecast_password(url),
+            PushTarget::Icecast { url } => redact_icecast_password(url),
         }
     }
 }
@@ -796,26 +795,22 @@ mod tests {
     }
 
     #[test]
-    fn icecast_target_emits_mp3_output_args() {
+    fn icecast_target_copies_opus_to_ogg() {
         let t = PushTarget::Icecast {
-            url: "icecast://source:pw@127.0.0.1:8010/live.mp3".to_string(),
-            bitrate: "128k".to_string(),
-            sample_rate: 44100,
+            url: "icecast://source:pw@127.0.0.1:8005/live".to_string(),
         };
         let args = t.output_args();
-        assert!(args.iter().any(|a| a == "libmp3lame"));
-        assert!(args.windows(2).any(|w| w == ["-b:a", "128k"]));
-        assert!(args.windows(2).any(|w| w == ["-ar", "44100"]));
-        assert!(args
-            .windows(2)
-            .any(|w| w == ["-content_type", "audio/mpeg"]));
-        // MP3 muxer + Icecast URL last.
+        // No re-encode on the harbor leg — Liquidsoap owns the final MP3.
+        assert!(args.windows(2).any(|w| w == ["-c:a", "copy"]));
+        assert!(!args.iter().any(|a| a == "libmp3lame"));
+        assert!(args.windows(2).any(|w| w == ["-content_type", "audio/ogg"]));
+        // Ogg muxer + Icecast URL last.
         assert_eq!(
             &args[args.len() - 3..],
             &[
                 "-f".to_string(),
-                "mp3".to_string(),
-                "icecast://source:pw@127.0.0.1:8010/live.mp3".to_string()
+                "ogg".to_string(),
+                "icecast://source:pw@127.0.0.1:8005/live".to_string()
             ]
         );
     }
@@ -823,12 +818,10 @@ mod tests {
     #[test]
     fn icecast_password_is_redacted_for_logs() {
         let t = PushTarget::Icecast {
-            url: "icecast://source:s3cret@127.0.0.1:8010/live.mp3".to_string(),
-            bitrate: "128k".to_string(),
-            sample_rate: 44100,
+            url: "icecast://source:s3cret@127.0.0.1:8005/live".to_string(),
         };
         let r = t.redacted();
-        assert_eq!(r, "icecast://source:***@127.0.0.1:8010/live.mp3");
+        assert_eq!(r, "icecast://source:***@127.0.0.1:8005/live");
         assert!(!r.contains("s3cret"));
         // RTMP has no secret to redact.
         assert_eq!(

--- a/docs/stream-rework/backend-hetzner-migration.md
+++ b/docs/stream-rework/backend-hetzner-migration.md
@@ -130,7 +130,8 @@ a code change. The `stream_output` input (default `rtmp`) controls the generated
   `STREAM_OUTPUT=icecast`,
   `ICECAST_URL=icecast://source:<HARBOR_LIVE_PASSWORD>@host.docker.internal:8005/live`,
   `ICECAST_STATUS_URL=http://host.docker.internal:8010/status-json.xsl` — i.e.
-  ffmpeg pushes MP3 to the co-located Liquidsoap harbor `live` mount and metrics
+  ffmpeg copies Opus (no re-encode, Ogg) to the co-located Liquidsoap harbor
+  `live` mount — Liquidsoap does the one MP3 encode — and metrics
   poll the local Icecast. The recording tee stays an independent ffmpeg, so the
   flip never gaps the archive (#185 isolation).
 

--- a/docs/stream-rework/local-test-harness/README.md
+++ b/docs/stream-rework/local-test-harness/README.md
@@ -72,12 +72,28 @@ cd docs/stream-rework/local-test-harness
 docker compose -f docker-compose.no-nms.yml up --build
 ```
 
-Chain: `producer (ffmpeg) ──icecast SOURCE──▶ Liquidsoap harbor ─▶ Icecast /live.mp3`.
+Chain: `producer (ffmpeg) ──Ogg/Opus SOURCE──▶ Liquidsoap harbor ─▶ Icecast /live.mp3`.
 The `producer` service runs the **exact** ffmpeg output args the Rust backend emits for
-`PushTarget::Icecast` (`backend/src/stream_bridge.rs`), so a green run validates the real
-backend→Liquidsoap→Icecast leg — no NMS, no RTMP. Validate with the same gates as above,
-but against **`/live.mp3`** (e.g. `http://localhost:8010/live.mp3`, and the iPhone-on-LAN
-Safari check). `mksafe` still fills silence until the producer connects.
+`PushTarget::Icecast` (`backend/src/stream_bridge.rs`) — `-c:a copy -f ogg`, i.e. it
+**copies** a simulated browser Opus/WebM stream through the harbor with no re-encode, and
+Liquidsoap performs the single 256 kbps MP3 encode. So a green run validates the real
+backend→Liquidsoap→Icecast leg — no NMS, no RTMP, no double transcode. Validate with the
+same gates as above, but against **`/live.mp3`** (e.g. `http://localhost:8010/live.mp3`,
+and the iPhone-on-LAN Safari check). `mksafe` still fills silence until the producer connects.
+
+**Extra gate for the quality change — confirm the public bitrate is actually 256k:**
+
+```bash
+ffprobe -v error -show_entries stream=bit_rate,codec_name -of default=nw=1 \
+  http://localhost:8010/live.mp3              # → codec_name=mp3, bit_rate≈256000
+```
+
+(If `bit_rate` reads empty for the live mount, sample it instead:
+`curl -s --max-time 6 http://localhost:8010/live.mp3 -o /tmp/l.mp3 && ffprobe -v error -show_entries format=bit_rate -of default=nw=1 /tmp/l.mp3` → ~256000.)
+
+If `producer` exits or the harbor logs a decode error, ffmpeg's live WebM/Opus→Ogg copy
+isn't clean enough — switch the producer's second ffmpeg (and `output_args`) to the FLAC
+fallback: `-c:a flac -content_type audio/ogg -f ogg`. Same single-lossy-stage result.
 
 Tear down with `docker compose -f docker-compose.no-nms.yml down -v`.
 

--- a/docs/stream-rework/local-test-harness/docker-compose.no-nms.yml
+++ b/docs/stream-rework/local-test-harness/docker-compose.no-nms.yml
@@ -4,9 +4,10 @@
 #
 # There is NO NodeMediaServer and NO RTMP here — this is the architecture that
 # replaces them. The `producer` runs the EXACT ffmpeg output args the Rust
-# backend emits for `PushTarget::Icecast` (see backend/src/stream_bridge.rs),
-# only swapping the WebM-on-stdin input for a synthetic test tone. So a green run
-# proves the backend→Liquidsoap→Icecast leg end-to-end, codec and all.
+# backend emits for `PushTarget::Icecast` (see backend/src/stream_bridge.rs):
+# it copies a simulated browser Opus/WebM stream straight into the harbor
+# (`-c:a copy -f ogg`), no re-encode. Liquidsoap does the one MP3 encode (256k).
+# So a green run proves the backend→Liquidsoap→Icecast leg end-to-end, codec and all.
 #
 #   docker compose -f docker-compose.no-nms.yml up --build
 #   open http://localhost:8010/live.mp3        # desktop; iPhone uses http://<LAN-ip>:8010/live.mp3
@@ -31,34 +32,27 @@ services:
     command: ["liquidsoap", "/moafunk.liq"]
     restart: unless-stopped
 
-  # Producer — stands in for the backend. Pushes a 440 Hz tone to the Liquidsoap
-  # harbor using the SAME ffmpeg output chain as PushTarget::Icecast::output_args:
-  #   -c:a libmp3lame -b:a 128k -ar 44100 -ac 2 -vn -content_type audio/mpeg -f mp3 icecast://…
-  # restart keeps it retrying until the harbor is listening (no ordering dance).
+  # Producer — stands in for the backend. Faithfully rehearses BOTH legs of the
+  # real chain in two piped ffmpegs:
+  #   1. simulate the browser MediaRecorder: 440 Hz tone → Opus 192k in WebM
+  #      (matches useAudioCapture.ts: audioBitsPerSecond 192000, webm/opus).
+  #   2. the EXACT backend leg: `-f webm -i pipe:0` (start_stream input) +
+  #      PushTarget::Icecast::output_args (`-c:a copy -vn -content_type audio/ogg
+  #      -f ogg icecast://…`). No re-encode — copies the Opus straight through.
+  # A green run proves ffmpeg's live WebM/Opus→Ogg copy is clean enough for the
+  # harbor AND that Liquidsoap decodes it and emits the single 256k MP3. `restart`
+  # keeps it retrying until the harbor is listening (no ordering dance).
   producer:
     image: jrottenberg/ffmpeg:6.1-alpine
     depends_on: [liquidsoap]
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - "-hide_banner"
-      - "-loglevel"
-      - "warning"
-      - "-re"
-      - "-f"
-      - "lavfi"
-      - "-i"
-      - "sine=frequency=440:sample_rate=48000"
-      - "-c:a"
-      - "libmp3lame"
-      - "-b:a"
-      - "128k"
-      - "-ar"
-      - "44100"
-      - "-ac"
-      - "2"
-      - "-vn"
-      - "-content_type"
-      - "audio/mpeg"
-      - "-f"
-      - "mp3"
-      - "icecast://source:harborpw@liquidsoap:8005/live"
+      - >
+        ffmpeg -hide_banner -loglevel warning -re
+        -f lavfi -i sine=frequency=440:sample_rate=48000
+        -c:a libopus -b:a 192k -f webm pipe:1
+        | ffmpeg -hide_banner -loglevel warning
+        -f webm -i pipe:0
+        -c:a copy -vn -content_type audio/ogg -f ogg
+        icecast://source:harborpw@liquidsoap:8005/live
     restart: unless-stopped

--- a/docs/stream-rework/local-test-harness/liquidsoap/moafunk-harbor.liq
+++ b/docs/stream-rework/local-test-harness/liquidsoap/moafunk-harbor.liq
@@ -1,25 +1,29 @@
 # Greenfield (no-NMS) rehearsal — issue #194 decision (B).
 #
-# The backend ffmpeg pushes MP3 straight into Liquidsoap's HARBOR (which speaks
-# the Icecast SOURCE protocol); Liquidsoap re-emits to Icecast. This is the path
-# that REPLACES NodeMediaServer: there is no RTMP and no NMS anywhere in the chain.
+# The backend ffmpeg copies the broadcaster's Opus (no re-encode) straight into
+# Liquidsoap's HARBOR (which speaks the Icecast SOURCE protocol); Liquidsoap
+# performs the single lossy MP3 encode to Icecast. This is the path that
+# REPLACES NodeMediaServer: no RTMP and no NMS anywhere in the chain.
 #
-#   backend ffmpeg ──icecast://…@liquidsoap:8005/live──▶ input.harbor ─▶ mksafe ─▶ Icecast /live.mp3
+#   backend ffmpeg ──icecast://…@liquidsoap:8005/live (Ogg/Opus)──▶ input.harbor ─▶ mksafe ─▶ Icecast /live.mp3
 #
 # Compare with moafunk.liq (the NMS parallel-run rehearsal), which instead PULLS
 # RTMP from NodeMediaServer via input.ffmpeg.
 
 # Harbor input: receive the producer's source push on port 8005, mount "live".
-# Same wire protocol as an Icecast source, so the backend's existing
-# `-f mp3 icecast://source:pw@host:port/mount` output targets it unchanged.
+# Same wire protocol as an Icecast source, so the backend's
+# `-c:a copy -f ogg icecast://source:pw@host:port/mount` output targets it
+# unchanged. Liquidsoap sniffs the Ogg/Opus container automatically.
 src = input.harbor("live", port=8005, password="harborpw")
 
 # Never let the public mount 404 if the producer drops — fall back to silence.
 radio = mksafe(src)
 
-# Output: MP3 to Icecast /live.mp3 (iOS-safe codec; NEVER Opus/Ogg for the public mount).
+# Output: MP3 to Icecast /live.mp3 (iOS-safe codec; NEVER Opus/Ogg for the
+# public mount). The ONLY lossy encode in the chain — runs at 256 kbps to match
+# prod (the internal harbor leg is lossless Opus passthrough).
 output.icecast(
-  %mp3(bitrate=128, samplerate=44100, stereo=true),
+  %mp3(bitrate=256, samplerate=44100, stereo=true),
   host="icecast",
   port=8000,
   password="localsource",

--- a/docs/stream-rework/prod/README.md
+++ b/docs/stream-rework/prod/README.md
@@ -1,8 +1,8 @@
 # Production stream stack — Icecast-KH + Liquidsoap (no NMS)
 
-Deploy-ready configs for the **greenfield #194 target**: the backend pushes audio
-into a Liquidsoap **harbor**, Liquidsoap re-emits MP3 to **Icecast-KH**. No
-NodeMediaServer, no RTMP. These are the production counterparts to the validated
+Deploy-ready configs for the **greenfield #194 target**: the backend copies the
+broadcaster's Opus (no re-encode) into a Liquidsoap **harbor**, and Liquidsoap
+performs the single lossy MP3 encode to **Icecast-KH**. No NodeMediaServer, no RTMP. These are the production counterparts to the validated
 [`../local-test-harness/`](../local-test-harness/) (decision **B**), and the
 on-box steps live in [`../phase-2-icecast-runbook.md`](../phase-2-icecast-runbook.md).
 

--- a/docs/stream-rework/prod/moafunk.liq
+++ b/docs/stream-rework/prod/moafunk.liq
@@ -1,7 +1,9 @@
 # Production Liquidsoap producer — issue #194 decision (B), no NMS.
 #
-# The backend ffmpeg (STREAM_OUTPUT=icecast) pushes MP3 into Liquidsoap's HARBOR
-# (Icecast SOURCE protocol); Liquidsoap re-emits to Icecast-KH. Two independent
+# The backend ffmpeg (STREAM_OUTPUT=icecast) copies the broadcaster's Opus
+# (no re-encode, `-c:a copy` → Ogg) into Liquidsoap's HARBOR (Icecast SOURCE
+# protocol); Liquidsoap performs the single lossy MP3 encode to Icecast-KH. The
+# harbor hop is localhost, so the internal leg is lossless. Two independent
 # chains give the #173 "separate /test and /live mounts with separate creds":
 #
 #   backend (ICECAST_URL=…/test) ─▶ harbor "test" :8005 ─▶ mksafe ─▶ Icecast /test.mp3   (preview)
@@ -28,8 +30,11 @@ ice_host       = "127.0.0.1"
 ice_port       = int_of_string(default=8010, environment.get("ICECAST_PORT"))
 
 # MP3 only on the public mounts — iOS Safari can't decode Opus/Ogg (would
-# silently lock out every iPhone). 128 kbps matches the validated harness.
-enc = %mp3(bitrate=128, samplerate=44100, stereo=true)
+# silently lock out every iPhone). This is now the ONLY lossy encode in the
+# chain (the backend copies Opus through the harbor untouched), so we run a high
+# bitrate here without paying for a second transcode. Source is Opus ~192 kbps;
+# 256 kbps MP3 preserves it transparently. ~2x listener egress vs the old 128k.
+enc = %mp3(bitrate=256, samplerate=44100, stereo=true)
 
 # --- preview chain: harbor "test" → Icecast /test.mp3 -------------------------
 # mksafe serves silence (never 404) until the broadcaster connects.


### PR DESCRIPTION
## What

The live stream now reaches listeners at **256 kbps MP3** instead of 128k, by removing a redundant encode stage rather than just turning a knob up.

## Why

The live chain was encoding MP3 **twice at 128k**:

```
browser ─Opus 192k─▶ backend ffmpeg ─MP3 128k─▶ harbor ─▶ Liquidsoap ─MP3 128k─▶ /live.mp3 ─▶ listeners
                       (lossy #1)                          (lossy #2)
```

The backend→harbor hop is localhost, so encoding there only threw away signal before Liquidsoap re-encoded it anyway. Now the backend **copies** the browser's Opus straight through (`-c:a copy -f ogg`, no re-encode), and Liquidsoap's `enc` is the single lossy stage — raised to `%mp3(bitrate=256)`:

```
browser ─Opus 192k─▶ backend ffmpeg ─Opus (copy)─▶ harbor ─▶ Liquidsoap ─MP3 256k─▶ /live.mp3 ─▶ listeners
                      (no re-encode, lossless leg)            (single lossy stage)
```

Public mount stays MP3 (iOS-safe); only the internal leg format changed.

## Changes

- **`stream_bridge.rs`** — `PushTarget::Icecast` slimmed to `{ url }`; output args are now `-c:a copy -vn -content_type audio/ogg -f ogg`. FLAC fallback documented inline.
- **`config.rs`** — dropped the now-unused `icecast_bitrate` / `icecast_sample_rate` knobs (public bitrate is owned by `moafunk.liq`).
- **Liquidsoap** — `enc` 128k → 256k in prod (`prod/moafunk.liq`) and the harness.
- **Harness** — `docker-compose.no-nms.yml` producer now faithfully rehearses the real copy/ogg leg from a simulated browser Opus/WebM source; README gains a 256k bitrate-verification gate.
- Runbook docs updated (no longer claim "ffmpeg pushes MP3").

## Validation

- `cargo build` / `cargo clippy` clean; **8 stream_bridge + 6 config tests** pass.
- **End-to-end on the no-NMS harness:** harbor decodes the copied Opus and switches off silence; `/live.mp3` serves `mp3, 44100 Hz, stereo, 256 kb/s`, mean volume −21 dB (non-silent). The live WebM/Opus→Ogg copy is clean — FLAC fallback not needed.

## Before merge ⚠️

#222 added **auto-deploy to Hetzner on push to main**, so merging this ships it. Recommend a Tier-3 check first: run the real backend (`STREAM_OUTPUT=icecast` → harness harbor) and confirm `/live.mp3` is 256k + the **iOS-on-LAN Safari** playback gate from the harness README.

Note: ~2× listener egress vs 128k (trivial for the Hetzner box).