### PR TITLE
ci(stream): sync Liquidsoap config to Hetzner on deploy

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -438,6 +438,50 @@ jobs:
           RUN_TESTS="${{ inputs.run_tests == false && '0' || '1' }}" \
           ./backend/scripts/deploy_hetzner.sh
 
+      # Sync the Liquidsoap producer config (#194). The .liq is NOT baked into
+      # the backend image — it's bind-mounted into the host's liquidsoap
+      # container at /etc/moafunk/moafunk.liq (see docs/stream-rework/prod/
+      # liquidsoap.service). Without this, repo edits to the encoder (e.g. the
+      # 256k output bitrate) never reach the box and the stream silently keeps
+      # the old settings. Restart Liquidsoap ONLY when the file actually changed,
+      # so routine backend pushes don't gap the stream. (The deploy step above
+      # already restarts unheard-api and drops any in-progress broadcast WS, so a
+      # same-deploy Liquidsoap restart adds no new live-show hazard.)
+      - name: Sync Liquidsoap config to Hetzner (icecast only)
+        if: env.STREAM_OUTPUT_MODE == 'icecast'
+        env:
+          HETZNER_IP: ${{ steps.bitwarden-secrets.outputs.HETZNER_IP }}
+        run: |
+          set -euo pipefail
+          KEY=~/.ssh/hetzner.pem
+          HOST="root@${HETZNER_IP}"   # Hetzner Cloud Ubuntu images log in as root
+
+          scp -i "$KEY" -o StrictHostKeyChecking=no \
+            docs/stream-rework/prod/moafunk.liq "$HOST:/tmp/moafunk.liq.new"
+
+          ssh -i "$KEY" -o StrictHostKeyChecking=no "$HOST" bash -s <<'REMOTE'
+          set -euo pipefail
+          DEST=/etc/moafunk/moafunk.liq
+          NEW=/tmp/moafunk.liq.new
+          if [[ -f "$DEST" ]] && cmp -s "$NEW" "$DEST"; then
+            echo "Liquidsoap config unchanged — skipping restart."
+            rm -f "$NEW"
+            exit 0
+          fi
+          echo "Liquidsoap config changed — installing and restarting."
+          install -m 644 "$NEW" "$DEST"
+          rm -f "$NEW"
+          systemctl restart liquidsoap
+          sleep 5
+          if systemctl is-active --quiet liquidsoap; then
+            echo "liquidsoap active after restart."
+          else
+            echo "ERROR: liquidsoap failed to start after config sync." >&2
+            systemctl status liquidsoap --no-pager -l | tail -30 >&2
+            exit 1
+          fi
+          REMOTE
+
   deploy-monitoring:
     # Deploy the #178 observability stack to the Hetzner box (manual only).
     # Additive + reversible: never touches the backend, the stream stack, or DNS.

--- a/docs/stream-rework/prod/README.md
+++ b/docs/stream-rework/prod/README.md
@@ -20,7 +20,7 @@ backend ffmpeg (STREAM_OUTPUT=icecast)
 |------|---------|---------|
 | `icecast.xml` | `/etc/moafunk/icecast.xml` | Icecast-KH: `/live.mp3` + `/test.mp3` mounts, port 8010 |
 | `icecast-kh.Dockerfile` | `/etc/moafunk/icecast-kh.Dockerfile` | builds the pinned Icecast-KH image from source |
-| `moafunk.liq` | `/etc/moafunk/moafunk.liq` | Liquidsoap: harbor inputs → Icecast, secrets from env |
+| `moafunk.liq` | `/etc/moafunk/moafunk.liq` | Liquidsoap: harbor inputs → Icecast, secrets from env. **Auto-synced by the `deploy-hetzner` CI job** (restarts Liquidsoap only on change) — edit it in the repo, not on the box |
 | `stream.env.example` | `/etc/moafunk/stream.env` (filled) | harbor + Icecast passwords (Bitwarden-injected) |
 | `liquidsoap.service` | `/etc/systemd/system/` | supervises Liquidsoap (docker, `Restart=always`, mem cap) |
 | `icecast.service` | `/etc/systemd/system/` | supervises Icecast-KH (docker, `Restart=always`, mem cap) |
@@ -30,7 +30,9 @@ backend ffmpeg (STREAM_OUTPUT=icecast)
 Both Icecast-KH and Liquidsoap run as **docker containers** supervised by systemd
 (`--network host`, `Restart=always`, hard `--memory` cap) — one consistent pattern.
 
-1. `sudo mkdir -p /etc/moafunk && sudo cp icecast.xml icecast-kh.Dockerfile moafunk.liq /etc/moafunk/`.
+1. `sudo mkdir -p /etc/moafunk && sudo cp icecast.xml icecast-kh.Dockerfile moafunk.liq /etc/moafunk/`
+   (first-time bootstrap only — thereafter `moafunk.liq` is kept current by the
+   `deploy-hetzner` CI job, which re-syncs it and restarts Liquidsoap on change).
 2. Build the pinned Icecast-KH image (no official image exists; we build our own
    from source — see the Dockerfile):
    ```


### PR DESCRIPTION
## What

Adds a step to the `deploy-hetzner` job that ships `docs/stream-rework/prod/moafunk.liq` to the box and restarts Liquidsoap **only when the file changed**.

## Why

Verified after #227 merged: the public mount **stayed at 128 kb/s** even though the 256k change deployed. Root cause — `moafunk.liq` is **bind-mounted** into the host's `liquidsoap` container (`/etc/moafunk/moafunk.liq`, see `liquidsoap.service`); it's not in the backend image and was in **no** pipeline. `sync-scripts` only pushes `backend/scripts/*` to Lightsail. So repo edits to the encoder silently never reached production:

```
$ ffprobe https://admin.live.moafunk.de/live.mp3
  Audio: mp3, 44100 Hz, stereo, 128 kb/s        # ← still old, post-#227
```

## How

New step (icecast mode only — i.e. every push to main):
- `scp` the repo's `moafunk.liq` → `/tmp/moafunk.liq.new` on the box.
- `cmp` against `/etc/moafunk/moafunk.liq`; **unchanged → skip** (no restart, no stream gap).
- changed → `install` + `systemctl restart liquidsoap`, then assert the service is active (fail the job with `systemctl status` on error).

Safety: the deploy step already restarts `unheard-api` and drops any in-progress broadcast WS, so a same-deploy Liquidsoap restart adds **no new** live-show hazard. The change-gating means routine backend pushes (config unchanged) never touch Liquidsoap.

## Effect of merging

Merging this is itself a push to main → `deploy-hetzner` runs → syncs the already-256k `moafunk.liq` and restarts Liquidsoap → **the public mount becomes 256k with no manual step.**

## Validation

- `backend.yml` parses (`yaml.safe_load`); heredoc de-indents correctly (closing delimiter at col 0 after YAML strips block indent).
- Post-merge check: re-probe `https://admin.live.moafunk.de/live.mp3` → expect `256 kb/s`.