### PR TITLE
feat(auth): add dev-only login gated by APP_ENV

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,12 @@ HOST=0.0.0.0
 PORT=8000
 SECRET_KEY=change-this-to-a-random-secret-key
 
+# Deployment environment: "development" (or "dev") enables an always-available
+# `dev` / `dev` superadmin login for local work. Any other value — including the
+# default when unset — is treated as production, where that account is actively
+# removed on startup. NEVER set this to development in prod.
+APP_ENV=development
+
 # Superadmin password hash (Argon2)
 # Generate with: cargo run --bin hash_password -- "your-password"
 # Must be single-quoted: the hash contains '$', which dotenvy expands otherwise.

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -10,6 +10,12 @@ pub struct Config {
 
     pub secret_key: String,
 
+    // Deployment environment. "development" (or "dev") enables the always-available
+    // `dev` / `dev` login seeded by `db::seed_dev_user`; anything else (the default)
+    // is treated as production and that account is actively removed if present.
+    #[serde(default = "default_app_env")]
+    pub app_env: String,
+
     // Superadmin credentials (seeded on first run if no users exist)
     #[serde(default = "default_superadmin_username")]
     pub superadmin_username: String,
@@ -142,6 +148,10 @@ fn default_port() -> u16 {
     8000
 }
 
+fn default_app_env() -> String {
+    "production".to_string()
+}
+
 fn default_superadmin_username() -> String {
     "superadmin".to_string()
 }
@@ -255,6 +265,12 @@ impl Config {
         Ok(config)
     }
 
+    /// True when running in a development environment (`APP_ENV=development|dev`).
+    /// Gates the always-available `dev` login; defaults to false (production).
+    pub fn is_dev(&self) -> bool {
+        app_env_is_dev(&self.app_env)
+    }
+
     pub fn max_file_size_bytes(&self) -> u64 {
         self.max_file_size_mb * 1024 * 1024
     }
@@ -358,6 +374,16 @@ fn test_producer_target_from_url(url: Option<&str>) -> Option<crate::stream_brid
     })
 }
 
+/// Whether an `APP_ENV` value denotes a development environment. Case-insensitive
+/// and whitespace-tolerant; anything other than `development`/`dev` is production.
+/// Pure (no env / Config) so it's unit-testable.
+fn app_env_is_dev(app_env: &str) -> bool {
+    matches!(
+        app_env.trim().to_ascii_lowercase().as_str(),
+        "development" | "dev"
+    )
+}
+
 /// Validate the producer output selection. `icecast` requires a non-empty
 /// `ICECAST_URL`; any value other than `rtmp`/`icecast` is rejected. Pure (no
 /// env access) so it's unit-testable without building a full [`Config`].
@@ -454,6 +480,16 @@ mod tests {
             derive_status_url("icecast://radio.example.com:8000/test.mp3").as_deref(),
             Some("http://radio.example.com:8000/status-json.xsl")
         );
+    }
+
+    #[test]
+    fn is_dev_only_for_development_values() {
+        assert!(app_env_is_dev("development"));
+        assert!(app_env_is_dev("dev"));
+        assert!(app_env_is_dev("  Development  ")); // trimmed + case-insensitive
+        assert!(!app_env_is_dev("production"));
+        assert!(!app_env_is_dev("prod"));
+        assert!(!app_env_is_dev(""));
     }
 
     #[test]

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -615,6 +615,57 @@ pub async fn seed_superadmin(pool: &SqlitePool, config: &Config) -> Result<(), s
     Ok(())
 }
 
+/// Username/password for the development-only convenience login.
+const DEV_USERNAME: &str = "dev";
+const DEV_PASSWORD: &str = "dev";
+
+/// Keep the always-available `dev` login in sync with the environment.
+///
+/// When `is_dev` is true (from `Config::is_dev()`) this upserts a
+/// `dev` / `dev` superadmin on **every** startup, so the account is always usable
+/// regardless of any prior password drift (unlike [`seed_superadmin`], which only
+/// inserts when the table is empty). Outside development it actively deletes any
+/// stray `dev` user — so a production DB cloned from a dev one can never carry the
+/// backdoor — making the account strictly dev-only.
+pub async fn seed_dev_user(pool: &SqlitePool, is_dev: bool) -> Result<(), sqlx::Error> {
+    if !is_dev {
+        let deleted = sqlx::query("DELETE FROM users WHERE username = ?")
+            .bind(DEV_USERNAME)
+            .execute(pool)
+            .await?
+            .rows_affected();
+        if deleted > 0 {
+            tracing::warn!(
+                "Removed {deleted} stray '{DEV_USERNAME}' user(s): APP_ENV is not development"
+            );
+        }
+        return Ok(());
+    }
+
+    let password_hash = crate::auth::hash_password(DEV_PASSWORD)
+        .map_err(|_| sqlx::Error::Protocol("failed to hash dev password".into()))?;
+
+    // Upsert so the dev login is always present and never drifts. Reset the
+    // mutable bits a prior session might have changed (role/expiry/forced change).
+    sqlx::query(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'superadmin') \
+         ON CONFLICT(username) DO UPDATE SET \
+         password_hash = excluded.password_hash, \
+         role = 'superadmin', \
+         must_change_password = 0, \
+         expires_at = NULL",
+    )
+    .bind(DEV_USERNAME)
+    .bind(&password_hash)
+    .execute(pool)
+    .await?;
+
+    tracing::warn!(
+        "DEV MODE: '{DEV_USERNAME}' / '{DEV_PASSWORD}' login is enabled (APP_ENV=development)"
+    );
+    Ok(())
+}
+
 // ============================================================================
 // Recording Versions CRUD
 // ============================================================================
@@ -789,6 +840,50 @@ mod tests {
             .await
             .unwrap()
             .last_insert_rowid()
+    }
+
+    async fn count_user(pool: &SqlitePool, username: &str) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE username = ?")
+            .bind(username)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    /// In development the `dev` login is created (and re-created idempotently on
+    /// every startup) as a superadmin.
+    #[tokio::test]
+    async fn seed_dev_user_creates_dev_login_in_development() {
+        let pool = mem_db().await;
+        seed_dev_user(&pool, true).await.unwrap();
+        assert_eq!(count_user(&pool, DEV_USERNAME).await, 1);
+
+        let role: String = sqlx::query_scalar("SELECT role FROM users WHERE username = ?")
+            .bind(DEV_USERNAME)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(role, "superadmin");
+
+        // Idempotent: a second run does not duplicate the account.
+        seed_dev_user(&pool, true).await.unwrap();
+        assert_eq!(count_user(&pool, DEV_USERNAME).await, 1);
+    }
+
+    /// Outside development the `dev` login is actively removed — so a prod DB
+    /// cloned from a dev one can never carry the backdoor.
+    #[tokio::test]
+    async fn seed_dev_user_removes_dev_login_outside_development() {
+        let pool = mem_db().await;
+        insert_user(&pool, DEV_USERNAME).await; // simulate a stray dev account
+        assert_eq!(count_user(&pool, DEV_USERNAME).await, 1);
+
+        seed_dev_user(&pool, false).await.unwrap();
+        assert_eq!(count_user(&pool, DEV_USERNAME).await, 0);
+
+        // Idempotent when already absent.
+        seed_dev_user(&pool, false).await.unwrap();
+        assert_eq!(count_user(&pool, DEV_USERNAME).await, 0);
     }
 
     async fn insert_template(pool: &SqlitePool, owner: i64, name: &str) -> i64 {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -248,6 +248,10 @@ async fn main() -> anyhow::Result<()> {
     // Seed superadmin if no users exist
     db::seed_superadmin(&db, &config).await?;
 
+    // Keep the dev-only `dev` login in sync: created in development, removed
+    // otherwise (see `seed_dev_user`).
+    db::seed_dev_user(&db, config.is_dev()).await?;
+
     // Initialize S3 client for R2 (avoid aws-config to reduce dependencies/compile time).
     // Client construction (incl. the R2 checksum-behavior fix) lives in storage.rs
     // so it's shared with integration tests.


### PR DESCRIPTION
## What

Adds an always-available `dev` / `dev` superadmin login for local development, gated by a new `APP_ENV` env var.

## Why

Local logins drift: `seed_superadmin` only inserts when the `users` table is empty, so a local DB seeded under an old `SUPERADMIN_PASSWORD_HASH` keeps rejecting the current password. A dedicated, self-healing dev login avoids that.

## How

- **config**: new `APP_ENV` field (default `production`) + `Config::is_dev()` — true only for `development`/`dev` (case-insensitive, trimmed). Pure `app_env_is_dev` helper with a unit test.
- **db**: `seed_dev_user`, called on startup after `seed_superadmin`:
  - In dev → **upserts** `dev` / `dev` superadmin on *every* boot, so it can never drift.
  - Otherwise → **deletes** any stray `dev` user, so a prod DB cloned from a dev one can't carry the backdoor. Strictly dev-only.
- **main**: wires in `seed_dev_user`.
- **.env.example**: documents `APP_ENV` with a prod warning.

## Test plan

- `cargo build` ✅
- `cargo test --bin unheard-backend is_dev` ✅
- `clippy` clean on changed code ✅
- Manual: `APP_ENV=development` → boot logs `DEV MODE: 'dev' / 'dev' login is enabled`, login works.