### PR TITLE
fix(stream): guard flow steps on reload and reflect active audio input

### DIFF
--- a/frontend/src/admin/__tests__/flowRouteGuard.test.ts
+++ b/frontend/src/admin/__tests__/flowRouteGuard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable stub the guard reads through the dynamic `import('./composables')`.
+const flowStub: { show: { value: unknown }; fetchMyShow: ReturnType<typeof vi.fn> } = {
+  show: { value: null },
+  fetchMyShow: vi.fn(),
+};
+
+vi.mock('../composables', () => ({
+  useHostFlow: () => flowStub,
+}));
+
+import { ensureFlowReady } from '../router';
+
+describe('ensureFlowReady (flow step guard)', () => {
+  beforeEach(() => {
+    flowStub.show.value = null;
+    flowStub.fetchMyShow = vi.fn();
+  });
+
+  it('lets navigation through when a show is already selected (no refetch)', async () => {
+    flowStub.show.value = { id: 1, date: '2026-06-20', start_time: '20:00' };
+    const next = vi.fn();
+
+    await ensureFlowReady({}, {}, next);
+
+    expect(flowStub.fetchMyShow).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('refetches when no show is selected, then proceeds once it resolves', async () => {
+    flowStub.fetchMyShow = vi.fn().mockImplementation(async () => {
+      flowStub.show.value = { id: 2, date: '2026-06-20', start_time: '21:00' };
+    });
+    const next = vi.fn();
+
+    await ensureFlowReady({}, {}, next);
+
+    expect(flowStub.fetchMyShow).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('redirects to the smart /stream entry when no show can be resolved', async () => {
+    flowStub.fetchMyShow = vi.fn().mockResolvedValue(undefined); // show stays null
+    const next = vi.fn();
+
+    await ensureFlowReady({}, {}, next);
+
+    expect(flowStub.fetchMyShow).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith('/stream');
+  });
+});

--- a/frontend/src/admin/pages/flow/FlowLive.vue
+++ b/frontend/src/admin/pages/flow/FlowLive.vue
@@ -21,6 +21,14 @@ function onDeviceChange() {
 onMounted(async () => {
   // First refresh prompts for permission so device labels are populated.
   await audioCapture.refreshDevices();
+  // The capture singleton persists across navigations (so audio survives into
+  // the Stream step). If we re-enter setup while a device is still being
+  // captured, mirror it in the dropdown — otherwise the UI shows "no input
+  // selected" while actually recording that stale device on Start Test.
+  const activeId = audioCapture.selectedDeviceId.value;
+  if (audioCapture.isCapturing.value && activeId && activeId !== 'screen') {
+    selectedDevice.value = activeId;
+  }
   // Keep the list fresh: react to hot-plug events, plus a slow timer fallback.
   navigator.mediaDevices.addEventListener('devicechange', onDeviceChange);
   deviceRefreshInterval = setInterval(() => audioCapture.listDevices(), 3000);

--- a/frontend/src/admin/router.ts
+++ b/frontend/src/admin/router.ts
@@ -25,6 +25,30 @@ const FlowLive = () => import('./pages/flow/FlowLive.vue');
 const FlowOnAir = () => import('./pages/flow/FlowOnAir.vue');
 const FlowNotAssigned = () => import('./pages/flow/FlowNotAssigned.vue');
 
+/**
+ * Guard for the stateful flow steps (upload / confirm / live / on-air). These
+ * read the selected show from the `useHostFlow` singleton, which is lost on a
+ * hard reload or when the step URL is opened directly. Without a show the page
+ * renders blank (no date, frozen countdown, no auto-start). Refetch once; if a
+ * show still can't be resolved, bounce through the smart `/stream` redirect.
+ */
+export async function ensureFlowReady(
+  _to: unknown,
+  _from: unknown,
+  next: (target?: string) => void
+): Promise<void> {
+  const { useHostFlow } = await import('./composables');
+  const flow = useHostFlow();
+  if (!flow.show.value) {
+    await flow.fetchMyShow();
+  }
+  if (!flow.show.value) {
+    next('/stream');
+    return;
+  }
+  next();
+}
+
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
@@ -132,21 +156,25 @@ const router = createRouter({
           path: 'upload',
           name: 'stream-upload',
           component: FlowUpload,
+          beforeEnter: ensureFlowReady,
         },
         {
           path: 'confirm',
           name: 'stream-confirm',
           component: FlowConfirm,
+          beforeEnter: ensureFlowReady,
         },
         {
           path: 'live',
           name: 'stream-live',
           component: FlowLive,
+          beforeEnter: ensureFlowReady,
         },
         {
           path: 'on-air',
           name: 'stream-on-air',
           component: FlowOnAir,
+          beforeEnter: ensureFlowReady,
         },
         {
           // Legacy redirects


### PR DESCRIPTION
## Two host-flow bugs hardened

### 1. Empty waiting room / frozen countdown / can't start (reload)
The host flow keeps the selected show only in the `useHostFlow` singleton. Only the `/stream` index route had a `beforeEnter` calling `fetchMyShow()`; the step routes had none. Reloading or opening `#/stream/on-air` directly left `flow.show` undefined → Start/End show `—`, countdown stuck at `--:--:--`, `getTargetDate()` returns `null`, auto-start never fires.

**Fix:** `ensureFlowReady` guard on `upload`/`confirm`/`live`/`on-air` — refetch the show once, and if still unresolved, bounce through the smart `/stream` redirect.

### 2. Test records with "no audio source selected"
`useAudioCapture` is a singleton whose capture persists across navigations (intended). Re-entering live setup reset the dropdown to blank while still capturing the previous mic, so Start Test recorded with nothing apparently selected.

**Fix:** on `FlowLive` mount, mirror the active capture device into the dropdown.

## Tests
- New `flowRouteGuard.test.ts` (3 cases) covering the guard's paths.
- Full suite: 56 passed. Prettier clean; no new type errors vs. baseline.