### PR TITLE
chore(telegram): add TELEGRAM_ENABLED kill-switch, default off

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -87,6 +87,8 @@ DEFAULT_LOGO_PATH=./assets/brand/moafunk.png
 # OPENAI_API_KEY=sk-...
 
 # Telegram bot (optional — bot disabled if token unset)
+# Master kill-switch: bot is OFF unless TELEGRAM_ENABLED=true, even with a token set.
+# TELEGRAM_ENABLED=true
 # Create via @BotFather, get chat ID from https://api.telegram.org/bot<TOKEN>/getUpdates
 # TELEGRAM_BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
 # TELEGRAM_ADMIN_CHAT_ID=123456789

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -126,6 +126,11 @@ pub struct Config {
     pub soundcloud_redirect_uri: String,
 
     // Telegram Bot settings (optional - for admin notifications and control)
+    /// Master kill-switch for the Telegram bot. Defaults to `false` (off): the
+    /// long-polling dispatcher never starts and every send site no-ops, even if
+    /// a token is configured. Set `TELEGRAM_ENABLED=true` to turn it back on.
+    #[serde(default)]
+    pub telegram_enabled: bool,
     pub telegram_bot_token: Option<String>,
     pub telegram_admin_chat_id: Option<i64>,
     #[serde(default = "default_telegram_topic_id")]
@@ -235,6 +240,13 @@ fn normalize_telegram_topic_id(configured: Option<i32>) -> Option<i32> {
 
 fn default_telegram_artist_preview_hour() -> u32 {
     16 // 4:00 PM Berlin time
+}
+
+/// The Telegram bot runs only when explicitly enabled via the kill-switch AND a
+/// token is configured. Gating both the long-polling dispatcher and every send
+/// site on this keeps the whole integration silent when `enabled` is false.
+pub fn telegram_bot_active(enabled: bool, has_token: bool) -> bool {
+    enabled && has_token
 }
 
 fn default_admin_base_url() -> String {
@@ -446,6 +458,17 @@ mod tests {
             }
             other => panic!("expected Icecast test target, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn telegram_bot_active_requires_enabled_and_token() {
+        // Off by default: disabled kill-switch keeps the bot silent even with a token.
+        assert!(!telegram_bot_active(false, false));
+        assert!(!telegram_bot_active(false, true));
+        // Enabled but no token → nothing to run.
+        assert!(!telegram_bot_active(true, false));
+        // Only enabled AND configured brings the bot up.
+        assert!(telegram_bot_active(true, true));
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -271,15 +271,29 @@ async fn main() -> anyhow::Result<()> {
     // Initialize cover regeneration debounce tracker
     let cover_debounce = Arc::new(RwLock::new(HashMap::new()));
 
-    // Initialize Telegram bot (if configured)
-    let telegram_bot = config.telegram_bot_token.as_ref().map(|token| {
+    // Initialize Telegram bot (only when enabled and configured).
+    // `telegram_enabled` is the master kill-switch (default off): when the bot is
+    // inactive we leave `telegram_bot` as `None`, which no-ops the long-polling
+    // dispatcher and every send site — the single choke point for the whole
+    // integration.
+    let telegram_bot = if config::telegram_bot_active(
+        config.telegram_enabled,
+        config.telegram_bot_token.is_some(),
+    ) {
+        let token = config
+            .telegram_bot_token
+            .as_ref()
+            .expect("active implies a configured token");
         tracing::info!(
             chat_id = ?config.telegram_admin_chat_id,
             topic_id = ?config.telegram_topic_id,
             "Telegram bot configured"
         );
-        teloxide::Bot::new(token)
-    });
+        Some(teloxide::Bot::new(token))
+    } else {
+        tracing::info!("Telegram bot disabled (set TELEGRAM_ENABLED=true to enable)");
+        None
+    };
 
     // Initialize pending show notifications tracker (for debouncing)
     let pending_show_notifications = Arc::new(tokio::sync::Mutex::new(HashMap::new()));


### PR DESCRIPTION
Closes #246.

## What
Adds a committed master kill-switch for the backend Telegram bot. Default **off** — the bot is silent (no long-polling dispatcher, no outbound notifications/messages) unless `TELEGRAM_ENABLED=true`.

## How
`state.telegram_bot: Option<teloxide::Bot>` is the single choke point: `telegram.rs::run()` no-ops on `None`, every `telegram_notify` send site gates on `Some(bot)`, and the `main.rs` guards check `telegram_bot.is_none()`. Construction is now gated on `telegram_bot_active(enabled, has_token)`, so `None` (and thus full silence) results whenever the flag is off.

- `Config.telegram_enabled: bool` (`#[serde(default)]` → false)
- `main.rs` builds the bot only when active; logs "Telegram bot disabled" otherwise
- `TELEGRAM_ENABLED` documented in `backend/.env.example`
- Unit test for the truth table

## Deploy effect
Prod env sets a token but **not** `TELEGRAM_ENABLED`, so shipping this build makes the bot default-off — no secret/env change required. Merge → Hetzner auto-deploy → live bot goes silent.

## Re-enable
Set `TELEGRAM_ENABLED=true` (BWS/env) and redeploy, or revert. No code removed.

Distinct from #225 (Alertmanager Telegram sender — separate path).