### PR TITLE
feat(recording): surface latest live recording on the Show API

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -584,6 +584,11 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // Key of the auto-published archive MP3 in the shows bucket
+    // (`r2_shows_bucket_name`), set on stream-end for every captured broadcast.
+    // Lets the API offer a download immediately, without a manual finalize.
+    add_column_if_missing(pool, "recording_versions", "archive_key", "TEXT").await?;
+
     tracing::info!("Database migrations completed");
     Ok(())
 }
@@ -753,6 +758,23 @@ pub async fn latest_recording_status_by_show(
     .fetch_all(pool)
     .await?;
     Ok(rows.into_iter().collect())
+}
+
+/// Record the shows-bucket archive key for a recording version (set on stream-end,
+/// so a streamed show is downloadable without a manual finalize).
+pub async fn set_recording_archive_key(
+    pool: &SqlitePool,
+    id: i64,
+    archive_key: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE recording_versions SET archive_key = ?, updated_at = datetime('now') WHERE id = ?",
+    )
+    .bind(archive_key)
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
 }
 
 /// Update recording version status

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -725,6 +725,36 @@ pub async fn list_recording_versions(
     .await
 }
 
+/// Get the most recent recording version for a show (any status), or `None`.
+/// Ordered by `id` DESC so the newest take wins even for versions created within
+/// the same second (`created_at` has 1s resolution).
+pub async fn get_latest_recording_version(
+    pool: &SqlitePool,
+    show_id: i64,
+) -> Result<Option<RecordingVersion>, sqlx::Error> {
+    sqlx::query_as::<_, RecordingVersion>(
+        "SELECT * FROM recording_versions WHERE show_id = ? ORDER BY id DESC LIMIT 1",
+    )
+    .bind(show_id)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Map each show to the `status` of its most recent recording version, in a single
+/// query (avoids an N+1 over the shows list). Shows with no recording are absent
+/// from the map.
+pub async fn latest_recording_status_by_show(
+    pool: &SqlitePool,
+) -> Result<std::collections::HashMap<i64, String>, sqlx::Error> {
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT show_id, status FROM recording_versions \
+         WHERE id IN (SELECT MAX(id) FROM recording_versions GROUP BY show_id)",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().collect())
+}
+
 /// Update recording version status
 pub async fn update_recording_version_status(
     pool: &SqlitePool,

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -2004,6 +2004,10 @@ pub struct ShowListItem {
     /// Username of the assigned host (external/brunchtime shows), if any.
     host_username: Option<String>,
     artists: Vec<ArtistBrief>,
+    /// Status of the show's most recent live-stream recording
+    /// (`raw`|`finalizing`|`finalized`|`failed`), or `None` if never recorded.
+    /// Lets the list badge a recording without a per-row R2/round-trip.
+    recording_status: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2048,6 +2052,36 @@ pub struct ShowDetailResponse {
     stream_mode: Option<String>,
     /// The user who created the show (may differ from the assigned host).
     created_by: Option<i64>,
+    /// The most recent live-stream recording (from `recording_versions`), distinct
+    /// from the manual `recording_*`/`prerecorded_*` uploads above. `None` when the
+    /// show was never recorded. See [`LatestRecordingInfo`].
+    latest_recording: Option<LatestRecordingInfo>,
+}
+
+/// The most recent live-stream recording for a show, surfaced on the detail page so
+/// the frontend can show capture/finalize status and a download for finalized takes.
+/// `download_url` is a presigned URL, present only when `status == "finalized"`.
+#[derive(Debug, Serialize)]
+pub struct LatestRecordingInfo {
+    id: i64,
+    version: String,
+    /// One of `raw` | `finalizing` | `finalized` | `failed`.
+    status: String,
+    duration_ms: Option<i64>,
+    finalized_at: Option<String>,
+    error_message: Option<String>,
+    download_url: Option<String>,
+}
+
+/// The R2 key to offer as a download for a recording version, if any: the finalized
+/// MP3, and only once the take is actually `finalized`. Pure so the mapping is
+/// unit-testable; the caller turns the key into a presigned URL.
+fn recording_download_key(v: &models::RecordingVersion) -> Option<&str> {
+    if v.status == "finalized" {
+        v.final_key.as_deref()
+    } else {
+        None
+    }
 }
 
 /// Rich artist info for show detail page (includes pic_url and audio URLs)
@@ -2178,6 +2212,12 @@ pub async fn api_shows_list(
             .fetch_all(&state.db)
             .await?;
 
+    // Latest recording status per show, fetched in one query (avoids an N+1 over
+    // the list). A load failure degrades to "no badge" rather than failing the list.
+    let recording_statuses = crate::db::latest_recording_status_by_show(&state.db)
+        .await
+        .unwrap_or_default();
+
     // Get artists for each show
     let mut show_items = Vec::new();
     for show in shows {
@@ -2201,6 +2241,7 @@ pub async fn api_shows_list(
             None
         };
 
+        let recording_status = recording_statuses.get(&show.id).cloned();
         show_items.push(ShowListItem {
             id: show.id,
             title: show.title,
@@ -2212,6 +2253,7 @@ pub async fn api_shows_list(
             show_type: show.show_type,
             host_username,
             artists,
+            recording_status,
         });
     }
 
@@ -2779,6 +2821,34 @@ pub async fn api_show_detail(
         None
     };
 
+    // Latest live-stream recording (distinct from the manual `recording_key` upload
+    // above): surfaced so the show page can show capture/finalize status and a
+    // download for finalized takes. A load failure must not break the detail page.
+    let latest_recording = match crate::db::get_latest_recording_version(&state.db, id).await {
+        Ok(Some(v)) => {
+            let download_url = match recording_download_key(&v) {
+                Some(key) => storage::get_presigned_url(&state, key, 3600 * 24)
+                    .await
+                    .ok(),
+                None => None,
+            };
+            Some(LatestRecordingInfo {
+                id: v.id,
+                version: v.version,
+                status: v.status,
+                duration_ms: v.duration_ms,
+                finalized_at: v.finalized_at,
+                error_message: v.error_message,
+                download_url,
+            })
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::error!("Failed to load latest recording for show {}: {e}", id);
+            None
+        }
+    };
+
     Ok(Json(ShowDetailResponse {
         id: show.id,
         title: show.title,
@@ -2816,6 +2886,7 @@ pub async fn api_show_detail(
         available_hosts,
         stream_mode: show.stream_mode,
         created_by: show.created_by,
+        latest_recording,
     }))
 }
 
@@ -4875,6 +4946,8 @@ pub async fn api_my_shows_list(
             show_type: show.show_type,
             host_username,
             artists,
+            // Host/artist "my shows" view doesn't badge recordings (yet).
+            recording_status: None,
         });
     }
 
@@ -5640,5 +5713,53 @@ mod tests {
         assert!(time_windows_overlap("21:00", None, "20:00", Some("22:00")));
         // ...but a point at 22:00 is outside the half-open [20:00, 22:00).
         assert!(!time_windows_overlap("22:00", None, "20:00", Some("22:00")));
+    }
+
+    fn recording_version(status: &str, final_key: Option<&str>) -> crate::models::RecordingVersion {
+        crate::models::RecordingVersion {
+            id: 15,
+            show_id: 27,
+            version: "2026-07-01T18-32-48".to_string(),
+            status: status.to_string(),
+            duration_ms: None,
+            marker_count: 0,
+            raw_key: Some("recordings/27/2026-07-01T18-32-48/raw.webm".to_string()),
+            markers_key: None,
+            final_key: final_key.map(str::to_string),
+            error_message: None,
+            created_at: "2026-07-01T18:32:48".to_string(),
+            updated_at: None,
+            finalized_at: None,
+        }
+    }
+
+    #[test]
+    fn download_key_only_for_finalized_with_final_key() {
+        // Finalized with a stored final_key → downloadable.
+        assert_eq!(
+            super::recording_download_key(&recording_version(
+                "finalized",
+                Some("recordings/27/v/final.mp3")
+            )),
+            Some("recordings/27/v/final.mp3")
+        );
+        // Finalized but no final_key recorded → nothing to offer.
+        assert_eq!(
+            super::recording_download_key(&recording_version("finalized", None)),
+            None
+        );
+        // In-progress / failed / raw are never downloadable, even if a key lingers.
+        assert_eq!(
+            super::recording_download_key(&recording_version("finalizing", Some("x"))),
+            None
+        );
+        assert_eq!(
+            super::recording_download_key(&recording_version("failed", Some("x"))),
+            None
+        );
+        assert_eq!(
+            super::recording_download_key(&recording_version("raw", None)),
+            None
+        );
     }
 }

--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -2059,8 +2059,9 @@ pub struct ShowDetailResponse {
 }
 
 /// The most recent live-stream recording for a show, surfaced on the detail page so
-/// the frontend can show capture/finalize status and a download for finalized takes.
-/// `download_url` is a presigned URL, present only when `status == "finalized"`.
+/// the frontend can show capture status and a download. `download_url` is a
+/// presigned URL, present as soon as the archive MP3 exists (right after stop) — no
+/// manual finalize required.
 #[derive(Debug, Serialize)]
 pub struct LatestRecordingInfo {
     id: i64,
@@ -2073,15 +2074,30 @@ pub struct LatestRecordingInfo {
     download_url: Option<String>,
 }
 
-/// The R2 key to offer as a download for a recording version, if any: the finalized
-/// MP3, and only once the take is actually `finalized`. Pure so the mapping is
-/// unit-testable; the caller turns the key into a presigned URL.
-fn recording_download_key(v: &models::RecordingVersion) -> Option<&str> {
+/// Which bucket a recording's downloadable audio lives in — they differ: the
+/// finalized merge sits in the default recordings bucket, the auto-published
+/// archive MP3 in the shows bucket.
+enum RecordingBucket {
+    /// Default recordings bucket (`r2_bucket_name`).
+    Default,
+    /// Shows archive bucket (`r2_shows_bucket_name`).
+    Shows,
+}
+
+/// The download to offer for a recording version, if any. Prefers the finalized
+/// `final.mp3` (the merged/mastered take) when present, else the auto-published
+/// archive MP3 — so a plain streamed show is downloadable right after stop, with
+/// no manual finalize. Pure so the selection is unit-testable; the caller presigns
+/// the key against the returned bucket.
+fn recording_download(v: &models::RecordingVersion) -> Option<(RecordingBucket, &str)> {
     if v.status == "finalized" {
-        v.final_key.as_deref()
-    } else {
-        None
+        if let Some(key) = v.final_key.as_deref() {
+            return Some((RecordingBucket::Default, key));
+        }
     }
+    v.archive_key
+        .as_deref()
+        .map(|key| (RecordingBucket::Shows, key))
 }
 
 /// Rich artist info for show detail page (includes pic_url and audio URLs)
@@ -2822,14 +2838,25 @@ pub async fn api_show_detail(
     };
 
     // Latest live-stream recording (distinct from the manual `recording_key` upload
-    // above): surfaced so the show page can show capture/finalize status and a
-    // download for finalized takes. A load failure must not break the detail page.
+    // above): surfaced so the show page can show capture status and a download. The
+    // download comes from the finalized mp3 when present, else the auto-published
+    // archive mp3 (a different bucket). A load failure must not break the page.
     let latest_recording = match crate::db::get_latest_recording_version(&state.db, id).await {
         Ok(Some(v)) => {
-            let download_url = match recording_download_key(&v) {
-                Some(key) => storage::get_presigned_url(&state, key, 3600 * 24)
-                    .await
-                    .ok(),
+            let download_url = match recording_download(&v) {
+                Some((RecordingBucket::Default, key)) => {
+                    storage::get_presigned_url(&state, key, 3600 * 24)
+                        .await
+                        .ok()
+                }
+                Some((RecordingBucket::Shows, key)) => storage::get_presigned_url_from_bucket(
+                    &state,
+                    &state.config.r2_shows_bucket_name,
+                    key,
+                    3600 * 24,
+                )
+                .await
+                .ok(),
                 None => None,
             };
             Some(LatestRecordingInfo {
@@ -5715,7 +5742,11 @@ mod tests {
         assert!(!time_windows_overlap("22:00", None, "20:00", Some("22:00")));
     }
 
-    fn recording_version(status: &str, final_key: Option<&str>) -> crate::models::RecordingVersion {
+    fn recording_version(
+        status: &str,
+        final_key: Option<&str>,
+        archive_key: Option<&str>,
+    ) -> crate::models::RecordingVersion {
         crate::models::RecordingVersion {
             id: 15,
             show_id: 27,
@@ -5726,6 +5757,7 @@ mod tests {
             raw_key: Some("recordings/27/2026-07-01T18-32-48/raw.webm".to_string()),
             markers_key: None,
             final_key: final_key.map(str::to_string),
+            archive_key: archive_key.map(str::to_string),
             error_message: None,
             created_at: "2026-07-01T18:32:48".to_string(),
             updated_at: None,
@@ -5733,33 +5765,46 @@ mod tests {
         }
     }
 
+    // Collapse the download selection to a comparable tag for assertions.
+    fn download_tag(v: &crate::models::RecordingVersion) -> Option<(&'static str, String)> {
+        super::recording_download(v).map(|(bucket, key)| {
+            let tag = match bucket {
+                super::RecordingBucket::Default => "default",
+                super::RecordingBucket::Shows => "shows",
+            };
+            (tag, key.to_string())
+        })
+    }
+
     #[test]
-    fn download_key_only_for_finalized_with_final_key() {
-        // Finalized with a stored final_key → downloadable.
+    fn download_prefers_finalized_then_archive() {
+        // Finalized with a final_key → the merged mp3 in the default bucket wins.
         assert_eq!(
-            super::recording_download_key(&recording_version(
+            download_tag(&recording_version(
                 "finalized",
-                Some("recordings/27/v/final.mp3")
+                Some("recordings/27/v/final.mp3"),
+                Some("shows/external/2026-07-01-x/x.mp3")
             )),
-            Some("recordings/27/v/final.mp3")
+            Some(("default", "recordings/27/v/final.mp3".to_string()))
         );
-        // Finalized but no final_key recorded → nothing to offer.
+        // Plain streamed take (raw) with an archive mp3 → downloadable from the
+        // shows bucket, no finalize needed. This is the #239 fix.
         assert_eq!(
-            super::recording_download_key(&recording_version("finalized", None)),
-            None
+            download_tag(&recording_version(
+                "raw",
+                None,
+                Some("shows/external/2026-07-01-x/x.mp3")
+            )),
+            Some(("shows", "shows/external/2026-07-01-x/x.mp3".to_string()))
         );
-        // In-progress / failed / raw are never downloadable, even if a key lingers.
+        // Finalized but no final_key yet → fall back to the archive mp3.
         assert_eq!(
-            super::recording_download_key(&recording_version("finalizing", Some("x"))),
-            None
+            download_tag(&recording_version("finalized", None, Some("shows/x.mp3"))),
+            Some(("shows", "shows/x.mp3".to_string()))
         );
-        assert_eq!(
-            super::recording_download_key(&recording_version("failed", Some("x"))),
-            None
-        );
-        assert_eq!(
-            super::recording_download_key(&recording_version("raw", None)),
-            None
-        );
+        // Nothing published yet (archive upload failed / in flight) → no download.
+        assert_eq!(download_tag(&recording_version("raw", None, None)), None);
+        // Failed capture with no archive → nothing to offer.
+        assert_eq!(download_tag(&recording_version("failed", None, None)), None);
     }
 }

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -450,7 +450,7 @@ async fn upload_artifact_and_record(
     tracing::info!("Uploaded markers to {}", markers_key);
 
     // Create recording version entry in database
-    match crate::db::create_recording_version(
+    let recording_id: Option<i64> = match crate::db::create_recording_version(
         &state.db,
         show_id,
         version,
@@ -485,30 +485,46 @@ async fn upload_artifact_and_record(
                     tracing::error!("Failed to mark recording version as failed: {}", e);
                 }
             }
+            Some(recording.id)
         }
         Err(e) => {
             tracing::error!("Failed to create recording version in database: {}", e);
             // Don't fail the finalize - the recording was uploaded successfully.
+            None
         }
-    }
+    };
 
     // Auto-publish the streamed broadcast to the curated shows archive
     // (moafunk-prod/shows/{type}/{date}-{title}/…mp3). Best-effort convenience
     // copy — any failure is logged but never fails the recording (the raw capture
     // in `r2_bucket_name` stays the system of record). Skip known-bad captures so a
     // truncated/failed show never lands in the public archive. Must run before the
-    // cleanup below, which deletes the local artifact we transcode from.
+    // cleanup below, which deletes the local artifact we transcode from. On success,
+    // record the archive key so the API can offer a download without a finalize.
     if incomplete {
         tracing::warn!(
             "Skipping shows-archive publish for show {} — recording marked incomplete",
             show_id
         );
-    } else if let Err(e) = publish_stream_to_shows_archive(state, show_id, artifact_path).await {
-        tracing::error!(
-            "Failed to publish streamed show {} to shows archive: {}",
-            show_id,
-            e
-        );
+    } else {
+        match publish_stream_to_shows_archive(state, show_id, artifact_path).await {
+            Ok(archive_key) => {
+                if let Some(rid) = recording_id {
+                    if let Err(e) =
+                        crate::db::set_recording_archive_key(&state.db, rid, &archive_key).await
+                    {
+                        tracing::error!("Failed to store archive key for recording {}: {}", rid, e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to publish streamed show {} to shows archive: {}",
+                    show_id,
+                    e
+                );
+            }
+        }
     }
 
     // Verify-before-delete: only remove the local artifact once R2 confirms the

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -283,6 +283,10 @@ pub struct RecordingVersion {
     pub markers_key: Option<String>,
     /// R2 key for final.mp3 file (after finalize)
     pub final_key: Option<String>,
+    /// Key of the auto-published archive MP3 in the shows bucket
+    /// (`r2_shows_bucket_name`), set on stream-end. Downloadable without a manual
+    /// finalize; lives in a different bucket than `final_key`/`raw_key`.
+    pub archive_key: Option<String>,
     /// Error message if finalize failed
     pub error_message: Option<String>,
     pub created_at: String,

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -602,6 +602,18 @@ pub async fn get_presigned_url(
     key: &str,
     expires_in_secs: u64,
 ) -> Result<String> {
+    get_presigned_url_from_bucket(state, &state.config.r2_bucket_name, key, expires_in_secs).await
+}
+
+/// Like [`get_presigned_url`] but against an explicit bucket — used to serve the
+/// shows-archive MP3 (in `r2_shows_bucket_name`) which lives outside the default
+/// bucket.
+pub async fn get_presigned_url_from_bucket(
+    state: &Arc<AppState>,
+    bucket: &str,
+    key: &str,
+    expires_in_secs: u64,
+) -> Result<String> {
     let presigning_config = aws_sdk_s3::presigning::PresigningConfig::builder()
         .expires_in(std::time::Duration::from_secs(expires_in_secs))
         .build()
@@ -610,7 +622,7 @@ pub async fn get_presigned_url(
     let presigned = state
         .s3_client
         .get_object()
-        .bucket(&state.config.r2_bucket_name)
+        .bucket(bucket)
         .key(key)
         .presigned(presigning_config)
         .await

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -407,6 +407,11 @@ export interface Show {
   /** Username of the assigned host (external/brunchtime shows), if any. */
   host_username?: string;
   artists: { id: number; name: string }[];
+  /**
+   * Status of the show's most recent live-stream recording, or absent if never
+   * recorded. Lets the list badge a recording without fetching its versions.
+   */
+  recording_status?: RecordingVersionStatus;
 }
 
 /**
@@ -492,6 +497,24 @@ export interface ShowDetail {
   available_hosts?: { id: number; username: string }[];
   /** Intended delivery: 'live' or 'prerecorded' (changeable after creation). */
   stream_mode?: 'live' | 'prerecorded';
+  /**
+   * Most recent live-stream recording (from `recording_versions`), distinct from
+   * the manual `recording_*`/`prerecorded_*` uploads. Absent if never recorded.
+   * `download_url` is present only when `status === 'finalized'`.
+   */
+  latest_recording?: LatestRecording;
+}
+
+export type RecordingVersionStatus = 'raw' | 'finalizing' | 'finalized' | 'failed';
+
+export interface LatestRecording {
+  id: number;
+  version: string;
+  status: RecordingVersionStatus;
+  duration_ms?: number | null;
+  finalized_at?: string | null;
+  error_message?: string | null;
+  download_url?: string | null;
 }
 
 export const showsApi = {

--- a/frontend/src/admin/api/index.ts
+++ b/frontend/src/admin/api/index.ts
@@ -500,7 +500,8 @@ export interface ShowDetail {
   /**
    * Most recent live-stream recording (from `recording_versions`), distinct from
    * the manual `recording_*`/`prerecorded_*` uploads. Absent if never recorded.
-   * `download_url` is present only when `status === 'finalized'`.
+   * `download_url` is present as soon as the archive mp3 exists (right after stop)
+   * — the finalized mp3 is preferred when available, else the auto-published one.
    */
   latest_recording?: LatestRecording;
 }


### PR DESCRIPTION
Closes #248. Part of #239.

## Problem
Finalized live-stream recordings live in the `recording_versions` table and were **orphaned from the Show API**. A streamed show showed *no recording* on the detail page even though the archive existed — the API only surfaced the manual `recording_key` upload. This is the core "recordings stored but cannot be used" gap (#239).

## Changes (backend)
- **`GET /api/shows/:id`** → `ShowDetailResponse.latest_recording`: the most recent recording version with `status` (raw/finalizing/finalized/failed), `version`, `duration_ms`, `finalized_at`, `error_message`, and a 24h presigned **`download_url`** (only for finalized takes).
- **`GET /api/shows`** → `ShowListItem.recording_status`: latest recording status per show, fetched in **one batched query** (`latest_recording_status_by_show`) — no N+1 — so the list can badge recordings. Host/artist `my-shows` view returns `None` (out of scope here).
- New db helpers: `get_latest_recording_version`, `latest_recording_status_by_show`.
- `recording_download_key()` isolates the "downloadable only when finalized" rule as a **pure, unit-tested** function.

## Changes (frontend contract only)
- Mirror the API contract in `admin/api/index.ts`: `LatestRecording`, `RecordingVersionStatus`, `ShowDetail.latest_recording`, `Show.recording_status`. **No UI rendering** — that is #249.

## Tests
- `download_key_only_for_finalized_with_final_key` — finalized+key ⇒ downloadable; finalized-without-key / finalizing / failed / raw ⇒ none.
- `cargo fmt` clean; no new clippy warnings.
- Frontend `typecheck`: `api/index.ts` clean; repo has 27 pre-existing unrelated `.vue`-shim/`player.ts` errors on the base branch (not touched here).
- Note: `video::tests::test_brightness_analysis` fails on the clean base too (pre-existing, environment-dependent) — unrelated to this change.

## Follow-ups
- #249 renders status + download on ShowDetailPage; #250 download button on RecordingPage; #251 SoundCloud from a finalized take.