### PR TITLE
fix(auth): default APP_ENV to production in env template

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,11 +12,12 @@ HOST=0.0.0.0
 PORT=8000
 SECRET_KEY=change-this-to-a-random-secret-key
 
-# Deployment environment: "development" (or "dev") enables an always-available
-# `dev` / `dev` superadmin login for local work. Any other value — including the
-# default when unset — is treated as production, where that account is actively
-# removed on startup. NEVER set this to development in prod.
-APP_ENV=development
+# Deployment environment. Safe default is production; any value other than
+# "development"/"dev" (including unset) is treated as production, where the
+# convenience login below is actively removed on startup. Set APP_ENV=development
+# — ideally in .env.local — to enable an always-available `dev` / `dev` superadmin
+# for local work. NEVER set this to development in prod.
+APP_ENV=production
 
 # Superadmin password hash (Argon2)
 # Generate with: cargo run --bin hash_password -- "your-password"


### PR DESCRIPTION
Follow-up to #244.

The `.env.example` template shipped `APP_ENV=development`, contradicting its own "NEVER set this to development in prod" comment and enabling the `dev` / `dev` login for anyone using the documented `cp .env.example .env` fallback.

Default it to `production` (matches the code's unset behaviour, safe-by-default). Local devs opt in with `APP_ENV=development`, ideally in `.env.local` where personal values live.