### PR TITLE
feat(soundcloud): upload finalized live recording to SoundCloud

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -745,6 +745,23 @@ pub async fn get_latest_recording_version(
     .await
 }
 
+/// Latest *finalized* recording version for a show (status `finalized` with a
+/// `final_key`), newest first. This is the curated take the SoundCloud upload
+/// falls back to when a show has no manually attached `recording_key`.
+pub async fn get_latest_finalized_recording_version(
+    pool: &SqlitePool,
+    show_id: i64,
+) -> Result<Option<RecordingVersion>, sqlx::Error> {
+    sqlx::query_as::<_, RecordingVersion>(
+        "SELECT * FROM recording_versions \
+         WHERE show_id = ? AND status = 'finalized' AND final_key IS NOT NULL \
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(show_id)
+    .fetch_optional(pool)
+    .await
+}
+
 /// Map each show to the `status` of its most recent recording version, in a single
 /// query (avoids an N+1 over the shows list). Shows with no recording are absent
 /// from the map.
@@ -1042,5 +1059,69 @@ mod tests {
         .await
         .unwrap();
         assert!(other_row.is_none());
+    }
+
+    async fn insert_show(pool: &SqlitePool, title: &str) -> i64 {
+        sqlx::query("INSERT INTO shows (title, date) VALUES (?, '2026-01-01')")
+            .bind(title)
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_rowid()
+    }
+
+    async fn insert_recording_version(
+        pool: &SqlitePool,
+        show_id: i64,
+        version: &str,
+        status: &str,
+        final_key: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO recording_versions (show_id, version, status, final_key) VALUES (?, ?, ?, ?)",
+        )
+        .bind(show_id)
+        .bind(version)
+        .bind(status)
+        .bind(final_key)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// The SoundCloud fallback picks the newest *finalized* take with a `final_key`,
+    /// skipping raw/failed versions and finalized rows that never got a file.
+    #[tokio::test]
+    async fn latest_finalized_recording_version_skips_non_finalized() {
+        let pool = mem_db().await;
+        let show = insert_show(&pool, "Live Show").await;
+
+        insert_recording_version(&pool, show, "v1", "raw", None).await;
+        insert_recording_version(&pool, show, "v2", "finalized", Some("shows/1/v2.mp3")).await;
+        insert_recording_version(&pool, show, "v3", "finalized", Some("shows/1/v3.mp3")).await;
+        // A newer raw take must not shadow the finalized one.
+        insert_recording_version(&pool, show, "v4", "raw", None).await;
+        // A finalized row without a file is not a valid source.
+        insert_recording_version(&pool, show, "v5", "finalized", None).await;
+
+        let picked = get_latest_finalized_recording_version(&pool, show)
+            .await
+            .unwrap()
+            .expect("a finalized version with a final_key exists");
+        assert_eq!(picked.version, "v3");
+        assert_eq!(picked.final_key.as_deref(), Some("shows/1/v3.mp3"));
+    }
+
+    /// A show whose only takes are raw has no SoundCloud-eligible recording.
+    #[tokio::test]
+    async fn latest_finalized_recording_version_none_when_only_raw() {
+        let pool = mem_db().await;
+        let show = insert_show(&pool, "Unfinalized Show").await;
+        insert_recording_version(&pool, show, "v1", "raw", None).await;
+
+        assert!(get_latest_finalized_recording_version(&pool, show)
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/backend/src/soundcloud.rs
+++ b/backend/src/soundcloud.rs
@@ -224,11 +224,28 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
         .await?
         .ok_or_else(|| AppError::NotFound("Show not found".to_string()))?;
 
-    // Ensure recording exists
-    let recording_key = show
-        .recording_key
-        .as_ref()
-        .ok_or_else(|| AppError::BadRequest("Show has no recording to upload".to_string()))?;
+    // Resolve the audio source: a manually attached recording takes precedence
+    // (pre-recorded / UNHEARD shows); otherwise fall back to the latest finalized
+    // live recording version so streamed shows can be published too (#251).
+    let (recording_key, source_filename) = match show.recording_key.as_ref() {
+        Some(key) => (
+            key.clone(),
+            show.recording_filename
+                .clone()
+                .unwrap_or_else(|| "recording.mp3".to_string()),
+        ),
+        None => {
+            let version = crate::db::get_latest_finalized_recording_version(&state.db, show_id)
+                .await?
+                .ok_or_else(|| {
+                    AppError::BadRequest("Show has no recording to upload".to_string())
+                })?;
+            let final_key = version.final_key.clone().ok_or_else(|| {
+                AppError::BadRequest("Finalized recording has no file to upload".to_string())
+            })?;
+            (final_key, format!("{}.mp3", version.version))
+        }
+    };
 
     tracing::info!(
         show_id = show_id,
@@ -248,7 +265,7 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
 
     // Download recording from R2
     let (recording_bytes, recording_content_type) =
-        storage::download_file(state, recording_key).await?;
+        storage::download_file(state, &recording_key).await?;
     tracing::info!(
         show_id = show_id,
         size_mb = recording_bytes.len() as f64 / 1_048_576.0,
@@ -257,10 +274,7 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
     );
 
     // Determine filename for the upload
-    let filename = show
-        .recording_filename
-        .as_deref()
-        .unwrap_or("recording.mp3");
+    let filename = source_filename.as_str();
 
     // Build multipart form
     let recording_part = reqwest::multipart::Part::bytes(recording_bytes)


### PR DESCRIPTION
Closes #251. Part of #239.

## Problem
`api_upload_to_soundcloud` → `soundcloud::upload_track` resolved audio **only** from `show.recording_key` (manual / pre-recorded uploads). Streamed live shows keep their audio in `recording_versions.final_key`, so the existing "☁️ Upload to SoundCloud" button on ShowDetailPage failed for them with *"Show has no recording to upload"*.

## Change
- `db::get_latest_finalized_recording_version(show_id)` — newest `status='finalized'` version that has a `final_key`.
- `upload_track` now resolves the source with a fallback:
  1. `show.recording_key` (manual / UNHEARD) — unchanged, takes precedence.
  2. else the latest finalized recording version's `final_key`, filename derived from the version.
  3. else `BadRequest` as before.
- Title, description, cover art (`shows/{id}/cover.png`), privacy default (`private`) and the `soundcloud_*` DB update are all unchanged.

## Frontend
No change required — ShowDetailPage already has an ungated **☁️ Upload to SoundCloud** button (`uploadToSoundCloud(show.id)`); it now succeeds for live shows and updates the `soundcloud_*` fields.

## Tests
- `latest_finalized_recording_version_skips_non_finalized` — picks the newest finalized take with a file, skipping raw/failed and finalized-without-file rows.
- `latest_finalized_recording_version_none_when_only_raw`.
- `cargo build` + `cargo test` green.

## Acceptance
✅ A finalized live recording can be uploaded to SoundCloud from the UI; `soundcloud_*` fields update on the show.