### PR TITLE
feat(recording): reexport-archive CLI subcommand for offline recovery

### DIFF
--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -861,9 +861,22 @@ pub async fn reexport_recording_to_archive(
 ) -> Result<impl IntoResponse> {
     let _user = require_admin(&state, &headers).await?;
     let req = body.map(|Json(b)| b).unwrap_or_default();
+    let resp = reexport_to_archive(&state, show_id, req.version).await?;
+    Ok(Json(resp))
+}
 
+/// Core of the archive re-export, shared by the HTTP handler and the
+/// `reexport-archive` CLI subcommand (which carries no auth — it runs locally on
+/// the box via `docker exec`). Resolves the target version (explicit or latest),
+/// pulls the raw capture from R2, re-derives the archive mp3, and clears any
+/// stale `failed` status.
+pub async fn reexport_to_archive(
+    state: &Arc<AppState>,
+    show_id: i64,
+    version_filter: Option<String>,
+) -> Result<ReexportResponse> {
     // Resolve the target version: the explicit one, else the most recent.
-    let version = match req.version {
+    let version = match version_filter {
         Some(ref v) => crate::db::get_recording_version(&state.db, show_id, v)
             .await?
             .ok_or_else(|| {
@@ -886,7 +899,7 @@ pub async fn reexport_recording_to_archive(
     // Pull the raw capture (system of record) back from R2 to a temp file so the
     // existing transcode→publish path can run file→file. ./data/recordings-temp
     // is the same scratch dir the live recorder uses.
-    let (raw_data, _content_type) = storage::download_file(&state, &raw_key).await?;
+    let (raw_data, _content_type) = storage::download_file(state, &raw_key).await?;
     let temp_path = PathBuf::from("./data/recordings-temp")
         .join(format!("reexport_{}_{}.webm", show_id, version.version));
     if let Some(parent) = temp_path.parent() {
@@ -897,7 +910,7 @@ pub async fn reexport_recording_to_archive(
         .map_err(|e| AppError::Internal(format!("Failed to stage raw recording: {}", e)))?;
 
     // Re-derive the archive mp3, always cleaning up the staged webm afterwards.
-    let publish = publish_stream_to_shows_archive(&state, show_id, &temp_path).await;
+    let publish = publish_stream_to_shows_archive(state, show_id, &temp_path).await;
     let _ = tokio::fs::remove_file(&temp_path).await;
     let archive_key = publish?;
 
@@ -922,11 +935,11 @@ pub async fn reexport_recording_to_archive(
         archive_key
     );
 
-    Ok(Json(ReexportResponse {
+    Ok(ReexportResponse {
         show_id,
         version: version.version,
         archive_key,
-    }))
+    })
 }
 
 /// Helper to convert RecordingError to AppError

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -299,6 +299,40 @@ async fn main() -> anyhow::Result<()> {
         telegram_edit_sessions,
     });
 
+    // One-shot admin subcommands: run against the same config/db/R2 as the server,
+    // then exit before any background tasks or the listener start. Invoked locally
+    // on the box (e.g. `docker exec unheard-api ./unheard-backend reexport-archive 18`),
+    // so they carry no HTTP auth. No args → fall through and serve normally.
+    let cli_args: Vec<String> = std::env::args().collect();
+    if let Some(subcommand) = cli_args.get(1) {
+        match subcommand.as_str() {
+            "reexport-archive" => {
+                let show_id: i64 = cli_args
+                    .get(2)
+                    .and_then(|s| s.parse().ok())
+                    .expect("usage: unheard-backend reexport-archive <show_id> [version]");
+                let version = cli_args.get(3).cloned();
+                match handlers::recording::reexport_to_archive(&state, show_id, version).await {
+                    Ok(r) => {
+                        println!(
+                            "re-exported show {} (version {}) -> {}",
+                            r.show_id, r.version, r.archive_key
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        eprintln!("re-export failed: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+            other => {
+                eprintln!("unknown subcommand: {}", other);
+                std::process::exit(2);
+            }
+        }
+    }
+
     // Pre-generate and upload default cover to S3 at startup
     {
         let state_clone = state.clone();


### PR DESCRIPTION
## What
- Extract the archive re-export core into `reexport_to_archive(state, show_id, version)`, shared by the HTTP handler and a new `reexport-archive` `main()` subcommand.
- The subcommand runs against the same config/db/R2 as the server and exits before any background task or the listener starts.

## Why
The `POST /api/shows/:id/recordings/reexport` endpoint is admin-cookie gated, so it can't be triggered from the box (no browser session). This gives operators an auth-free local recovery path for a wrongly-failed or skipped archive publish — needed right now to recover show #18 'Küssen'.

## How
`docker exec unheard-api ./unheard-backend reexport-archive <show_id> [version]` → resolves the version (latest if omitted), pulls the raw capture from R2, re-derives the archive mp3, clears stale `failed` status. No args → serves normally.

## Test plan
- [x] `cargo build` / `clippy` / `fmt` / `cargo test recording::`
- [ ] After deploy: `docker exec unheard-api ./unheard-backend reexport-archive 18` → mp3 in moafunk-prod, row 14 failed→raw

## Risk
Low. Pure refactor + a guarded one-shot branch before server start; no change to the serving path (no args = unchanged). Rollback: revert.