### PR TITLE
fix(stream): bake stream URLs into the admin SPA Docker build

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -115,6 +115,12 @@ jobs:
           context: .
           file: backend/Dockerfile
           platforms: linux/amd64
+          # Bake the stream URLs into the admin SPA (Vite inlines them at build
+          # time). Same repo Variables the Pages build uses; empty → no-op.
+          build-args: |
+            VITE_STREAM_ICECAST_LIVE_URL=${{ vars.VITE_STREAM_ICECAST_LIVE_URL }}
+            VITE_STREAM_ICECAST_TEST_URL=${{ vars.VITE_STREAM_ICECAST_TEST_URL }}
+            VITE_STREAM_STATUS_URL=${{ vars.VITE_STREAM_STATUS_URL }}
           # Always push — workflow only runs on main or manual dispatch
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,16 @@ COPY frontend/package*.json ./
 RUN npm ci
 
 COPY frontend ./
+# Stream URLs are baked into the admin SPA at build time (Vite inlines
+# import.meta.env.VITE_*). Without these the admin's stream config is empty —
+# e.g. "Test Your Stream" reports "not configured". Passed as build args from CI
+# (same repo Variables the Pages build uses); empty is a safe no-op fallback.
+ARG VITE_STREAM_ICECAST_LIVE_URL=""
+ARG VITE_STREAM_ICECAST_TEST_URL=""
+ARG VITE_STREAM_STATUS_URL=""
+ENV VITE_STREAM_ICECAST_LIVE_URL=$VITE_STREAM_ICECAST_LIVE_URL \
+    VITE_STREAM_ICECAST_TEST_URL=$VITE_STREAM_ICECAST_TEST_URL \
+    VITE_STREAM_STATUS_URL=$VITE_STREAM_STATUS_URL
 RUN npm run build
 
 # Runtime stage


### PR DESCRIPTION
## What
The admin SPA (served from the Hetzner box) is built in `backend/Dockerfile`'s `frontend-builder` stage with **no `VITE_STREAM_*` env**. Vite inlines `import.meta.env.VITE_*` at build time, so the admin shipped with empty stream config.

## Why
The new **"Test Your Stream"** step gates on `config.stream.icecastTestUrl`; with it empty the button shows **"Test stream isn't configured on this server"** (screenshot). Same root cause hid the #175 on-air preview player all along. Only the GitHub **Pages** build passed these vars — but that's the public site, a different deployment.

## How
- `backend/Dockerfile`: `ARG` + `ENV` the three URLs before `npm run build`.
- `backend.yml` build step: `build-args` from the same repo Variables the Pages build uses. Empty → safe no-op.

## Test plan
- [ ] After this image deploys: admin → Set Up & Test → **Start Test** is enabled (no "not configured")
- [ ] Test broadcast reaches `https://admin.live.moafunk.de/test.mp3`; public stays off-air

## Risk
Low. Build-time only; empty args reproduce current behaviour. Verified locally that `npm run build` with the env set bakes `test.mp3`/`live.mp3`/status into the config chunk.