### PR TITLE
feat(frontend): enable admin feedback widget in production

### DIFF
--- a/docs/feedback-widget.md
+++ b/docs/feedback-widget.md
@@ -1,9 +1,9 @@
 # Feedback widget (dev/review)
 
-A drop-in **feedback layer** for the dev/review process, mounted on the **admin
-dashboard only**. Reviewers click a bug button, annotate a screenshot, and submit —
-it becomes a **GitHub issue** with the screenshot plus page URL and browser/viewport
-context. The public pages are intentionally never touched.
+A drop-in **feedback layer** mounted on the **admin dashboard**, in **every
+environment (production included)**. Admins/reviewers click a bug button, annotate a
+screenshot, and submit — it becomes a **GitHub issue** with the screenshot plus page
+URL and browser/viewport context. The public pages are intentionally never touched.
 
 - **Tool:** [BugDrop](https://github.com/mean-weasel/bugdrop) — MIT, open source.
 - **Where feedback lands:** GitHub Issues in a target repo (default: `phaabe/live.moafunk.de`).
@@ -23,26 +23,24 @@ context. The public pages are intentionally never touched.
 
 A conditional Vite plugin (`bugdropFeedbackWidget` in `frontend/vite.config.ts`)
 injects the widget's `<script>` tag into the **admin SPA** (`src/admin/index.html`)
-only — never the public pages — and only when `VITE_FEEDBACK_WIDGET` is set to a
-GitHub `owner/repo`. Production builds (GitHub Pages, admin Docker) never set the
-var, so the tag is absent from those bundles.
+only — never the public pages. It is **on by default** in all builds, filing into
+`phaabe/live.moafunk.de`. The admin SPA is built and served by the backend
+(`backend/Dockerfile` → `/static/admin`), so production admin gets it too; the
+public GitHub Pages build is untouched.
 
-## Enabling it
+## Configuring it
 
-**Local dev** — add to `frontend/.env.local` (gitignored):
+On by default — nothing to enable. Control it via `VITE_FEEDBACK_WIDGET`:
 
-```
-VITE_FEEDBACK_WIDGET=phaabe/live.moafunk.de
-```
-
-Then `npm run dev` (or `npm run build` for a static review build). Unset it to turn
-the widget off.
-
-**Review/preview build** — set the var for that build only, e.g.:
+- **Change target repo:** `VITE_FEEDBACK_WIDGET=owner/other-repo` (build/env or `.env.local`).
+- **Disable entirely:** `VITE_FEEDBACK_WIDGET=off` (also `false` / `none` / `0`).
 
 ```
-VITE_FEEDBACK_WIDGET=phaabe/live.moafunk.de npm run build
+# disable for a build
+VITE_FEEDBACK_WIDGET=off npm run build
 ```
+
+The default target repo is the `FEEDBACK_REPO` constant in `frontend/vite.config.ts`.
 
 ## Triaging incoming feedback
 
@@ -61,8 +59,9 @@ wizard (`WizardHost.vue`). Apply masks as those become reachable in review build
 
 ## Verifying
 
-- Local: `npm run dev` with the var set → open `/admin/`, the bug button appears (and is absent on the public `/`); submit → issue lands in the repo with screenshot + context.
-- Prod guard: `npm run build` **without** the var, then `grep -r bugdrop dist` → no matches.
+- Default build: `npm run build`, then `grep -rl bugdrop dist` → **only** `dist/admin/index.html` (never the public pages).
+- Disable: `VITE_FEEDBACK_WIDGET=off npm run build`, then `grep -r bugdrop dist` → no matches.
+- Local: `npm run dev` → open `/admin/`, the bug button appears (and is absent on the public `/`); submit → issue lands in the repo with screenshot + context.
 
 ## Self-host upgrade path (optional)
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,12 +16,12 @@ VITE_STREAM_ICECAST_LIVE_URL=
 # Set together with VITE_STREAM_ICECAST_LIVE_URL, e.g. https://admin.live.moafunk.de/api/stream/status
 VITE_STREAM_STATUS_URL=
 
-# Feedback widget (dev/review only — leave UNSET in production)
-# When set to a GitHub "owner/repo", the BugDrop feedback widget
-# (https://github.com/mean-weasel/bugdrop) is injected into the ADMIN dashboard
-# only (public pages are never touched). Reviewers click the bug button to file
-# feedback as a GitHub issue with a screenshot + page/browser context. Requires the
-# BugDrop GitHub App installed on that repo. Production pipelines must NOT set this.
+# Feedback widget — ON by default in the ADMIN dashboard, all environments
+# (production included). Public pages are never touched. The BugDrop widget
+# (https://github.com/mean-weasel/bugdrop) files feedback as a GitHub issue with a
+# screenshot + page/browser context, into phaabe/live.moafunk.de by default.
+# Override the target repo with owner/repo, or disable entirely with `off`
+# (also: false/none/0). Requires the BugDrop GitHub App on the target repo.
 # See docs/feedback-widget.md.
 VITE_FEEDBACK_WIDGET=
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,17 +36,18 @@ function emitVersionManifest(): Plugin {
 }
 
 const BUGDROP_ORIGIN = 'https://bugdrop.neonwatty.workers.dev';
+// Repo that feedback issues are filed into. Requires the BugDrop GitHub App
+// installed on it. Override per build with VITE_FEEDBACK_WIDGET=other/repo.
+const FEEDBACK_REPO = 'phaabe/live.moafunk.de';
 
 // Inject the BugDrop feedback widget (https://github.com/mean-weasel/bugdrop)
-// into the admin dashboard only — and only for dev/review builds. The target repo
-// is read from VITE_FEEDBACK_WIDGET (e.g. "phaabe/live.moafunk.de"); feedback
-// becomes a GitHub issue with a screenshot + page/browser context. Production
-// pipelines (GitHub Pages, admin Docker) never set the var, so nothing is injected
-// and the prod bundles stay clean. Emits BugDrop's documented synchronous tag —
-// deliberately no async/defer, so the widget can read data-repo off its own tag.
+// into the admin dashboard — in every environment, production included. Feedback
+// becomes a GitHub issue with a screenshot + page/browser context. Emits BugDrop's
+// documented synchronous tag — deliberately no async/defer, so the widget can read
+// data-repo off its own tag.
 //
 // Scope: admin SPA (src/admin/index.html) only. The public pages are intentionally
-// left untouched, so visitors never see the widget.
+// left untouched, so site visitors never see the widget.
 function bugdropFeedbackWidget(repo: string | undefined): Plugin {
   return {
     name: 'bugdrop-feedback-widget',
@@ -71,10 +72,13 @@ function bugdropFeedbackWidget(repo: string | undefined): Plugin {
 }
 
 export default defineConfig(({ mode }) => {
-  // Read .env files (and CLI/process env) so review builds can opt in via
-  // VITE_FEEDBACK_WIDGET=owner/repo in .env.local or on the command line.
+  // The admin feedback widget is ON by default in every environment. Override the
+  // target repo with VITE_FEEDBACK_WIDGET=other/repo, or disable it entirely with
+  // VITE_FEEDBACK_WIDGET=off (also: false/none/0). Read from .env files + CLI/env.
   const env = loadEnv(mode, process.cwd(), '');
-  const feedbackRepo = env.VITE_FEEDBACK_WIDGET || process.env.VITE_FEEDBACK_WIDGET;
+  const feedbackEnv = env.VITE_FEEDBACK_WIDGET || process.env.VITE_FEEDBACK_WIDGET || '';
+  const feedbackOff = ['off', 'false', 'none', '0'].includes(feedbackEnv.toLowerCase());
+  const feedbackRepo = feedbackOff ? undefined : feedbackEnv || FEEDBACK_REPO;
 
   return {
     define: { __BUILD_ID__: JSON.stringify(BUILD_ID) },


### PR DESCRIPTION
## What

The BugDrop feedback widget is now **on by default for the admin dashboard in every environment, production included**. Previously it was opt-in via `VITE_FEEDBACK_WIDGET`, so it never reached prod (#238).

## Why

The admin SPA is built and served by the backend (`backend/Dockerfile` → `/static/admin`), so defaulting the widget on means production admin gets it. Public GitHub Pages build stays untouched.

## Behaviour

- **Default:** widget injected into `src/admin/index.html`, filing into `phaabe/live.moafunk.de` (the `FEEDBACK_REPO` constant).
- **Override repo:** `VITE_FEEDBACK_WIDGET=owner/other-repo`.
- **Disable:** `VITE_FEEDBACK_WIDGET=off` (also `false`/`none`/`0`).
- Public pages never touched.

## Verification

- Default build → `grep -rl bugdrop dist` = only `dist/admin/index.html`.
- `VITE_FEEDBACK_WIDGET=off` build → no matches anywhere.
- ESLint clean.

Docs (`docs/feedback-widget.md`) + `frontend/.env.example` updated to reflect always-on/opt-out.