### PR TITLE
feat(recording): number repeat show recordings instead of overwriting

### DIFF
--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -1481,7 +1481,16 @@ async fn publish_stream_to_shows_archive(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Show {} not found", show_id)))?;
 
-    let key = storage::build_show_archive_key(&show.show_type, &show.title, &show.date);
+    // Build the human-friendly key, then number it (`…-2.mp3`, `…-3.mp3`, …) if a
+    // recording for this show already exists, so repeat broadcasts of the same
+    // show never overwrite each other.
+    let base_key = storage::build_show_archive_key(&show.show_type, &show.title, &show.date);
+    let key = storage::unique_object_key(
+        &state.s3_client,
+        &state.config.r2_shows_bucket_name,
+        &base_key,
+    )
+    .await;
 
     // Transcode the captured broadcast (WebM/Opus) to a temp MP3 on disk.
     let mp3_path = audio::convert_file_to_mp3(artifact_path, &state.config).await?;

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -435,6 +435,59 @@ pub fn build_show_archive_key(show_type: &str, title: &str, date: &str) -> Strin
     format!("shows/{}/{}/{}.mp3", type_slug, stem, stem)
 }
 
+/// Insert a `-{n}` suffix before the extension of an object key's filename,
+/// keeping its directory. `shows/x/stem.mp3`, 2 → `shows/x/stem-2.mp3`. A key
+/// with no extension just gets the suffix appended.
+pub fn numbered_key(key: &str, n: u32) -> String {
+    let (dir, file) = match key.rsplit_once('/') {
+        Some((d, f)) => (Some(d), f),
+        None => (None, key),
+    };
+    let numbered = match file.rsplit_once('.') {
+        Some((stem, ext)) => format!("{}-{}.{}", stem, n, ext),
+        None => format!("{}-{}", file, n),
+    };
+    match dir {
+        Some(d) => format!("{}/{}", d, numbered),
+        None => numbered,
+    }
+}
+
+/// Resolve `desired_key` to a key that does not yet exist in `bucket`: the base
+/// key if it's free, otherwise `…-2`, `…-3`, … (see [`numbered_key`]) so repeated
+/// recordings of the same show never overwrite each other. Probes via HEAD; a
+/// successful HEAD means the object exists. The probe is bounded — on the
+/// (practically impossible) miss it falls back to the base key.
+pub async fn unique_object_key(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    desired_key: &str,
+) -> String {
+    if !object_exists(client, bucket, desired_key).await {
+        return desired_key.to_string();
+    }
+    for n in 2..=999 {
+        let candidate = numbered_key(desired_key, n);
+        if !object_exists(client, bucket, &candidate).await {
+            return candidate;
+        }
+    }
+    desired_key.to_string()
+}
+
+/// Whether `key` exists in `bucket`. A successful HEAD ⇒ exists; any error
+/// (NotFound or transient) ⇒ treated as absent, matching prior overwrite
+/// behaviour on the base key.
+async fn object_exists(client: &aws_sdk_s3::Client, bucket: &str, key: &str) -> bool {
+    client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .is_ok()
+}
+
 fn extract_ext(filename: &str) -> String {
     std::path::Path::new(filename)
         .extension()
@@ -1129,6 +1182,28 @@ mod tests {
             build_show_archive_key("", "", "2026-01-02"),
             "shows/untitled/2026-01-02-show/2026-01-02-show.mp3"
         );
+    }
+
+    #[test]
+    fn numbered_key_suffixes_filename_before_extension() {
+        // Numbers the filename stem, keeps the directory and extension.
+        assert_eq!(
+            numbered_key(
+                "shows/external/2026-06-20-testshow/2026-06-20-testshow.mp3",
+                2
+            ),
+            "shows/external/2026-06-20-testshow/2026-06-20-testshow-2.mp3"
+        );
+        assert_eq!(
+            numbered_key(
+                "shows/external/2026-06-20-testshow/2026-06-20-testshow.mp3",
+                10
+            ),
+            "shows/external/2026-06-20-testshow/2026-06-20-testshow-10.mp3"
+        );
+        // No directory and no extension are both handled.
+        assert_eq!(numbered_key("stem.mp3", 3), "stem-3.mp3");
+        assert_eq!(numbered_key("noext", 2), "noext-2");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
- Repeat broadcasts of the same show no longer overwrite each other in `moafunk-prod/shows/`. The first take keeps `…/{stem}.mp3`; subsequent takes become `…/{stem}-2.mp3`, `{stem}-3.mp3`, … in the same per-show folder.
- New `storage::unique_object_key` (HEAD-probes for the next free key) + pure `storage::numbered_key` helper, unit-tested.

## Why
The archive key is derived from show type/title/date, so re-streaming a show produced the same key and silently replaced the previous mp3 (observed live: two test runs collapsed to one object).

## How
- `publish_stream_to_shows_archive` resolves the base key through `unique_object_key` before upload.
- `numbered_key` inserts `-{n}` before the extension, preserving directory + extension.
- Existence check = successful HEAD; any error (NotFound or transient) is treated as absent, matching prior overwrite behaviour on the base key.

## Test plan
- [x] `cargo build`, `cargo test numbered_key`, `cargo clippy` (no new warnings).
- [ ] Stream the same show twice → confirm `…-testshow.mp3` and `…-testshow-2.mp3` both exist.

## Risk
Low — additive; only the streamed-show archive publish path changes. Adds 1–2 HEAD requests per finalize (best-effort, off the live path). Rollback: revert the commit.
