### PR TITLE
feat(soundcloud): auto-upload finalized recording (private) into a per-show playlist

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -101,3 +101,6 @@ DEFAULT_LOGO_PATH=./assets/brand/moafunk.png
 # SOUNDCLOUD_CLIENT_ID=your-client-id
 # SOUNDCLOUD_CLIENT_SECRET=your-client-secret
 # SOUNDCLOUD_ACCESS_TOKEN=your-access-token
+# Auto-upload a recording to SoundCloud (private) when it finishes finalizing.
+# Defaults to true; set to false to keep uploads manual.
+# SOUNDCLOUD_AUTO_UPLOAD=false

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -124,6 +124,13 @@ pub struct Config {
     /// OAuth redirect URI (defaults to http://localhost:8000/api/soundcloud/callback)
     #[serde(default = "default_soundcloud_redirect_uri")]
     pub soundcloud_redirect_uri: String,
+    /// When true (the default), a recording that finishes finalizing is
+    /// automatically uploaded to SoundCloud as a private track (title +
+    /// description built from the show). Set `SOUNDCLOUD_AUTO_UPLOAD=false` to
+    /// disable and keep uploads manual. Still requires SoundCloud to be
+    /// configured and authorized; otherwise the auto-upload silently no-ops.
+    #[serde(default = "default_true")]
+    pub soundcloud_auto_upload: bool,
 
     // Telegram Bot settings (optional - for admin notifications and control)
     /// Master kill-switch for the Telegram bot. Defaults to `false` (off): the
@@ -255,6 +262,10 @@ fn default_admin_base_url() -> String {
 
 fn default_soundcloud_redirect_uri() -> String {
     "http://localhost:8000/api/soundcloud/callback".to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Config {

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -1269,6 +1269,15 @@ async fn handle_finalize_socket(socket: WebSocket, state: Arc<AppState>, query: 
                         recording.id,
                         final_key
                     );
+
+                    // Fire-and-forget: auto-publish the finalized take to SoundCloud
+                    // (private, with title + description). Detached so it neither
+                    // delays the finalize socket nor fails the finalize on error.
+                    let sc_state = Arc::clone(&state);
+                    let sc_show_id = query.show_id;
+                    tokio::spawn(async move {
+                        crate::soundcloud::auto_upload_on_finalize(&sc_state, sc_show_id).await;
+                    });
                 }
             } else {
                 tracing::warn!(

--- a/backend/src/soundcloud.rs
+++ b/backend/src/soundcloud.rs
@@ -373,6 +373,83 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
     })
 }
 
+/// Whether a just-finalized recording should be auto-uploaded to SoundCloud.
+/// Pure decision so the policy is testable: upload only when the feature is
+/// enabled, the integration is configured, and the show hasn't been uploaded yet
+/// (re-finalizing must not create a duplicate track).
+pub(crate) fn should_auto_upload(enabled: bool, configured: bool, already_uploaded: bool) -> bool {
+    enabled && configured && !already_uploaded
+}
+
+/// Best-effort automatic SoundCloud upload, fired when a recording finishes
+/// finalizing (see `handle_finalize_socket`). Uploads as a private track with the
+/// show's title + description via [`upload_track`]. Never returns an error: every
+/// failure is logged and swallowed so it can run detached without affecting the
+/// finalize flow. No-ops when disabled, unconfigured, or already uploaded.
+pub async fn auto_upload_on_finalize(state: &Arc<AppState>, show_id: i64) {
+    // Cheap gate before touching the DB.
+    if !should_auto_upload(
+        state.config.soundcloud_auto_upload,
+        is_configured(state),
+        false,
+    ) {
+        tracing::debug!(
+            show_id = show_id,
+            enabled = state.config.soundcloud_auto_upload,
+            configured = is_configured(state),
+            "Skipping SoundCloud auto-upload (disabled or not configured)"
+        );
+        return;
+    }
+
+    // Skip if this show already has a SoundCloud track (avoid duplicates on re-finalize).
+    let show: models::Show = match sqlx::query_as("SELECT * FROM shows WHERE id = ?")
+        .bind(show_id)
+        .fetch_optional(&state.db)
+        .await
+    {
+        Ok(Some(show)) => show,
+        Ok(None) => {
+            tracing::warn!(show_id, "SoundCloud auto-upload: show not found");
+            return;
+        }
+        Err(e) => {
+            tracing::error!(show_id, error = %e, "SoundCloud auto-upload: failed to load show");
+            return;
+        }
+    };
+    if show.soundcloud_track_id.is_some() {
+        tracing::info!(
+            show_id,
+            "SoundCloud auto-upload: show already uploaded, skipping"
+        );
+        return;
+    }
+
+    tracing::info!(show_id, "Auto-uploading finalized recording to SoundCloud");
+    match upload_track(state, show_id).await {
+        Ok(result) if result.success => {
+            if let Some(ref url) = result.track_url {
+                let title = build_title(state, &show)
+                    .await
+                    .unwrap_or_else(|_| format!("Show #{show_id}"));
+                crate::telegram_notify::notify_soundcloud_upload(state, show_id, &title, url);
+            }
+            tracing::info!(show_id, "SoundCloud auto-upload succeeded");
+        }
+        Ok(result) => {
+            tracing::error!(
+                show_id,
+                error = result.error.as_deref().unwrap_or("unknown"),
+                "SoundCloud auto-upload failed"
+            );
+        }
+        Err(e) => {
+            tracing::error!(show_id, error = %e, "SoundCloud auto-upload errored");
+        }
+    }
+}
+
 // ============================================================================
 // Privacy Toggle
 // ============================================================================
@@ -557,5 +634,24 @@ pub async fn get_status(state: &Arc<AppState>) -> SoundCloudStatus {
         configured,
         authorized,
         auth_url,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_auto_upload;
+
+    #[test]
+    fn auto_upload_only_when_enabled_configured_and_fresh() {
+        // Happy path: on, configured, not yet uploaded.
+        assert!(should_auto_upload(true, true, false));
+
+        // Any single blocker prevents the upload.
+        assert!(!should_auto_upload(false, true, false)); // kill-switch off
+        assert!(!should_auto_upload(true, false, false)); // not configured
+        assert!(!should_auto_upload(true, true, true)); // already uploaded (no dup)
+
+        // Fully off stays off.
+        assert!(!should_auto_upload(false, false, true));
     }
 }

--- a/backend/src/soundcloud.rs
+++ b/backend/src/soundcloud.rs
@@ -343,6 +343,7 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
         .await
         .map_err(|e| AppError::Internal(format!("Failed to parse SoundCloud response: {}", e)))?;
 
+    let track_numeric_id = track.id;
     let track_id = track.id.to_string();
     let track_url = track
         .permalink_url
@@ -364,6 +365,20 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
     .bind(show_id)
     .execute(&state.db)
     .await?;
+
+    // Group the track under a per-show-title playlist so every recording of a
+    // recurring show lands in the same SoundCloud playlist. Best-effort: a
+    // failure here must not fail the upload that already succeeded.
+    if let Err(e) =
+        ensure_track_in_show_playlist(&access_token, &show.title, track_numeric_id).await
+    {
+        tracing::error!(
+            show_id = show_id,
+            playlist = show.title.as_str(),
+            error = %e,
+            "Uploaded track but failed to add it to the show playlist"
+        );
+    }
 
     Ok(SoundCloudUploadResult {
         success: true,
@@ -448,6 +463,202 @@ pub async fn auto_upload_on_finalize(state: &Arc<AppState>, show_id: i64) {
             tracing::error!(show_id, error = %e, "SoundCloud auto-upload errored");
         }
     }
+}
+
+// ============================================================================
+// Playlists (one per show title)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct PlaylistSummary {
+    id: i64,
+    title: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlaylistDetail {
+    #[serde(default)]
+    tracks: Vec<PlaylistTrackRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlaylistTrackRef {
+    id: i64,
+}
+
+/// Ensure a playlist named exactly `show_title` exists and contains `track_id`.
+/// Finds the caller's playlist by title (case-insensitive), otherwise creates a
+/// private one. Adding to an existing playlist re-sends the union of its current
+/// tracks and the new one (SoundCloud replaces the whole track list on update).
+async fn ensure_track_in_show_playlist(
+    access_token: &str,
+    show_title: &str,
+    track_id: i64,
+) -> Result<()> {
+    let client = reqwest::Client::new();
+
+    match find_playlist_by_title(&client, access_token, show_title).await? {
+        Some(playlist_id) => {
+            let mut ids = get_playlist_track_ids(&client, access_token, playlist_id).await?;
+            if ids.contains(&track_id) {
+                tracing::debug!(playlist_id, track_id, "Track already in show playlist");
+                return Ok(());
+            }
+            ids.push(track_id);
+            set_playlist_tracks(&client, access_token, playlist_id, &ids).await?;
+            tracing::info!(
+                playlist_id,
+                track_id,
+                "Added track to existing show playlist"
+            );
+        }
+        None => {
+            let playlist_id = create_playlist(&client, access_token, show_title, track_id).await?;
+            tracing::info!(
+                playlist_id,
+                track_id,
+                playlist = show_title,
+                "Created show playlist"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Find one of the caller's playlists whose title matches `title` (case-insensitive).
+async fn find_playlist_by_title(
+    client: &reqwest::Client,
+    access_token: &str,
+    title: &str,
+) -> Result<Option<i64>> {
+    let resp = client
+        .get(format!("{}/me/playlists", SOUNDCLOUD_API_BASE))
+        .header("Authorization", format!("OAuth {}", access_token))
+        .query(&[("limit", "200"), ("linked_partitioning", "false")])
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("List playlists request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "List playlists failed ({}): {}",
+            status, body
+        )));
+    }
+
+    let playlists: Vec<PlaylistSummary> = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse playlists: {}", e)))?;
+
+    let wanted = title.trim().to_lowercase();
+    Ok(playlists
+        .into_iter()
+        .find(|p| {
+            p.title
+                .as_deref()
+                .map(|t| t.trim().to_lowercase() == wanted)
+                .unwrap_or(false)
+        })
+        .map(|p| p.id))
+}
+
+/// Fetch the current track ids of a playlist.
+async fn get_playlist_track_ids(
+    client: &reqwest::Client,
+    access_token: &str,
+    playlist_id: i64,
+) -> Result<Vec<i64>> {
+    let resp = client
+        .get(format!("{}/playlists/{}", SOUNDCLOUD_API_BASE, playlist_id))
+        .header("Authorization", format!("OAuth {}", access_token))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Get playlist request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "Get playlist failed ({}): {}",
+            status, body
+        )));
+    }
+
+    let detail: PlaylistDetail = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse playlist: {}", e)))?;
+    Ok(detail.tracks.into_iter().map(|t| t.id).collect())
+}
+
+/// Replace a playlist's track list (SoundCloud PUT semantics).
+async fn set_playlist_tracks(
+    client: &reqwest::Client,
+    access_token: &str,
+    playlist_id: i64,
+    track_ids: &[i64],
+) -> Result<()> {
+    let tracks: Vec<serde_json::Value> = track_ids
+        .iter()
+        .map(|id| serde_json::json!({ "id": id }))
+        .collect();
+    let resp = client
+        .put(format!("{}/playlists/{}", SOUNDCLOUD_API_BASE, playlist_id))
+        .header("Authorization", format!("OAuth {}", access_token))
+        .json(&serde_json::json!({ "playlist": { "tracks": tracks } }))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Update playlist request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "Update playlist failed ({}): {}",
+            status, body
+        )));
+    }
+    Ok(())
+}
+
+/// Create a private playlist with a single initial track. Returns its id.
+async fn create_playlist(
+    client: &reqwest::Client,
+    access_token: &str,
+    title: &str,
+    track_id: i64,
+) -> Result<i64> {
+    let resp = client
+        .post(format!("{}/playlists", SOUNDCLOUD_API_BASE))
+        .header("Authorization", format!("OAuth {}", access_token))
+        .json(&serde_json::json!({
+            "playlist": {
+                "title": title,
+                "sharing": "private",
+                "tracks": [{ "id": track_id }],
+            }
+        }))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Create playlist request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Internal(format!(
+            "Create playlist failed ({}): {}",
+            status, body
+        )));
+    }
+
+    let created: PlaylistSummary = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to parse created playlist: {}", e)))?;
+    Ok(created.id)
 }
 
 // ============================================================================


### PR DESCRIPTION
Automatically upload a recording to SoundCloud (private, title + description) as soon as it finishes finalizing — and file it into a playlist named after the show, so every episode of a recurring show is grouped together.

## Auto-upload on finalize
- **Trigger:** `handle_finalize_socket`, right after `finalize_recording_version` marks the take finalized, spawns a **detached** best-effort task. Never delays the finalize socket nor fails finalize on a SoundCloud error.
- **Upload:** reuses `upload_track` — already `private`, with `build_title` + `build_description` — and updates the `soundcloud_*` fields. Fires the same Telegram notification as a manual upload.
- **Guards** (`should_auto_upload`, pure + unit-tested):
  1. `SOUNDCLOUD_AUTO_UPLOAD` kill-switch — **default on**, mirrors `TELEGRAM_ENABLED`.
  2. `is_configured` — silently no-ops if SoundCloud isn't set up/authorized.
  3. not-already-uploaded — re-finalizing never creates a duplicate track.

## Per-show-title playlist
- After a track uploads (both manual and auto paths, since it lives in `upload_track`), `ensure_track_in_show_playlist` files it under a playlist named exactly after **`show.title`**.
- Finds the caller's playlist by title (case-insensitive) via `GET /me/playlists`; if none, creates a **private** one (`POST /playlists`). Adding to an existing playlist re-sends the union of its current tracks (`GET` then `PUT /playlists/{id}` — SoundCloud replaces the whole track list).
- **Best-effort:** a playlist failure is logged but never fails the upload that already succeeded. Idempotent: skips if the track is already in the playlist.

## Files
- `config.rs` — `soundcloud_auto_upload: bool` (default true).
- `soundcloud.rs` — `auto_upload_on_finalize`, `should_auto_upload` (+test), and the playlist helpers.
- `handlers/recording.rs` — spawn the detached upload on finalize success.
- `.env.example` — document `SOUNDCLOUD_AUTO_UPLOAD`.

## Tests
- `auto_upload_only_when_enabled_configured_and_fresh` covers the policy matrix.
- `cargo build` + `cargo test` green; clippy clean on touched files.

## Notes
- Backend-only; no PR CI runs the Rust build (push-to-main only), so correctness is from local `cargo build`/`test`.
- Merging deploys the backend to prod. With SoundCloud connected, the next finalize publishes a private track into its show's playlist automatically.