### PR TITLE
feat(frontend): add BugDrop feedback widget to admin dashboard

### DIFF
--- a/docs/feedback-widget.md
+++ b/docs/feedback-widget.md
@@ -1,0 +1,72 @@
+# Feedback widget (dev/review)
+
+A drop-in **feedback layer** for the dev/review process, mounted on the **admin
+dashboard only**. Reviewers click a bug button, annotate a screenshot, and submit —
+it becomes a **GitHub issue** with the screenshot plus page URL and browser/viewport
+context. The public pages are intentionally never touched.
+
+- **Tool:** [BugDrop](https://github.com/mean-weasel/bugdrop) — MIT, open source.
+- **Where feedback lands:** GitHub Issues in a target repo (default: `phaabe/live.moafunk.de`).
+- **Hosting:** the free hosted Cloudflare Worker (`bugdrop.neonwatty.workers.dev`).
+  No GitHub token lives in the browser — a GitHub App does the token exchange
+  server-side. Self-hosting the Worker is possible later (see below).
+- **Scope:** dev/review **only**. Never injected into production.
+
+## One-time setup (org admin)
+
+1. Install the **BugDrop GitHub App** on the target repo from the
+   [Marketplace listing](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues).
+   Works with private repos and branch-protection rules. On first feedback it
+   auto-creates a `bugdrop-screenshots` branch to hold screenshot images.
+
+## How it's wired
+
+A conditional Vite plugin (`bugdropFeedbackWidget` in `frontend/vite.config.ts`)
+injects the widget's `<script>` tag into the **admin SPA** (`src/admin/index.html`)
+only — never the public pages — and only when `VITE_FEEDBACK_WIDGET` is set to a
+GitHub `owner/repo`. Production builds (GitHub Pages, admin Docker) never set the
+var, so the tag is absent from those bundles.
+
+## Enabling it
+
+**Local dev** — add to `frontend/.env.local` (gitignored):
+
+```
+VITE_FEEDBACK_WIDGET=phaabe/live.moafunk.de
+```
+
+Then `npm run dev` (or `npm run build` for a static review build). Unset it to turn
+the widget off.
+
+**Review/preview build** — set the var for that build only, e.g.:
+
+```
+VITE_FEEDBACK_WIDGET=phaabe/live.moafunk.de npm run build
+```
+
+## Triaging incoming feedback
+
+Issues arrive in the target repo. Apply this repo's taxonomy when triaging:
+one or more `type::*` (`backend` / `frontend` / `ci`) plus the most specific
+`project::*` area (e.g. `public-pages`, `admin_dashboard`, `Stream`). Use `later`
+for backlog items.
+
+## Privacy
+
+Add `data-bugdrop-mask` to any element that could expose sensitive data in a
+screenshot — password/credit-card inputs are masked automatically, but stream keys
+and user PII are not. Candidate spots in the admin SPA: `UserEditPage.vue`,
+`UsersPage.vue`, `ChangePasswordPage.vue`, and any stream-key field in the show
+wizard (`WizardHost.vue`). Apply masks as those become reachable in review builds.
+
+## Verifying
+
+- Local: `npm run dev` with the var set → open `/admin/`, the bug button appears (and is absent on the public `/`); submit → issue lands in the repo with screenshot + context.
+- Prod guard: `npm run build` **without** the var, then `grep -r bugdrop dist` → no matches.
+
+## Self-host upgrade path (optional)
+
+Self-host the BugDrop Cloudflare Worker for full data ownership. Configure via env
+(`GITHUB_APP_NAME`, `ALLOWED_ORIGINS`, `MAX_SCREENSHOT_SIZE_MB`, optional
+short-lived `AUTH_TOKEN_*` to restrict who can file), then point the plugin's script
+`src` at your Worker. No widget-side code change.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,6 +16,15 @@ VITE_STREAM_ICECAST_LIVE_URL=
 # Set together with VITE_STREAM_ICECAST_LIVE_URL, e.g. https://admin.live.moafunk.de/api/stream/status
 VITE_STREAM_STATUS_URL=
 
+# Feedback widget (dev/review only — leave UNSET in production)
+# When set to a GitHub "owner/repo", the BugDrop feedback widget
+# (https://github.com/mean-weasel/bugdrop) is injected into the ADMIN dashboard
+# only (public pages are never touched). Reviewers click the bug button to file
+# feedback as a GitHub issue with a screenshot + page/browser context. Requires the
+# BugDrop GitHub App installed on that repo. Production pipelines must NOT set this.
+# See docs/feedback-widget.md.
+VITE_FEEDBACK_WIDGET=
+
 # Analytics Configuration
 VITE_ANALYTICS_DOMAIN=live.moafunk.de
 VITE_ANALYTICS_SCRIPT_URL=https://plausible.moafunk.de/js/plausible.js

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
 import { resolve } from 'path';
 import { execSync } from 'node:child_process';
 import vue from '@vitejs/plugin-vue';
@@ -35,51 +35,93 @@ function emitVersionManifest(): Plugin {
   };
 }
 
-export default defineConfig({
-  define: { __BUILD_ID__: JSON.stringify(BUILD_ID) },
-  plugins: [vue(), emitVersionManifest()],
-  root: 'src',
-  publicDir: '../public',
-  build: {
-    outDir: '../dist',
-    emptyOutDir: true,
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'src/index.html'),
-        relisten: resolve(__dirname, 'src/pages/re-listen.html'),
-        techrider: resolve(__dirname, 'src/pages/tech-rider.html'),
-        unheardform: resolve(__dirname, 'src/pages/unheard-artists-form.html'),
-        admin: resolve(__dirname, 'src/admin/index.html'),
+const BUGDROP_ORIGIN = 'https://bugdrop.neonwatty.workers.dev';
+
+// Inject the BugDrop feedback widget (https://github.com/mean-weasel/bugdrop)
+// into the admin dashboard only — and only for dev/review builds. The target repo
+// is read from VITE_FEEDBACK_WIDGET (e.g. "phaabe/live.moafunk.de"); feedback
+// becomes a GitHub issue with a screenshot + page/browser context. Production
+// pipelines (GitHub Pages, admin Docker) never set the var, so nothing is injected
+// and the prod bundles stay clean. Emits BugDrop's documented synchronous tag —
+// deliberately no async/defer, so the widget can read data-repo off its own tag.
+//
+// Scope: admin SPA (src/admin/index.html) only. The public pages are intentionally
+// left untouched, so visitors never see the widget.
+function bugdropFeedbackWidget(repo: string | undefined): Plugin {
+  return {
+    name: 'bugdrop-feedback-widget',
+    transformIndexHtml(html, ctx) {
+      if (!repo) return html;
+      const isAdmin = ctx.filename.replace(/\\/g, '/').includes('/src/admin/');
+      if (!isAdmin) return html;
+      return {
+        html,
+        tags: [
+          {
+            tag: 'script',
+            attrs: { src: `${BUGDROP_ORIGIN}/widget.js`, 'data-repo': repo },
+            // End of <body>, not <head>: the widget appends its UI to
+            // document.body synchronously on load, so body must already exist.
+            injectTo: 'body',
+          },
+        ],
+      };
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
+  // Read .env files (and CLI/process env) so review builds can opt in via
+  // VITE_FEEDBACK_WIDGET=owner/repo in .env.local or on the command line.
+  const env = loadEnv(mode, process.cwd(), '');
+  const feedbackRepo = env.VITE_FEEDBACK_WIDGET || process.env.VITE_FEEDBACK_WIDGET;
+
+  return {
+    define: { __BUILD_ID__: JSON.stringify(BUILD_ID) },
+    plugins: [vue(), emitVersionManifest(), bugdropFeedbackWidget(feedbackRepo)],
+    root: 'src',
+    publicDir: '../public',
+    build: {
+      outDir: '../dist',
+      emptyOutDir: true,
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'src/index.html'),
+          relisten: resolve(__dirname, 'src/pages/re-listen.html'),
+          techrider: resolve(__dirname, 'src/pages/tech-rider.html'),
+          unheardform: resolve(__dirname, 'src/pages/unheard-artists-form.html'),
+          admin: resolve(__dirname, 'src/admin/index.html'),
+        },
       },
     },
-  },
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '/ws': {
-        target: 'ws://localhost:8000',
-        ws: true,
-      },
-      // Download routes (must not conflict with SPA hash routes)
-      '^/shows/\\d+/download': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '^/artists/\\d+/download': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
+        '/ws': {
+          target: 'ws://localhost:8000',
+          ws: true,
+        },
+        // Download routes (must not conflict with SPA hash routes)
+        '^/shows/\\d+/download': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
+        '^/artists/\\d+/download': {
+          target: 'http://localhost:8000',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src'),
-      '@admin': resolve(__dirname, 'src/admin'),
-      '@shared': resolve(__dirname, 'src/shared'),
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+        '@admin': resolve(__dirname, 'src/admin'),
+        '@shared': resolve(__dirname, 'src/shared'),
+      },
     },
-  },
+  };
 });


### PR DESCRIPTION
## What

Adds an open-source **feedback layer** for the dev/review process: reviewers click a bug button in the **admin dashboard**, annotate a screenshot, and submit — it becomes a **GitHub issue** with the screenshot plus page URL and browser/viewport context.

Tool: [BugDrop](https://github.com/mean-weasel/bugdrop) (MIT), hosted Worker endpoint. A GitHub App handles the token exchange server-side — no token in the browser.

## How

- A conditional Vite plugin (`bugdropFeedbackWidget` in `frontend/vite.config.ts`) injects the widget `<script>` into **`src/admin/index.html` only**, and **only when `VITE_FEEDBACK_WIDGET=owner/repo` is set**.
- Production pipelines (GitHub Pages, admin Docker) never set the var → the tag is absent from prod bundles.
- Tag injected at end of `<body>` (the widget appends its UI to `document.body` synchronously on load).
- Public pages are intentionally never touched.

## Scope / safety

- **Dev/review only** — gated on the env var; defaults off.
- **Admin only** — public visitors never see it.
- `docs/feedback-widget.md` covers GitHub App setup, enabling, triage labels, `data-bugdrop-mask` privacy guidance, and the self-host upgrade path.

## Verification

- Review build (`VITE_FEEDBACK_WIDGET=phaabe/live.moafunk.de npm run build`) → tag only in `dist/admin/index.html`; public pages + their CSP untouched.
- Prod build (no var) → `grep -r bugdrop dist` = no matches.
- ESLint clean.
- Confirmed live: button renders on `/admin/`, absent on public `/`; issue creation works end-to-end.

## One-time setup (done)

BugDrop GitHub App installed on the target repo (`installed: true`).