### PR TITLE
fix(recording): word dead-man's-switch alert for sub-threshold captures

### DIFF
--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -267,7 +267,14 @@ pub struct FinalizedRecording {
 /// A recording shorter than this is treated as essentially empty — the recorder
 /// started but produced no usable audio (e.g. it died seconds in). No real show
 /// is under a minute, so this floor never fails a legitimate broadcast.
-const MIN_RECORDING_SECS: u64 = 60;
+pub(crate) const MIN_RECORDING_SECS: u64 = 60;
+
+/// Stable token embedded in the failure reason of a sub-threshold capture so the
+/// dead-man's-switch ([`crate::scheduler::check_missing_recordings`]) can word its
+/// alert accurately — "under the minimum, not archived" vs. "recorder may be
+/// broken" — without re-deriving the duration. Do not reword without updating the
+/// scheduler classifier (and note existing `failed` rows carry the old text).
+pub(crate) const SHORT_RECORDING_MARKER: &str = "essentially empty";
 
 /// If the recorded duration is implausibly short, return a human-readable reason;
 /// otherwise `None`. Returns `None` when the duration is unknown (can't judge).
@@ -284,9 +291,10 @@ fn detect_short_recording(show_id: i64, local_duration_ms: Option<u64>) -> Optio
     let duration_ms = local_duration_ms?;
     if duration_ms < MIN_RECORDING_SECS * 1000 {
         let reason = format!(
-            "recording for show {} is only {}s — essentially empty",
+            "recording for show {} is only {}s — {}",
             show_id,
-            duration_ms / 1000
+            duration_ms / 1000,
+            SHORT_RECORDING_MARKER
         );
         Some(reason)
     } else {

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -230,20 +230,46 @@ pub async fn check_missing_recordings(state: Arc<AppState>) {
             continue; // still live, just ended, or unparseable schedule
         }
 
+        // A qualifying show has no successful recording, but the cause matters:
+        // a capture rejected purely for being under the minimum length is benign
+        // (someone tested / aborted quickly) and shouldn't read like a broken
+        // recorder. Inspect the latest version row to word the alert accordingly.
+        let latest: Option<(String, Option<String>)> = match sqlx::query_as(
+            "SELECT status, error_message FROM recording_versions \
+             WHERE show_id = ? ORDER BY id DESC LIMIT 1",
+        )
+        .bind(show.id)
+        .fetch_optional(&state.db)
+        .await
+        {
+            Ok(row) => row,
+            Err(e) => {
+                tracing::error!(
+                    "Dead-man's-switch: failed to query recording versions for show {}: {e}",
+                    show.id
+                );
+                None
+            }
+        };
+        let too_short = latest
+            .as_ref()
+            .is_some_and(|(status, msg)| is_short_capture(status, msg.as_deref()));
+
         tracing::warn!(
-            "Dead-man's-switch: show {} ('{}') ended with no recording — alerting",
+            "Dead-man's-switch: show {} ('{}') ended with no usable recording (too_short={}) — alerting",
             show.id,
-            show.title
+            show.title,
+            too_short
         );
 
         telegram_notify::notify(
             &state,
-            &format!(
-                "⚠️ No recording for show \"{}\" (#{}) on {}{}. The live archive may be missing — check the recorder.",
-                show.title,
+            &missing_recording_alert(
+                &show.title,
                 show.id,
-                show.date,
-                show.end_time.as_deref().map(|t| format!(" ending {t}")).unwrap_or_default(),
+                &show.date,
+                show.end_time.as_deref(),
+                too_short,
             ),
         )
         .await;
@@ -260,6 +286,39 @@ pub async fn check_missing_recordings(state: Arc<AppState>) {
                 show.id
             );
         }
+    }
+}
+
+/// True when a `recording_versions` row represents a capture rejected purely for
+/// being under [`crate::handlers::recording::MIN_RECORDING_SECS`] (an "essentially
+/// empty" broadcast), as opposed to a write failure, R2 size mismatch, or no
+/// recording at all. Keyed on the shared marker so wording stays in sync.
+fn is_short_capture(status: &str, error_message: Option<&str>) -> bool {
+    status == "failed"
+        && error_message
+            .is_some_and(|m| m.contains(crate::handlers::recording::SHORT_RECORDING_MARKER))
+}
+
+/// Build the dead-man's-switch Telegram alert. A sub-threshold capture gets an
+/// informational message explaining it was intentionally not archived; anything
+/// else keeps the "archive may be missing — check the recorder" alarm.
+fn missing_recording_alert(
+    title: &str,
+    id: i64,
+    date: &str,
+    end_time: Option<&str>,
+    too_short: bool,
+) -> String {
+    let ending = end_time.map(|t| format!(" ending {t}")).unwrap_or_default();
+    if too_short {
+        format!(
+            "ℹ️ No archive for show \"{title}\" (#{id}) on {date}{ending}: the live recording was under the {min}s minimum, so it was treated as empty and not archived. If you expected a full recording, check the recorder.",
+            min = crate::handlers::recording::MIN_RECORDING_SECS,
+        )
+    } else {
+        format!(
+            "⚠️ No recording for show \"{title}\" (#{id}) on {date}{ending}. The live archive may be missing — check the recorder."
+        )
     }
 }
 
@@ -445,5 +504,44 @@ mod tests {
             end + chrono::Duration::minutes(60),
             15
         ));
+    }
+
+    #[test]
+    fn is_short_capture_only_matches_sub_threshold_failures() {
+        // The exact reason the upload verifier writes for a too-short capture.
+        assert!(is_short_capture(
+            "failed",
+            Some("recording for show 27 is only 29s — essentially empty")
+        ));
+        // Other failure reasons are genuine problems, not the benign short case.
+        assert!(!is_short_capture(
+            "failed",
+            Some("R2 size mismatch after upload (local 5 != remote 0)")
+        ));
+        // A non-failed row is never the short case.
+        assert!(!is_short_capture("raw", None));
+        assert!(!is_short_capture("finalized", None));
+        // Failed with no reason recorded → treat as a real gap, not too-short.
+        assert!(!is_short_capture("failed", None));
+    }
+
+    #[test]
+    fn missing_recording_alert_words_short_vs_missing() {
+        let short =
+            missing_recording_alert("phils test show", 27, "2026-07-01", Some("19:52"), true);
+        assert!(short.starts_with("ℹ️"));
+        assert!(short.contains("under the 60s minimum"));
+        assert!(short.contains("not archived"));
+        assert!(short.contains("ending 19:52"));
+
+        let missing =
+            missing_recording_alert("phils test show", 27, "2026-07-01", Some("19:52"), false);
+        assert!(missing.starts_with("⚠️"));
+        assert!(missing.contains("check the recorder"));
+        assert!(!missing.contains("minimum"));
+
+        // No end_time → no "ending …" suffix.
+        let no_end = missing_recording_alert("x", 1, "2026-07-01", None, true);
+        assert!(!no_end.contains("ending"));
     }
 }


### PR DESCRIPTION
Part of #239.

## What
The recording dead-man's-switch sent a generic **"⚠️ No recording … archive may be missing — check the recorder"** alert even when the capture was correctly rejected for being under the 60s minimum (an intentional, benign skip — e.g. a 29s test broadcast). It read like a broken recorder for what is really a too-short/aborted show.

Now the scheduler inspects the latest `recording_versions` row and, for a sub-threshold capture, sends an informational message:

> ℹ️ No archive for show "…" (#N) on DATE ending TIME: the live recording was under the 60s minimum, so it was treated as empty and not archived. If you expected a full recording, check the recorder.

Genuine gaps (R2 size mismatch, write failure, no recording at all) keep the original alarm wording.

## How
- Share the `"essentially empty"` marker + `MIN_RECORDING_SECS` between the upload verifier (`handlers/recording.rs`) and the scheduler so wording stays in sync; existing `failed` rows classify correctly (their `error_message` already carries the marker).
- `scheduler.rs`: classify latest version → `is_short_capture()` → pick message via `missing_recording_alert()`.

## Trigger
Real alert from show #27 "phils test show" (2026-07-01): a 29s stream was correctly marked `failed` / not archived, but the Telegram alert implied the recorder was broken.

## Tests
- `is_short_capture` — marker match vs. size-mismatch / raw / finalized / no-reason.
- `missing_recording_alert` — short vs. missing wording, `ending` suffix handling.
- `cargo fmt --check` clean; no new clippy warnings.

Note: retroactive message-only; #27 already alerted (`recording_alert_sent_at` set) so it won't re-fire. Future sub-60s shows get the new wording.