### PR TITLE
chore(infra): configure R2 CORS for shows archive bucket

### DIFF
--- a/backend/scripts/configure_r2_cors.sh
+++ b/backend/scripts/configure_r2_cors.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Configure CORS for the R2 bucket to allow audio/image playback from admin panel.
+# Configure CORS for the R2 buckets to allow audio/image playback from the admin panel.
+#
+# WaveSurfer fetch()es recording audio to draw its waveform, which is CORS-gated.
+# BOTH buckets the admin reads from need the policy:
+#   - the default recordings bucket (raw/finalized takes)
+#   - the shows archive bucket `moafunk-prod` (auto-published streamed-show mp3s;
+#     see publish_stream_to_shows_archive / RecordingVersion.archive_key)
+# The S3 object token cannot manage CORS (PutBucketCors -> AccessDenied), so this
+# runs through wrangler (Cloudflare account auth).
 #
 # Requirements:
-# - wrangler CLI installed and authenticated
+# - wrangler CLI installed and authenticated (`wrangler login`)
 #
 # Usage:
 #   ./backend/scripts/configure_r2_cors.sh
 #
-# Or with custom bucket/origins:
-#   BUCKET=my-bucket ORIGINS="https://example.com,http://localhost:5173" ./backend/scripts/configure_r2_cors.sh
+# Or with custom buckets/origins:
+#   BUCKETS="my-bucket other-bucket" ORIGINS="https://example.com,http://localhost:5173" ./backend/scripts/configure_r2_cors.sh
+#   BUCKET=one-bucket ./backend/scripts/configure_r2_cors.sh   # single-bucket override (back-compat)
 
-BUCKET="${BUCKET:-unheard-artists-dev}"
+# Space-separated list of buckets to configure. `BUCKET` (singular) still works
+# as a single-bucket override for back-compat.
+BUCKETS="${BUCKETS:-${BUCKET:-unheard-artists-dev moafunk-prod}}"
 ACCOUNT_ID="${ACCOUNT_ID:-4acacbddb37198e8eed490e4b7c752ee}"
 
 # Default allowed origins (localhost for dev, production domains)
@@ -33,7 +44,7 @@ if ! wrangler whoami &> /dev/null; then
     exit 1
 fi
 
-echo "Configuring CORS for R2 bucket: $BUCKET"
+echo "Configuring CORS for R2 buckets: $BUCKETS"
 echo "Account ID: $ACCOUNT_ID"
 echo "Allowed origins: $ORIGINS"
 echo ""
@@ -68,16 +79,16 @@ echo ""
 # Create temporary file for CORS rules
 CORS_FILE=$(mktemp)
 echo "$CORS_RULES" > "$CORS_FILE"
+trap 'rm -f "$CORS_FILE"' EXIT
 
-# Apply CORS rules using file
-echo "Applying CORS rules..."
-wrangler r2 bucket cors set "$BUCKET" --file "$CORS_FILE" --force
+# Apply the same rules to every bucket the admin reads from
+for bucket in $BUCKETS; do
+    echo "Applying CORS rules to '$bucket'..."
+    wrangler r2 bucket cors set "$bucket" --file "$CORS_FILE" --force
+    echo ""
+    echo "Verifying '$bucket'..."
+    wrangler r2 bucket cors list "$bucket"
+    echo ""
+done
 
-# Cleanup temp file
-rm -f "$CORS_FILE"
-
-echo ""
-echo "✅ CORS configured successfully!"
-echo ""
-echo "Verifying configuration..."
-wrangler r2 bucket cors list "$BUCKET"
+echo "✅ CORS configured successfully for: $BUCKETS"


### PR DESCRIPTION
## What

`configure_r2_cors.sh` only applied a CORS policy to the default recordings bucket. The **shows archive bucket** `moafunk-prod` — where streamed shows are auto-published (`publish_stream_to_shows_archive` → `RecordingVersion.archive_key`) — had **no CORS policy at all** (R2: `CORS not configured for this bucket`).

Result: on a show detail page, WaveSurfer `fetch()`ed the archive mp3 to draw the waveform and the browser blocked the read (missing `Access-Control-Allow-Origin`) → `NetworkError`. Download and native `<audio>` playback were unaffected (not CORS-gated).

## Change

- Loop the CORS policy over **both** buckets. New `BUCKETS` (space-separated) defaults to `unheard-artists-dev moafunk-prod`; `BUCKET` still works as a single-bucket back-compat override.
- `trap`-cleanup the temp rules file; per-bucket apply + verify.

The S3 object token can't manage CORS (`PutBucketCors` → AccessDenied), so this runs via wrangler (Cloudflare account auth).

## Verification

`moafunk-prod` policy is **already live** (applied via `wrangler r2 bucket cors set` while debugging). Preflight now returns:

```
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: http://localhost:3000
Access-Control-Allow-Methods: GET, HEAD
```

Waveform loads on the show detail page. This PR checks the fix into the repo so it's reproducible for prod / fresh setups.