### PR TITLE
fix(recording): auto-start pre-recorded shows without an open admin tab

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -197,6 +197,11 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     // who assigns a guest as the host still retains edit rights over the show.
     add_column_if_missing(pool, "shows", "created_by", "INTEGER REFERENCES users(id)").await?;
 
+    // When the pre-recorded-show auto-start scheduler fired go-live for this
+    // show. Ensures it starts exactly once (a manual "Go Live" click also stamps
+    // this so the scheduler doesn't restart an already-running stream).
+    add_column_if_missing(pool, "shows", "prerecorded_started_at", "TEXT").await?;
+
     // App settings table for storing OAuth tokens and other key-value config
     sqlx::query(
         r#"

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -5392,48 +5392,64 @@ pub async fn api_my_show_go_live(
 ) -> Result<impl IntoResponse> {
     let (user, show) = require_user_show(&state, &headers, query.show_id).await?;
 
+    start_prerecorded_show_stream(&state, &show, &user.username).await?;
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "message": "Prerecorded stream started",
+    })))
+}
+
+/// Start a show's pre-recorded stream: presign the uploaded file, push it
+/// through FFmpeg via the stream bridge, and stamp `prerecorded_started_at` so
+/// it's never auto-started twice. Shared by the manual "Go Live" button
+/// (`api_my_show_go_live`) and [`crate::scheduler::check_prerecorded_show_start`].
+pub async fn start_prerecorded_show_stream(
+    state: &Arc<AppState>,
+    show: &models::Show,
+    username: &str,
+) -> Result<()> {
     // Must have a confirmed prerecorded file
-    if show.prerecorded_key.is_none() {
-        return Err(AppError::BadRequest(
-            "No prerecorded file uploaded".to_string(),
-        ));
-    }
+    let key = show
+        .prerecorded_key
+        .as_ref()
+        .ok_or_else(|| AppError::BadRequest("No prerecorded file uploaded".to_string()))?;
     if show.prerecorded_confirmed_at.is_none() {
         return Err(AppError::BadRequest(
             "Prerecorded file not confirmed yet".to_string(),
         ));
     }
 
-    let key = show.prerecorded_key.as_ref().unwrap();
-
     // Generate a long-lived presigned URL for FFmpeg to read from (4 hours)
-    let presigned_url = storage::get_presigned_url(&state, key, 4 * 3600).await?;
+    let presigned_url = storage::get_presigned_url(state, key, 4 * 3600).await?;
     let push_target = state.config.producer_target();
 
     tracing::info!(
         "Starting prerecorded stream for show_id={}, user='{}', key='{}'",
         show.id,
-        user.username,
+        username,
         key
     );
 
     // Start the prerecorded stream via stream bridge
     crate::stream_bridge::start_prerecorded_stream(
         &state.stream_state,
-        user.username.clone(),
+        username.to_string(),
         &presigned_url,
         &push_target,
     )
     .await
     .map_err(|e| AppError::Internal(format!("Failed to start prerecorded stream: {}", e)))?;
 
-    // Notify via Telegram
-    telegram_notify::notify_stream_start(&state, &user.username);
+    sqlx::query("UPDATE shows SET prerecorded_started_at = datetime('now') WHERE id = ?")
+        .bind(show.id)
+        .execute(&state.db)
+        .await?;
 
-    Ok(Json(serde_json::json!({
-        "success": true,
-        "message": "Prerecorded stream started",
-    })))
+    // Notify via Telegram
+    telegram_notify::notify_stream_start(state, username);
+
+    Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -797,6 +797,21 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Spawn the pre-recorded show auto-start scheduler: fires go-live once a
+    // confirmed pre-recorded show reaches its scheduled start, so it doesn't
+    // depend on an admin having the waiting-room page open (issue #240). Runs
+    // every 30s; self-guards via the `prerecorded_started_at` column.
+    {
+        let state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                scheduler::check_prerecorded_show_start(state.clone()).await;
+            }
+        });
+    }
+
     // Spawn the Icecast listener/quality telemetry poller (#177). No-op if no
     // status URL is configured (or derivable from icecast_url).
     stream_metrics::spawn_poller(state.clone());

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -119,6 +119,10 @@ pub struct Show {
     /// creates a show may assign a guest they created as the host, yet retains
     /// edit rights over the show via this field.
     pub created_by: Option<i64>,
+    /// When go-live was triggered for this show's pre-recorded stream (manual
+    /// button or the auto-start scheduler). Guards against the scheduler
+    /// re-starting an already-started show.
+    pub prerecorded_started_at: Option<String>,
 }
 
 /// Reusable show template: a per-user bundle of presentation content

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -10,6 +10,11 @@ use crate::{models, telegram_notify, AppState};
 /// finalize still in flight.
 const RECORDING_ALERT_GRACE_MINS: i64 = 15;
 
+/// If a pre-recorded show has no `end_time` recorded, how long past its
+/// scheduled start we'll still auto-start it. Bounds how far a long server
+/// outage can reach back and kick off a stale, long-past show.
+const PRERECORDED_START_GRACE_HOURS: i64 = 6;
+
 /// Check if any artist Instagram previews need to be sent today.
 ///
 /// Logic:
@@ -134,6 +139,18 @@ fn parse_hhmm(s: &str) -> Option<NaiveTime> {
     NaiveTime::parse_from_str(s, "%H:%M").ok()
 }
 
+/// Compute a show's scheduled start as a UTC instant, interpreting `date`+`start_time`
+/// in Europe/Berlin. Returns `None` if the date/time can't be parsed or the
+/// local time is invalid (DST gap).
+fn show_start_utc(date: &str, start_time: &str) -> Option<DateTime<Utc>> {
+    let day = NaiveDate::parse_from_str(date, "%Y-%m-%d").ok()?;
+    let start = parse_hhmm(start_time)?;
+    Berlin
+        .from_local_datetime(&day.and_time(start))
+        .single()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
 /// Compute a show's scheduled end as a UTC instant, interpreting `date`+`end_time`
 /// in Europe/Berlin. Handles overnight shows (end ≤ start → next calendar day).
 /// Returns `None` if the date/time can't be parsed or the local time is invalid
@@ -246,9 +263,139 @@ pub async fn check_missing_recordings(state: Arc<AppState>) {
     }
 }
 
+/// Resolve the username to stream as for a show: the directly-assigned host
+/// (`host_user_id`, external/brunchtime shows), or failing that the first
+/// assigned artist's linked user (UNHEARD shows). Mirrors the two lookup paths
+/// in `handlers::api::resolve_user_shows`.
+async fn resolve_show_host_username(state: &Arc<AppState>, show: &models::Show) -> Option<String> {
+    if let Some(host_user_id) = show.host_user_id {
+        if let Ok(Some(username)) =
+            sqlx::query_scalar::<_, String>("SELECT username FROM users WHERE id = ?")
+                .bind(host_user_id)
+                .fetch_optional(&state.db)
+                .await
+        {
+            return Some(username);
+        }
+    }
+
+    sqlx::query_scalar::<_, String>(
+        "SELECT u.username FROM artist_show_assignments asa \
+         INNER JOIN artists a ON a.id = asa.artist_id \
+         INNER JOIN users u ON u.id = a.user_id \
+         WHERE asa.show_id = ? \
+         ORDER BY asa.sort_order LIMIT 1",
+    )
+    .bind(show.id)
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Auto-start a pre-recorded show's stream once its scheduled start time
+/// arrives, so going live doesn't depend on an admin having the waiting-room
+/// page open in a browser tab (see issue #240). Scoped to confirmed uploads
+/// that haven't been started yet, and bounded so a show that's already ended
+/// (or, lacking an end time, is well past its start) is never resurrected.
+pub async fn check_prerecorded_show_start(state: Arc<AppState>) {
+    let now = Utc::now();
+
+    let shows: Vec<models::Show> = match sqlx::query_as(
+        "SELECT * FROM shows \
+         WHERE stream_mode = 'prerecorded' \
+           AND prerecorded_confirmed_at IS NOT NULL \
+           AND prerecorded_started_at IS NULL \
+           AND start_time IS NOT NULL \
+           AND date >= date('now', '-2 days')",
+    )
+    .fetch_all(&state.db)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!("Prerecorded auto-start: failed to query shows: {e}");
+            return;
+        }
+    };
+
+    for show in &shows {
+        let Some(start_time) = show.start_time.as_deref() else {
+            continue;
+        };
+        let Some(start) = show_start_utc(&show.date, start_time) else {
+            tracing::warn!(
+                "Prerecorded auto-start: cannot parse start time for show {}",
+                show.id
+            );
+            continue;
+        };
+        if now < start {
+            continue; // not time yet
+        }
+
+        // Never resurrect a show that has already ended, or that's well past
+        // its start with no recorded end time.
+        let past_grace = match show.end_time.as_deref() {
+            Some(end_time) => match show_end_utc(&show.date, Some(start_time), end_time) {
+                Some(end) => now >= end,
+                None => now >= start + chrono::Duration::hours(PRERECORDED_START_GRACE_HOURS),
+            },
+            None => now >= start + chrono::Duration::hours(PRERECORDED_START_GRACE_HOURS),
+        };
+        if past_grace {
+            tracing::warn!(
+                "Prerecorded auto-start: show {} ('{}') is stale, skipping",
+                show.id,
+                show.title
+            );
+            continue;
+        }
+
+        let Some(username) = resolve_show_host_username(&state, show).await else {
+            tracing::error!(
+                "Prerecorded auto-start: no host user found for show {} ('{}')",
+                show.id,
+                show.title
+            );
+            continue;
+        };
+
+        tracing::info!(
+            "Prerecorded auto-start: starting show {} ('{}') for user '{}'",
+            show.id,
+            show.title,
+            username
+        );
+
+        if let Err(e) =
+            crate::handlers::api::start_prerecorded_show_stream(&state, show, &username).await
+        {
+            tracing::error!(
+                "Prerecorded auto-start: failed to start show {} ('{}'): {e}",
+                show.id,
+                show.title
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn show_start_utc_handles_evening_show() {
+        // 18:00 Berlin (CEST, summer) → 16:00 UTC.
+        let start = show_start_utc("2026-06-01", "18:00").unwrap();
+        assert_eq!(start.to_rfc3339(), "2026-06-01T16:00:00+00:00");
+    }
+
+    #[test]
+    fn show_start_utc_rejects_garbage() {
+        assert!(show_start_utc("not-a-date", "18:00").is_none());
+        assert!(show_start_utc("2026-06-01", "nope").is_none());
+    }
 
     #[test]
     fn show_end_utc_handles_evening_show() {

--- a/backend/src/stream_bridge.rs
+++ b/backend/src/stream_bridge.rs
@@ -525,7 +525,7 @@ pub async fn start_prerecorded_stream(
 
         // Spawn FFmpeg with file/URL input:
         // -re: read at native frame rate (essential for streaming prerecorded content)
-        let child = Command::new("ffmpeg")
+        let mut child = Command::new("ffmpeg")
             .args([
                 "-hide_banner",
                 "-loglevel",
@@ -542,9 +542,26 @@ pub async fn start_prerecorded_stream(
             .spawn()
             .map_err(|e| StreamError::FfmpegSpawn(e.to_string()))?;
 
+        // Surface FFmpeg's warnings/errors (bad URL, unreachable Icecast, bad
+        // codec, ...) to the logs instead of silently discarding them — a failed
+        // prerecorded stream previously exited with no visible reason.
+        if let Some(stderr) = child.stderr.take() {
+            let log_user = user.clone();
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::warn!("ffmpeg (prerecorded, user '{}'): {}", log_user, line);
+                }
+            });
+        }
+
         state.current_user = Some(user.clone());
         state.ffmpeg_handle = Some(child);
-        // No ffmpeg_stdin for prerecorded streams
+        // No ffmpeg_stdin for prerecorded streams.
+        // Not a test broadcast: make sure a stale `is_test = true` from an
+        // earlier rehearsal never leaks in and flips the public status off.
+        state.is_test = false;
     }
 
     // Spawn a background task to monitor when FFmpeg exits
@@ -564,6 +581,7 @@ pub async fn start_prerecorded_stream(
                         );
                         state.current_user = None;
                         state.ffmpeg_handle = None;
+                        state.is_test = false;
                         true
                     }
                     Ok(None) => false, // still running
@@ -575,6 +593,7 @@ pub async fn start_prerecorded_stream(
                         );
                         state.current_user = None;
                         state.ffmpeg_handle = None;
+                        state.is_test = false;
                         true
                     }
                 }


### PR DESCRIPTION
## What
- Add a backend scheduler (`check_prerecorded_show_start`, polling every 30s) that automatically starts a confirmed pre-recorded show's stream once it reaches its scheduled start time.
- Extract the go-live logic out of `api_my_show_go_live` into a shared `start_prerecorded_show_stream` so both the manual "Go Live" button and the new scheduler use the same code path.
- Add a `shows.prerecorded_started_at` column (self-migrating) so a show is never auto-started twice, and never resurrected long after it should have ended.
- Fix a latent bug in `stream_bridge.rs`: `start_prerecorded_stream()` and its exit-monitor task never reset the shared `is_test` flag, which could leave `/api/stream/status` reporting `active: false` even while FFmpeg was genuinely streaming.
- Log FFmpeg stderr for the pre-recorded stream path so a failed stream is diagnosable from server logs instead of failing silently.

## Why
Fixes #240: pre-recorded shows uploaded fine but never actually went live — the player page just showed off-air.

Root cause: the *only* trigger for `start_prerecorded_stream()` was a client-side countdown in the admin waiting-room page (`FlowWaiting.vue`) that calls `POST /api/my-show/go-live` when it hits zero — but only while that browser tab stays open and mounted. If the admin closes the tab, the laptop sleeps, or nobody is present at showtime, the request is simply never sent and no stream ever starts. There was no server-side path to start a pre-recorded show at all.

## How
- `scheduler.rs`: new `show_start_utc()` helper (mirrors the existing `show_end_utc()`), `resolve_show_host_username()` (mirrors the two lookup paths in `resolve_user_shows`: direct `host_user_id`, or first assigned artist's linked user), and `check_prerecorded_show_start()` which queries confirmed-but-not-yet-started pre-recorded shows, checks the computed start time, and calls the shared go-live logic.
- `main.rs`: spawns the new scheduler alongside the existing interval-based jobs (dead-man's-switch, artist preview, etc).
- The frontend's client-side auto-start in `FlowWaiting.vue` is left as-is — it's now a harmless redundant path since the scheduler guards re-entry via `prerecorded_started_at`.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (new `show_start_utc` tests pass; the one failing test, `video::test_brightness_analysis`, is pre-existing and unrelated — confirmed it also fails on `main`)
- [x] `cargo clippy` — no new warnings in touched files
- [x] `cargo fmt --check` — clean
- [x] GitNexus `impact`/`detect_changes` reviewed, all LOW risk, diff matches intended scope
- [ ] Manual: create a show a few minutes out, upload + confirm a pre-recording, leave the admin tab closed, confirm the scheduler starts the stream unattended and the public player goes on-air
- [ ] Manual: start a live "test broadcast" via `FlowLive.vue`, kill the connection uncleanly, then trigger a pre-recorded go-live and confirm `/api/stream/status` reports `active: true`

## Risk
Medium — touches the show-scheduling and stream-start path, and adds a background job that automatically starts FFmpeg processes. Mitigated by: guarded re-entry (`prerecorded_started_at`), bounded staleness window (won't fire for shows well past their end), and the scheduler reusing the exact same start logic as the existing manual button (no new FFmpeg invocation code path). Rollback is a revert — the new column is additive and the frontend auto-start still works independently as a fallback.
