### PR TITLE
feat(stream): test broadcast to private /test mount before going live

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -323,6 +323,7 @@ jobs:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
             ea873605-a662-4a0f-99a9-b46e011fc8d6 > HARBOR_LIVE_PASSWORD
+            110bdca6-3a7b-477e-bce6-b46e011fb511 > HARBOR_TEST_PASSWORD
 
       # Mirrors the Lightsail `deploy` job's .env generation exactly. Keep the two
       # in sync; the goal of the migration is an identical backend on Hetzner.
@@ -398,6 +399,10 @@ jobs:
               echo "STREAM_OUTPUT=icecast"
               echo "ICECAST_URL=icecast://source:${{ steps.stream-secrets.outputs.HARBOR_LIVE_PASSWORD }}@host.docker.internal:8005/live"
               echo "ICECAST_STATUS_URL=http://host.docker.internal:8010/status-json.xsl"
+              # Private `/test` mount for the broadcaster's "Test Your Stream"
+              # step (?test=true): same harbor, separate mount + password. Lets a
+              # host rehearse through the real path without going public.
+              echo "ICECAST_TEST_URL=icecast://source:${{ steps.stream-secrets.outputs.HARBOR_TEST_PASSWORD }}@host.docker.internal:8005/test"
             else
               # Default: unchanged from Lightsail — producer pushes RTMP to NMS
               # (backend config supplies the RTMP destination default).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,6 +47,10 @@ RUST_LOG=info,tower_http=debug
 # ICECAST_URL=icecast://source:hackme@127.0.0.1:8010/live.mp3
 # ICECAST_BITRATE=128k
 # ICECAST_SAMPLE_RATE=44100
+# ICECAST_TEST_URL: optional private "/test" harbour mount for the broadcaster's
+# "Test Your Stream" step (?test=true). Same harbour, separate mount + password.
+# Unset → the in-product test is disabled (the stream WS rejects ?test=true).
+# ICECAST_TEST_URL=icecast://source:hackme@127.0.0.1:8005/test
 
 # Icecast listener/quality telemetry poller (#177)
 # ICECAST_STATUS_URL: status-json.xsl endpoint. If unset, derived from ICECAST_URL

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -68,6 +68,14 @@ pub struct Config {
     // `icecast_url` (host:port → http://host:port/status-json.xsl); if neither
     // is set, the poller stays disabled.
     pub icecast_status_url: Option<String>,
+    // Optional Icecast `/test` mount source URL, e.g.
+    // `icecast://source:hackme@127.0.0.1:8005/test`. When set, the broadcaster's
+    // "Test Your Stream" step pushes through the SAME producer→harbor→Icecast
+    // path as live but onto the private `/test` mount, so a rehearsal sounds
+    // exactly like `/live.mp3` without being public. Unset → the in-product test
+    // is unavailable (the WS rejects `?test=true`). Independent of the live
+    // `icecast_url`; never required.
+    pub icecast_test_url: Option<String>,
     #[serde(default = "default_icecast_metrics_poll_secs")]
     pub icecast_metrics_poll_secs: u64,
 
@@ -296,6 +304,15 @@ impl Config {
         }
     }
 
+    /// Where a *test* broadcast pushes — the private `/test` Icecast mount. Some
+    /// only when `icecast_test_url` is configured (non-empty); `None` disables
+    /// the in-product test (the stream WS rejects `?test=true`). The test always
+    /// uses Icecast regardless of `stream_output`, so a rehearsal exercises the
+    /// real harbor path even while the live producer is still on RTMP.
+    pub fn test_producer_target(&self) -> Option<crate::stream_bridge::PushTarget> {
+        test_producer_target_from_url(self.icecast_test_url.as_deref())
+    }
+
     pub fn telegram_instagram_account(&self) -> &str {
         self.telegram_instagram_account.as_deref().unwrap_or("prod")
     }
@@ -329,6 +346,16 @@ fn derive_status_url(icecast_url: &str) -> Option<String> {
         return None;
     }
     Some(format!("http://{host_port}/status-json.xsl"))
+}
+
+/// Build the *test* producer target from an optional `ICECAST_TEST_URL`. `Some`
+/// only for a non-empty (trimmed) URL; `None` disables the in-product test. Pure
+/// (no env / Config) so it's unit-testable without a full [`Config`].
+fn test_producer_target_from_url(url: Option<&str>) -> Option<crate::stream_bridge::PushTarget> {
+    let url = url.map(str::trim).filter(|u| !u.is_empty())?;
+    Some(crate::stream_bridge::PushTarget::Icecast {
+        url: url.to_string(),
+    })
 }
 
 /// Validate the producer output selection. `icecast` requires a non-empty
@@ -375,6 +402,24 @@ mod tests {
     fn unknown_output_is_rejected() {
         assert!(validate_stream_output("srt", Some("x")).is_err());
         assert!(validate_stream_output("", None).is_err());
+    }
+
+    #[test]
+    fn test_producer_target_present_only_when_url_set() {
+        use crate::stream_bridge::PushTarget;
+
+        // Unset / blank / whitespace → no test mount (in-product test disabled).
+        assert!(test_producer_target_from_url(None).is_none());
+        assert!(test_producer_target_from_url(Some("")).is_none());
+        assert!(test_producer_target_from_url(Some("   ")).is_none());
+
+        // Set → Icecast target carrying the trimmed URL.
+        match test_producer_target_from_url(Some(" icecast://source:pw@127.0.0.1:8005/test ")) {
+            Some(PushTarget::Icecast { url }) => {
+                assert_eq!(url, "icecast://source:pw@127.0.0.1:8005/test");
+            }
+            other => panic!("expected Icecast test target, got {other:?}"),
+        }
     }
 
     #[test]

--- a/backend/src/handlers/stream_ws.rs
+++ b/backend/src/handlers/stream_ws.rs
@@ -21,6 +21,12 @@ pub struct StreamQuery {
     /// Show being broadcast. When present, recording auto-starts for this show
     /// on go-live (no separate frontend call) and finalizes when the stream ends.
     pub show_id: Option<i64>,
+    /// Rehearsal mode: push to the private `/test` Icecast mount instead of
+    /// `/live`. No recording, no Telegram, and excluded from the public on-air
+    /// signal — the broadcaster can hear exactly what listeners would, privately,
+    /// before going live. Requires `ICECAST_TEST_URL` to be configured.
+    #[serde(default)]
+    pub test: bool,
 }
 
 /// Grace period after a live WS drops before the recording is finalized.
@@ -81,11 +87,13 @@ pub async fn stream_ws_handler(
         }
     }
 
-    let show_id = query.show_id;
+    // A test broadcast never records, so it ignores show_id entirely.
+    let test = query.test;
+    let show_id = if test { None } else { query.show_id };
 
     // Upgrade to WebSocket
     Ok(ws.on_upgrade(move |socket| {
-        handle_stream_socket(socket, state, stream_state, username, show_id)
+        handle_stream_socket(socket, state, stream_state, username, show_id, test)
     }))
 }
 
@@ -156,14 +164,38 @@ async fn handle_stream_socket(
     stream_state: SharedStreamState,
     username: String,
     show_id: Option<i64>,
+    test: bool,
 ) {
     let (mut sender, mut receiver) = socket.split();
 
+    // Pick the producer target. A test broadcast pushes to the private `/test`
+    // mount; if no test mount is configured, reject rather than leak the
+    // rehearsal onto the public `/live`.
+    let push_target = if test {
+        match state.config.test_producer_target() {
+            Some(t) => t,
+            None => {
+                tracing::warn!("Rejected test broadcast: ICECAST_TEST_URL not configured");
+                let _ = sender
+                    .send(Message::Text(
+                        "error: test stream is not configured on this server".into(),
+                    ))
+                    .await;
+                let _ = sender.close().await;
+                return;
+            }
+        }
+    } else {
+        state.config.producer_target()
+    };
+
     // Start the stream
-    let push_target = state.config.producer_target();
     {
         let mut stream = stream_state.lock().await;
-        if let Err(e) = stream.start_stream(username.clone(), &push_target).await {
+        if let Err(e) = stream
+            .start_stream(username.clone(), &push_target, test)
+            .await
+        {
             tracing::error!("Failed to start stream: {}", e);
             let _ = sender
                 .send(Message::Text(format!("error: {}", e).into()))
@@ -192,10 +224,17 @@ async fn handle_stream_socket(
         return;
     }
 
-    tracing::info!("Stream started for user '{}'", username);
+    tracing::info!(
+        "Stream started for user '{}'{}",
+        username,
+        if test { " (test)" } else { "" }
+    );
 
-    // Notify admin via Telegram (fire-and-forget)
-    crate::telegram_notify::notify_stream_start(&state, &username);
+    // Notify admin via Telegram (fire-and-forget). A test broadcast stays silent
+    // — no point pinging the group for a private rehearsal.
+    if !test {
+        crate::telegram_notify::notify_stream_start(&state, &username);
+    }
 
     // Process incoming messages (audio chunks). `explicit_stop` distinguishes a
     // deliberate end (finalize immediately) from a network drop (grace period).
@@ -274,8 +313,10 @@ async fn handle_stream_socket(
 
     tracing::info!("Stream ended for user '{}'", username);
 
-    // Notify admin via Telegram (fire-and-forget)
-    crate::telegram_notify::notify_stream_stop(&state, &username);
+    // Notify admin via Telegram (fire-and-forget). Suppressed for a test.
+    if !test {
+        crate::telegram_notify::notify_stream_stop(&state, &username);
+    }
 }
 
 /// Get current stream status.

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -134,6 +134,10 @@ pub struct StreamState {
     /// FFmpeg died). The recording is abandoned but the live stream keeps
     /// running. Surfaced via [`StreamStatus`] so it's never silently swallowed.
     recording_failed: Option<String>,
+    /// True while this is a *test* broadcast (pushing to the private `/test`
+    /// mount, no recording). The public on-air signal ([`StreamStatus::active`])
+    /// excludes it, so a rehearsal never flips listeners onto a silent `/live`.
+    is_test: bool,
 }
 
 impl Default for StreamState {
@@ -154,6 +158,7 @@ impl StreamState {
             recording_seg_dir: None,
             recording_path: None,
             recording_failed: None,
+            is_test: false,
         }
     }
 
@@ -179,10 +184,13 @@ impl StreamState {
     /// # Arguments
     /// * `user` - Username of the streamer
     /// * `target` - Where to push the encoded audio (RTMP/FLV or Icecast/MP3)
+    /// * `is_test` - True for a rehearsal to the private `/test` mount; kept out
+    ///   of the public on-air signal (see [`StreamState::is_test`]).
     pub async fn start_stream(
         &mut self,
         user: String,
         target: &PushTarget,
+        is_test: bool,
     ) -> Result<(), StreamError> {
         // Clean up any existing stream first
         if self.is_active() {
@@ -221,6 +229,7 @@ impl StreamState {
         self.current_user = Some(user);
         self.ffmpeg_stdin = Some(stdin);
         self.ffmpeg_handle = Some(child);
+        self.is_test = is_test;
 
         Ok(())
     }
@@ -232,6 +241,7 @@ impl StreamState {
     pub async fn stop_stream(&mut self) -> Result<(), StreamError> {
         let user = self.current_user.take();
         let had_stdin = self.ffmpeg_stdin.is_some();
+        self.is_test = false;
 
         // Close stdin to signal EOF to FFmpeg (live streams only)
         if let Some(mut stdin) = self.ffmpeg_stdin.take() {
@@ -464,9 +474,13 @@ impl StreamState {
     }
 
     /// Get status information about the current stream.
+    ///
+    /// `active` is the *public* on-air signal and deliberately excludes a test
+    /// broadcast: a rehearsal pushes only to the private `/test` mount, so the
+    /// public player must stay off-air rather than connect to a silent `/live`.
     pub fn get_status(&self) -> StreamStatus {
         StreamStatus {
-            active: self.is_active(),
+            active: self.is_active() && !self.is_test,
             user: self.current_user.clone(),
             recording: self.is_recording(),
             recording_path: self.recording_path.clone(),

--- a/frontend/src/admin/composables/useStreamSocket.ts
+++ b/frontend/src/admin/composables/useStreamSocket.ts
@@ -19,6 +19,10 @@ let socket: WebSocket | null = null;
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 // Remembered across reconnects so the backend keeps auto-recording the same show.
 let currentShowId: number | null = null;
+// Remembered across reconnects so a rehearsal stays on the private `/test` mount.
+// Without this, an auto-reconnect (which calls connect() with no flags) would
+// silently fall back to the public `/live` producer.
+let currentTest = false;
 let currentCallbacks: {
   onConnected?: () => void;
   onDisconnected?: () => void;
@@ -42,7 +46,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
   // Update callbacks so the currently-mounted component receives events
   currentCallbacks = { onConnected, onDisconnected, onError, onLive };
 
-  function connect(force = false, showId?: number): Promise<void> {
+  function connect(force = false, showId?: number, test?: boolean): Promise<void> {
     return new Promise((resolve, reject) => {
       if (socket && socket.readyState === WebSocket.OPEN) {
         resolve();
@@ -53,6 +57,10 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
       if (showId != null) {
         currentShowId = showId;
       }
+      // Remember test mode for reconnects (auto-reconnect passes no flags).
+      if (test != null) {
+        currentTest = test;
+      }
 
       error.value = null;
       state.value = 'connecting';
@@ -61,6 +69,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
       const params = new URLSearchParams();
       if (force) params.set('force', 'true');
       if (currentShowId != null) params.set('show_id', String(currentShowId));
+      if (currentTest) params.set('test', 'true');
       const qs = params.toString();
       const wsUrl = `${protocol}//${window.location.host}/ws/stream${qs ? `?${qs}` : ''}`;
 
@@ -149,6 +158,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
     }
 
     currentShowId = null;
+    currentTest = false;
     reconnectAttempts.value = 0;
     state.value = 'disconnected';
     error.value = null;
@@ -171,6 +181,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
     }
 
     currentShowId = null;
+    currentTest = false;
     reconnectAttempts.value = 0;
     state.value = 'disconnected';
     error.value = null;

--- a/frontend/src/admin/pages/flow/FlowLive.vue
+++ b/frontend/src/admin/pages/flow/FlowLive.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, shallowRef, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
-import { useHostFlow, useAudioCapture, useStreamTest } from '@admin/composables';
+import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
 import DbMeter from '@admin/components/DbMeter.vue';
-import AudioPlayer from '@admin/components/AudioPlayer.vue';
+import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
+import { config } from '@/config';
 
 const router = useRouter();
 const flow = useHostFlow();
+
+// The private Icecast `/test` mount the rehearsal plays back from. Same MP3 the
+// public `/live.mp3` would serve, but non-public. Empty (e.g. local dev) → the
+// real test can't run; the dev-skip below covers that case.
+const previewUrl = config.stream.icecastTestUrl;
 
 // ─── Device selection ────────────────────────────────────────────────────────
 const audioCapture = useAudioCapture();
@@ -49,76 +55,56 @@ const capturedLabel = computed(() => {
   );
 });
 
-// ─── Test stream (server round-trip) ─────────────────────────────────────────
-type TestPhase = 'ready' | 'recording' | 'waiting' | 'playing' | 'done' | 'error';
+// ─── Test broadcast (real producer → /test harbour → Icecast /test.mp3) ───────
+// This is the *same* pipeline as going live (browser → WS → backend ffmpeg →
+// Liquidsoap harbor → Icecast), just pushed to the private `/test` mount. The
+// host plays it back below to confirm it sounds exactly like `/live.mp3` would —
+// without anything reaching the public. No recording, no Telegram (backend skips
+// both for `?test=true`).
+type TestPhase = 'ready' | 'connecting' | 'live' | 'error';
 const testPhase = ref<TestPhase>('ready');
 const testError = ref<string | null>(null);
-const recordProgress = ref(0);
-let recordInterval: ReturnType<typeof setInterval> | null = null;
+const sentChunks = ref(0);
+// Guards onUnmounted so passing the test (which already stops the rehearsal)
+// doesn't race with cleanup.
+const testActive = computed(() => testPhase.value === 'connecting' || testPhase.value === 'live');
 
-const sentChunks = shallowRef<ArrayBuffer[]>([]);
-const playbackChunks = shallowRef<ArrayBuffer[]>([]);
-const playbackUrl = ref<string | null>(null);
-
-const streamTest = useStreamTest({
-  recordDuration: 10_000,
-  onPlaybackData: (data: ArrayBuffer) => {
-    playbackChunks.value = [...playbackChunks.value, data];
+const streamSocket = useStreamSocket({
+  onLive: () => {
+    testPhase.value = 'live';
   },
-  onError: (msg: string) => {
+  onError: (msg) => {
     testPhase.value = 'error';
     testError.value = msg;
-    clearRecordProgress();
+    stopTestRecording();
+  },
+  onDisconnected: () => {
+    // The rehearsal ended (server-side or dropped) before the host accepted it.
+    if (testPhase.value === 'live' || testPhase.value === 'connecting') {
+      testPhase.value = 'ready';
+      stopTestRecording();
+    }
   },
 });
 
-watch(
-  () => streamTest.state.value,
-  (s) => {
-    if (s === 'idle') return;
-    if (s === 'recording') {
-      testPhase.value = 'recording';
-      return;
-    }
-    if (s === 'waiting') {
-      testPhase.value = 'waiting';
-      stopTestRecording();
-      return;
-    }
-    if (s === 'playing') {
-      testPhase.value = 'playing';
-      return;
-    }
-    if (s === 'done') {
-      testPhase.value = 'done';
-      clearRecordProgress();
-      buildPlaybackBlob();
-      return;
-    }
-    if (s === 'error') {
-      testPhase.value = 'error';
-      testError.value = streamTest.error.value;
-      clearRecordProgress();
-    }
-  }
-);
-
 // ─── Test recorder (dedicated MediaRecorder on the capture stream) ──────────
+// Independent of the singleton capture's main onData wiring, so it never
+// disturbs the real go-live pipeline in the next step.
 let testRecorder: MediaRecorder | null = null;
 
-function startTestRecording() {
+function startTestRecording(): boolean {
   const stream = audioCapture.processedStream.value || audioCapture.mediaStream.value;
   if (!stream) {
     testPhase.value = 'error';
     testError.value = 'No audio stream available. Select an audio device first.';
-    return;
+    return false;
   }
 
   const tracks = stream.getAudioTracks();
   if (tracks.length === 0 || tracks.every((t) => t.readyState !== 'live')) {
     testPhase.value = 'error';
     testError.value = 'Audio device is no longer active. Re-select your device.';
-    return;
+    return false;
   }
 
   const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
@@ -130,8 +116,8 @@ function startTestRecording() {
   testRecorder.ondataavailable = async (event) => {
     if (event.data.size > 0) {
       const buffer = await event.data.arrayBuffer();
-      sentChunks.value = [...sentChunks.value, buffer];
-      streamTest.sendChunk(buffer);
+      streamSocket.send(buffer);
+      sentChunks.value++;
     }
   };
 
@@ -141,75 +127,54 @@ function startTestRecording() {
   };
 
   testRecorder.start(250);
+  return true;
 }
 
 function stopTestRecording() {
   if (testRecorder && testRecorder.state !== 'inactive') {
     testRecorder.stop();
-    testRecorder = null;
   }
+  testRecorder = null;
 }
 
 // ─── Test flow ────────────────────────────────────────────────────────────────
 async function runTest() {
-  testError.value = null;
-  testPhase.value = 'ready';
-  sentChunks.value = [];
-  playbackChunks.value = [];
-  revokePlaybackUrl();
-
-  try {
-    await streamTest.connect();
-    streamTest.startRecording();
-    testPhase.value = 'recording';
-    startTestRecording();
-
-    recordProgress.value = 0;
-    const start = Date.now();
-    recordInterval = setInterval(() => {
-      const elapsed = Date.now() - start;
-      recordProgress.value = Math.min(100, (elapsed / 10_000) * 100);
-    }, 100);
-  } catch {
+  if (!previewUrl) {
     testPhase.value = 'error';
-    testError.value = 'Failed to connect to test server';
-  }
-}
-
-function clearRecordProgress() {
-  if (recordInterval) {
-    clearInterval(recordInterval);
-    recordInterval = null;
-  }
-}
-
-function buildPlaybackBlob() {
-  if (playbackChunks.value.length === 0) {
-    testError.value = `No audio data received from server (sent: ${sentChunks.value.length} chunks)`;
+    testError.value = 'Test stream is not configured on this server.';
     return;
   }
-  const blob = new Blob(playbackChunks.value, { type: 'audio/webm;codecs=opus' });
-  playbackUrl.value = URL.createObjectURL(blob);
+
+  testError.value = null;
+  testPhase.value = 'connecting';
+  sentChunks.value = 0;
+
+  try {
+    // Connect in TEST mode → backend pushes to `/test`, not `/live`.
+    await streamSocket.connect(false, undefined, true);
+    // Stream live audio through the real pipeline. `onLive` flips to 'live'.
+    if (!startTestRecording()) {
+      streamSocket.stopStream();
+    }
+  } catch {
+    testPhase.value = 'error';
+    testError.value = 'Failed to connect to the test stream.';
+    stopTestRecording();
+  }
 }
 
-function revokePlaybackUrl() {
-  if (playbackUrl.value) {
-    URL.revokeObjectURL(playbackUrl.value);
-    playbackUrl.value = null;
-  }
+/** Stop the rehearsal broadcast (keeps the audio capture for the next step). */
+function stopTestBroadcast() {
+  stopTestRecording();
+  streamSocket.stopStream();
 }
 
 /** Reset test state (e.g. after switching inputs). */
 function resetTest() {
-  streamTest.stop();
-  stopTestRecording();
-  clearRecordProgress();
-  revokePlaybackUrl();
+  stopTestBroadcast();
   testPhase.value = 'ready';
   testError.value = null;
-  recordProgress.value = 0;
-  sentChunks.value = [];
-  playbackChunks.value = [];
+  sentChunks.value = 0;
   flow.setLiveTestPassed(false);
 }
 
@@ -218,6 +183,7 @@ function retryTest() {
 }
 
 function markTestPassed() {
+  stopTestBroadcast();
   flow.setLiveTestPassed(true);
   goToStream();
 }
@@ -240,10 +206,12 @@ onUnmounted(() => {
     clearInterval(deviceRefreshInterval);
     deviceRefreshInterval = null;
   }
-  streamTest.cleanup();
-  stopTestRecording();
-  clearRecordProgress();
-  revokePlaybackUrl();
+  // Stop a still-running rehearsal so we never leave a producer pushing to
+  // `/test` after navigating away. Passing the test already stopped it (this is
+  // then a no-op); a fresh go-live in FlowOnAir reconnects to `/live`.
+  if (testActive.value) {
+    stopTestBroadcast();
+  }
   // NOTE: do NOT call audioCapture.stopCapture() here —
   // the singleton capture persists into the Stream step (FlowOnAir).
 });
@@ -296,14 +264,16 @@ onUnmounted(() => {
     <div class="test-panel">
       <h3>Test Your Stream</h3>
       <p class="panel-hint">
-        We record 10 seconds and round-trip it through the server, then show it back as a waveform.
+        This sends your audio through the real broadcast path to a <strong>private</strong> test
+        mount — exactly what listeners would hear on the live stream, but not public. Press play
+        below to check it before going live.
       </p>
 
       <!-- Ready -->
       <div v-if="testPhase === 'ready'" class="test-state">
         <button
           class="btn-primary btn-lg"
-          :disabled="!audioCapture.isCapturing.value"
+          :disabled="!audioCapture.isCapturing.value || !previewUrl"
           @click="runTest"
         >
           🎤 Start Test
@@ -311,48 +281,32 @@ onUnmounted(() => {
         <p v-if="!audioCapture.isCapturing.value" class="text-muted">
           Select an audio input first.
         </p>
+        <p v-else-if="!previewUrl" class="text-muted">
+          Test stream isn’t configured on this server.
+        </p>
       </div>
 
-      <!-- Recording -->
-      <div v-else-if="testPhase === 'recording'" class="test-state">
+      <!-- Connecting -->
+      <div v-else-if="testPhase === 'connecting'" class="test-state">
+        <p class="text-muted">Connecting to the test stream…</p>
+      </div>
+
+      <!-- Live (test broadcast running) -->
+      <div v-else-if="testPhase === 'live'" class="test-state">
         <div class="test-recording-indicator">
           <span class="recording-dot"></span>
-          Recording... <span class="chunk-counter">({{ sentChunks.length }} chunks)</span>
-        </div>
-        <div class="progress-bar">
-          <div class="progress-fill" :style="{ width: `${recordProgress}%` }"></div>
-        </div>
-        <p class="text-muted">{{ Math.ceil((100 - recordProgress) / 10) }}s remaining</p>
-      </div>
-
-      <!-- Waiting -->
-      <div v-else-if="testPhase === 'waiting'" class="test-state">
-        <p>Sent {{ sentChunks.length }} chunks. Waiting for server...</p>
-      </div>
-
-      <!-- Playing (receiving) -->
-      <div v-else-if="testPhase === 'playing'" class="test-state">
-        <div class="test-playing-indicator">
-          <span class="playing-icon">🔊</span>
-          Receiving... <span class="chunk-counter">({{ playbackChunks.length }} chunks)</span>
-        </div>
-      </div>
-
-      <!-- Done -->
-      <div v-else-if="testPhase === 'done'" class="test-state">
-        <div v-if="playbackUrl" class="playback-section">
-          <AudioPlayer :src="playbackUrl" label="Your test recording" />
-        </div>
-        <div v-else class="playback-section">
-          <p class="error-text">
-            No audio data received from server. Sent {{ sentChunks.length }} chunks.
-          </p>
+          Test broadcast live
+          <span class="chunk-counter">({{ sentChunks }} chunks sent)</span>
         </div>
 
-        <p>Did you hear your audio clearly?</p>
+        <!-- Play back the private /test mount. Same component as the on-air
+             preview; runs a few seconds behind, so use headphones. -->
+        <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
+
+        <p>Does it sound clear on the test stream?</p>
         <div class="test-result-actions">
-          <button class="btn-success" @click="markTestPassed">✓ Yes, it sounds good!</button>
-          <button class="btn-secondary" @click="retryTest">Try Again</button>
+          <button class="btn-success" @click="markTestPassed">✓ Yes, go live</button>
+          <button class="btn-secondary" @click="retryTest">⏹ Stop test</button>
         </div>
       </div>
 


### PR DESCRIPTION
## What
- The broadcaster's **"Test Your Stream"** step (Set Up & Test) now pushes audio through the **real** producer path — browser → WS → backend ffmpeg → Liquidsoap harbor → Icecast — onto the **private `/test` mount**, then plays it back so the host hears exactly what listeners would on `/live.mp3`, **without anything going public**.
- Replaces the old local echo round-trip (record 10s → waveform), which never exercised the live pipeline.
- No recording, no Telegram, and **excluded from the public on-air signal** during a test.

## Why
A rehearsal that uses the same harbour/Icecast path as live is the only way to truly catch input/level/encoding problems before going public. Requested directly ("record source → upload to test harbour → get & check test stream ⇒ same as live.mp3 but not public").

## How
**Backend**
- `StreamQuery` gains `?test=true`; `handle_stream_socket` selects `config.test_producer_target()` (new `ICECAST_TEST_URL`) and, in test mode, ignores `show_id` (no recording) + suppresses both Telegram notifies. Rejects cleanly if no test mount is configured.
- `StreamState.is_test` tracks the rehearsal; `StreamStatus.active` (the public on-air signal) is now `is_active() && !is_test`, so the public player never connects to a silent `/live` during a test. The streamer-conflict guard still uses raw `is_active()` (can't test + go live at once).

**Frontend**
- `useStreamSocket.connect(force, showId, test)` — the `test` flag is **persisted across reconnects** so an auto-reconnect can't silently fall back to `/live`.
- `FlowLive.vue` test panel rewritten: real `/test` broadcast + `StreamPreviewPlayer` playback; **"✓ Yes, go live"** stops the rehearsal and advances; leaving the page stops any in-flight test producer.

**Ops**
- `deploy-hetzner` icecast block emits `ICECAST_TEST_URL` from the `HARBOR_TEST_PASSWORD` Bitwarden SM secret (mount `/test` on harbor :8005). Unset → in-product test cleanly disabled.

## Test plan
- [ ] `deploy-hetzner -f stream_output=icecast` → box `/app/.env` has `ICECAST_TEST_URL=…/test`
- [ ] Admin → Set Up & Test → **Start Test**: audio appears on `https://admin.live.moafunk.de/test.mp3` (~12s harbor latency); preview player plays it
- [ ] During the test: public page stays **off-air**; `/api/stream/status` → `{active:false}`; no Telegram ping; no recording row
- [ ] **Yes, go live** → real broadcast on `/live.mp3`; recording + shows-archive behave as before

## Risk
Low–medium. Additive `?test=true`; live path unchanged when the flag is absent. Backend `cargo test`/clippy green, frontend build+lint green, new unit test for the target builder. Main thing to verify live is the ~12s harbor latency UX and that the public status correctly excludes the test.
