### PR TITLE
fix(shows): honour stream_mode and refetch host shows on detail page

### DIFF
--- a/frontend/src/admin/__tests__/showMediaMode.test.ts
+++ b/frontend/src/admin/__tests__/showMediaMode.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMediaMode } from '../showMediaMode';
+
+describe('resolveMediaMode', () => {
+  it("opens on the live tab for a show created as stream_mode 'live'", () => {
+    expect(resolveMediaMode({ stream_mode: 'live', prerecorded_key: undefined })).toBe('live');
+  });
+
+  it("opens on the upload tab for a show created as stream_mode 'prerecorded'", () => {
+    expect(resolveMediaMode({ stream_mode: 'prerecorded', prerecorded_key: undefined })).toBe(
+      'upload'
+    );
+  });
+
+  it('defaults to upload when stream_mode is unset', () => {
+    expect(resolveMediaMode({ stream_mode: undefined, prerecorded_key: undefined })).toBe('upload');
+  });
+
+  it('forces upload when a prerecorded file is staged, even for a live show', () => {
+    expect(resolveMediaMode({ stream_mode: 'live', prerecorded_key: 'shows/1/audio.mp3' })).toBe(
+      'upload'
+    );
+  });
+});

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -19,6 +19,7 @@ import { useDataInvalidation } from '../composables/useDataInvalidation';
 import { useDateTimeRange } from '../composables/useDateTimeRange';
 import { useHostFlow } from '../composables/useHostFlow';
 import { useAuthStore } from '../stores/auth';
+import { resolveMediaMode } from '../showMediaMode';
 import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 
@@ -307,9 +308,9 @@ async function loadShow() {
     startTimeForm.value = show.value.start_time || '';
     endTimeForm.value = show.value.end_time || '';
     descriptionForm.value = show.value.description || '';
-    // A present prerecorded file implies upload mode; otherwise keep the
-    // current selection (defaults to 'upload' to surface the upload affordance).
-    if (show.value.prerecorded_key) mediaMode.value = 'upload';
+    // A present prerecorded file implies upload mode; otherwise honour the
+    // delivery mode the show was created with (defaults to 'upload').
+    mediaMode.value = resolveMediaMode(show.value);
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to load show';
   } finally {
@@ -402,8 +403,14 @@ async function enterFlow(mode: 'prerecorded' | 'live') {
   if (!show.value) return;
   const id = show.value.id;
   try {
-    if (!hostFlow.shows.value.length) await hostFlow.fetchMyShow();
-    const mine = hostFlow.shows.value.find((s) => s.id === id);
+    // The host flow caches a show list that may predate this show (e.g. it was
+    // created after the host last opened the stream flow). If the show isn't in
+    // the cache, refetch once before deciding it really isn't ours.
+    let mine = hostFlow.shows.value.find((s) => s.id === id);
+    if (!mine) {
+      await hostFlow.fetchMyShow();
+      mine = hostFlow.shows.value.find((s) => s.id === id);
+    }
     if (!mine) {
       flash.error('This show is not assigned to you.');
       return;

--- a/frontend/src/admin/showMediaMode.ts
+++ b/frontend/src/admin/showMediaMode.ts
@@ -1,0 +1,18 @@
+import type { ShowDetail } from './api';
+
+/**
+ * Decide which media tab the show detail page opens on (live vs upload).
+ *
+ * A present prerecorded file always implies upload mode (the host has already
+ * staged a file); otherwise honour the delivery mode the show was created with
+ * (`stream_mode`), defaulting to 'upload' when it is unset.
+ *
+ * Regression: a show created as `stream_mode: 'live'` must open on the live tab
+ * rather than silently defaulting to upload.
+ */
+export function resolveMediaMode(
+  show: Pick<ShowDetail, 'prerecorded_key' | 'stream_mode'>
+): 'live' | 'upload' {
+  if (show.prerecorded_key) return 'upload';
+  return show.stream_mode === 'live' ? 'live' : 'upload';
+}


### PR DESCRIPTION
## Two show-detail bugs hardened

### 1. New "live" show opened on the Upload tab
The backend persists the wizard's choice as `shows.stream_mode` and the API returns it, but `ShowDetailPage.loadShow()` never read it — `mediaMode` defaulted to `'upload'`. Now initialised via a pure `resolveMediaMode()` helper (a staged prerecorded file still forces upload).

### 2. Host could not "go live": "This show is not assigned to you"
`useHostFlow` is a session-wide singleton cache; `enterFlow` only refetched the show list when that cache was *empty*. A host who'd already opened the stream flow had a stale list missing their freshly created show → false error. Now looks up first, refetches once if missing, then re-checks.

## Tests
- New `showMediaMode.test.ts` (4 cases) as a regression guard for bug 1.
- Full suite: 53 passed. Prettier + `npm run lint` clean.