### PR TITLE
feat(recording): add download button on finalized takes in RecordingPage

### DIFF
--- a/frontend/src/admin/pages/RecordingPage.vue
+++ b/frontend/src/admin/pages/RecordingPage.vue
@@ -502,6 +502,14 @@ onUnmounted(() => {
               <div v-if="rec.download_url" class="recording-player">
                 <AudioPlayer :src="rec.download_url" :show-volume="true" :initial-volume="100" />
               </div>
+              <a
+                v-if="rec.download_url"
+                :href="rec.download_url"
+                class="download-btn"
+                :download="`${rec.version}.mp3`"
+              >
+                ⬇️ Download
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #250. Part of #239.

## Problem
RecordingPage's "Finalized" section only offered inline audio playback — no way to download the file.

## Change
Add a direct **Download** link under each finalized take's player, using the existing finalized presigned `download_url` and a `<version>.mp3` filename. Reuses the existing `.download-btn` style; the finalized item is already a stretch column so it sits full-width below the player.

Independent of #254/#255 (RecordingPage already fetches finalized versions with `download_url` via `listRecordings`), so this branches off `main`.

## Verification
`npm run build` compiles the RecordingPage SFC cleanly. (Repo `typecheck` can't resolve `.vue` shims and `lint` skips `.vue` — build is the SFC check.)