### PR TITLE
feat(soundcloud): auto-upload streamed recordings + replace track on re-record

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -762,6 +762,24 @@ pub async fn get_latest_finalized_recording_version(
     .await
 }
 
+/// Latest recording version for a show that has a shows-archive MP3
+/// (`archive_key`, set on stream-end) and isn't marked `failed`, newest first.
+/// Streamed shows stay `raw` with only an `archive_key` (no `final_key`), so this
+/// is the SoundCloud source when a show was never manually finalized.
+pub async fn get_latest_archived_recording_version(
+    pool: &SqlitePool,
+    show_id: i64,
+) -> Result<Option<RecordingVersion>, sqlx::Error> {
+    sqlx::query_as::<_, RecordingVersion>(
+        "SELECT * FROM recording_versions \
+         WHERE show_id = ? AND archive_key IS NOT NULL AND status != 'failed' \
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(show_id)
+    .fetch_optional(pool)
+    .await
+}
+
 /// Map each show to the `status` of its most recent recording version, in a single
 /// query (avoids an N+1 over the shows list). Shows with no recording are absent
 /// from the map.
@@ -1120,6 +1138,47 @@ mod tests {
         insert_recording_version(&pool, show, "v1", "raw", None).await;
 
         assert!(get_latest_finalized_recording_version(&pool, show)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    async fn insert_archived_version(pool: &SqlitePool, show_id: i64, version: &str, status: &str) {
+        sqlx::query(
+            "INSERT INTO recording_versions (show_id, version, status, archive_key) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(show_id)
+        .bind(version)
+        .bind(status)
+        .bind(format!("shows/{show_id}/{version}.mp3"))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Streamed shows keep only an `archive_key` (status `raw`); the archive
+    /// fallback picks the newest such take and ignores `failed` ones.
+    #[tokio::test]
+    async fn latest_archived_recording_version_prefers_newest_non_failed() {
+        let pool = mem_db().await;
+        let show = insert_show(&pool, "Streamed Show").await;
+
+        insert_archived_version(&pool, show, "v1", "raw").await;
+        insert_archived_version(&pool, show, "v2", "raw").await; // newest good → wins
+        insert_archived_version(&pool, show, "v3", "failed").await; // newer but failed → ignored
+
+        let picked = get_latest_archived_recording_version(&pool, show)
+            .await
+            .unwrap()
+            .expect("an archived take exists");
+        assert_eq!(picked.version, "v2");
+        assert_eq!(picked.archive_key, Some(format!("shows/{show}/v2.mp3")));
+
+        // A show whose only take is raw-without-archive has no archived source.
+        let other = insert_show(&pool, "No Archive").await;
+        insert_recording_version(&pool, other, "v1", "raw", None).await;
+        assert!(get_latest_archived_recording_version(&pool, other)
             .await
             .unwrap()
             .is_none());

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -354,6 +354,18 @@ pub async fn finalize_and_upload(state: &Arc<AppState>) -> Result<Option<Finaliz
     )
     .await?;
 
+    // Auto-publish a completed streamed broadcast to SoundCloud (private, into the
+    // show's playlist). Streamed shows finalize here — not via handle_finalize_socket
+    // — so this is where their auto-upload fires. Detached + best-effort; skip known-
+    // incomplete captures (they're marked `failed` and never reach the archive).
+    if !finalized.incomplete {
+        let sc_state = Arc::clone(state);
+        let sc_show_id = finalized.show_id;
+        tokio::spawn(async move {
+            crate::soundcloud::auto_upload_on_finalize(&sc_state, sc_show_id).await;
+        });
+    }
+
     Ok(Some(finalized))
 }
 

--- a/backend/src/soundcloud.rs
+++ b/backend/src/soundcloud.rs
@@ -224,31 +224,53 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
         .await?
         .ok_or_else(|| AppError::NotFound("Show not found".to_string()))?;
 
-    // Resolve the audio source: a manually attached recording takes precedence
-    // (pre-recorded / UNHEARD shows); otherwise fall back to the latest finalized
-    // live recording version so streamed shows can be published too (#251).
-    let (recording_key, source_filename) = match show.recording_key.as_ref() {
+    // Resolve the audio source, in priority order:
+    //   1. a manually attached recording (pre-recorded / UNHEARD shows),
+    //   2. the latest *finalized* live recording (final.mp3, default bucket),
+    //   3. the latest streamed *archive* MP3 (shows bucket) — streamed shows stay
+    //      `raw` with only an archive_key, so this is the auto-upload source (#251).
+    let (recording_bucket, recording_key, source_filename) = match show.recording_key.as_ref() {
         Some(key) => (
+            state.config.r2_bucket_name.clone(),
             key.clone(),
             show.recording_filename
                 .clone()
                 .unwrap_or_else(|| "recording.mp3".to_string()),
         ),
         None => {
-            let version = crate::db::get_latest_finalized_recording_version(&state.db, show_id)
-                .await?
-                .ok_or_else(|| {
-                    AppError::BadRequest("Show has no recording to upload".to_string())
+            if let Some(version) =
+                crate::db::get_latest_finalized_recording_version(&state.db, show_id).await?
+            {
+                let final_key = version.final_key.clone().ok_or_else(|| {
+                    AppError::BadRequest("Finalized recording has no file to upload".to_string())
                 })?;
-            let final_key = version.final_key.clone().ok_or_else(|| {
-                AppError::BadRequest("Finalized recording has no file to upload".to_string())
-            })?;
-            (final_key, format!("{}.mp3", version.version))
+                (
+                    state.config.r2_bucket_name.clone(),
+                    final_key,
+                    format!("{}.mp3", version.version),
+                )
+            } else if let Some(version) =
+                crate::db::get_latest_archived_recording_version(&state.db, show_id).await?
+            {
+                let archive_key = version.archive_key.clone().ok_or_else(|| {
+                    AppError::BadRequest("Archived recording has no file to upload".to_string())
+                })?;
+                (
+                    state.config.r2_shows_bucket_name.clone(),
+                    archive_key,
+                    format!("{}.mp3", version.version),
+                )
+            } else {
+                return Err(AppError::BadRequest(
+                    "Show has no recording to upload".to_string(),
+                ));
+            }
         }
     };
 
     tracing::info!(
         show_id = show_id,
+        bucket = recording_bucket.as_str(),
         recording_key = recording_key.as_str(),
         "Starting SoundCloud upload"
     );
@@ -263,9 +285,9 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
         "SoundCloud track title built"
     );
 
-    // Download recording from R2
+    // Download recording from R2 (from whichever bucket the source lives in)
     let (recording_bytes, recording_content_type) =
-        storage::download_file(state, &recording_key).await?;
+        storage::download_file_from_bucket(state, &recording_bucket, &recording_key).await?;
     tracing::info!(
         show_id = show_id,
         size_mb = recording_bytes.len() as f64 / 1_048_576.0,
@@ -311,8 +333,30 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
         }
     }
 
-    // Upload to SoundCloud
+    // The SoundCloud API cannot replace a track's audio in place (asset_data is
+    // upload-only; PUT changes metadata/artwork only). To make a newer recording
+    // supersede the show's track without piling up duplicates, delete the old track
+    // first, then create a fresh one. Tradeoff: the new track gets a new URL and
+    // drops the old track's plays/comments — acceptable for auto-archived private
+    // shows. Deleting the old track also removes it from the show playlist, so the
+    // playlist step below just adds the replacement.
     let client = reqwest::Client::new();
+    if let Some(old_track_id) = show.soundcloud_track_id.as_deref() {
+        match delete_track(&client, &access_token, old_track_id).await {
+            Ok(()) => tracing::info!(
+                show_id = show_id,
+                old_track_id = old_track_id,
+                "Deleted previous SoundCloud track before re-upload"
+            ),
+            Err(e) => tracing::warn!(
+                show_id = show_id,
+                old_track_id = old_track_id,
+                error = %e,
+                "Failed to delete previous SoundCloud track (continuing with a new upload)"
+            ),
+        }
+    }
+
     let resp = client
         .post(format!("{}/tracks", SOUNDCLOUD_API_BASE))
         .header("Authorization", format!("OAuth {}", access_token))
@@ -388,26 +432,46 @@ pub async fn upload_track(state: &Arc<AppState>, show_id: i64) -> Result<SoundCl
     })
 }
 
+/// Delete a SoundCloud track by id. Used to supersede a show's previous track when
+/// a newer recording is uploaded (the API can't replace audio in place). A 404 is
+/// treated as success — the track is already gone.
+async fn delete_track(client: &reqwest::Client, access_token: &str, track_id: &str) -> Result<()> {
+    let resp = client
+        .delete(format!("{}/tracks/{}", SOUNDCLOUD_API_BASE, track_id))
+        .header("Authorization", format!("OAuth {}", access_token))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Delete track request failed: {}", e)))?;
+
+    if resp.status().is_success() || resp.status() == reqwest::StatusCode::NOT_FOUND {
+        Ok(())
+    } else {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        Err(AppError::Internal(format!(
+            "Delete track failed ({}): {}",
+            status, body
+        )))
+    }
+}
+
 /// Whether a just-finalized recording should be auto-uploaded to SoundCloud.
 /// Pure decision so the policy is testable: upload only when the feature is
-/// enabled, the integration is configured, and the show hasn't been uploaded yet
-/// (re-finalizing must not create a duplicate track).
-pub(crate) fn should_auto_upload(enabled: bool, configured: bool, already_uploaded: bool) -> bool {
-    enabled && configured && !already_uploaded
+/// enabled and the integration is configured. Not gated on "already uploaded":
+/// a newer recording deliberately *replaces* the show's existing track audio.
+pub(crate) fn should_auto_upload(enabled: bool, configured: bool) -> bool {
+    enabled && configured
 }
 
 /// Best-effort automatic SoundCloud upload, fired when a recording finishes
-/// finalizing (see `handle_finalize_socket`). Uploads as a private track with the
-/// show's title + description via [`upload_track`]. Never returns an error: every
-/// failure is logged and swallowed so it can run detached without affecting the
-/// finalize flow. No-ops when disabled, unconfigured, or already uploaded.
+/// finalizing (streamed shows via `finalize_and_upload`, UNHEARD via
+/// `handle_finalize_socket`). Uploads as a private track with the show's title +
+/// description via [`upload_track`] — which, if the show already has a track,
+/// replaces that track's audio in place so a re-recording updates the same
+/// SoundCloud track. Never returns an error: every failure is logged and swallowed
+/// so it can run detached. No-ops when disabled or unconfigured.
 pub async fn auto_upload_on_finalize(state: &Arc<AppState>, show_id: i64) {
-    // Cheap gate before touching the DB.
-    if !should_auto_upload(
-        state.config.soundcloud_auto_upload,
-        is_configured(state),
-        false,
-    ) {
+    if !should_auto_upload(state.config.soundcloud_auto_upload, is_configured(state)) {
         tracing::debug!(
             show_id = show_id,
             enabled = state.config.soundcloud_auto_upload,
@@ -417,7 +481,6 @@ pub async fn auto_upload_on_finalize(state: &Arc<AppState>, show_id: i64) {
         return;
     }
 
-    // Skip if this show already has a SoundCloud track (avoid duplicates on re-finalize).
     let show: models::Show = match sqlx::query_as("SELECT * FROM shows WHERE id = ?")
         .bind(show_id)
         .fetch_optional(&state.db)
@@ -433,15 +496,15 @@ pub async fn auto_upload_on_finalize(state: &Arc<AppState>, show_id: i64) {
             return;
         }
     };
+
     if show.soundcloud_track_id.is_some() {
         tracing::info!(
             show_id,
-            "SoundCloud auto-upload: show already uploaded, skipping"
+            "Auto-upload: superseding show's SoundCloud track (delete + re-upload)"
         );
-        return;
+    } else {
+        tracing::info!(show_id, "Auto-uploading finalized recording to SoundCloud");
     }
-
-    tracing::info!(show_id, "Auto-uploading finalized recording to SoundCloud");
     match upload_track(state, show_id).await {
         Ok(result) if result.success => {
             if let Some(ref url) = result.track_url {
@@ -853,16 +916,14 @@ mod tests {
     use super::should_auto_upload;
 
     #[test]
-    fn auto_upload_only_when_enabled_configured_and_fresh() {
-        // Happy path: on, configured, not yet uploaded.
-        assert!(should_auto_upload(true, true, false));
+    fn auto_upload_only_when_enabled_and_configured() {
+        // Happy path: on + configured (fires even if the show already has a
+        // track — a new recording replaces that track's audio).
+        assert!(should_auto_upload(true, true));
 
-        // Any single blocker prevents the upload.
-        assert!(!should_auto_upload(false, true, false)); // kill-switch off
-        assert!(!should_auto_upload(true, false, false)); // not configured
-        assert!(!should_auto_upload(true, true, true)); // already uploaded (no dup)
-
-        // Fully off stays off.
-        assert!(!should_auto_upload(false, false, true));
+        // Either blocker prevents the upload.
+        assert!(!should_auto_upload(false, true)); // kill-switch off
+        assert!(!should_auto_upload(true, false)); // not configured
+        assert!(!should_auto_upload(false, false));
     }
 }

--- a/backend/src/storage.rs
+++ b/backend/src/storage.rs
@@ -572,10 +572,20 @@ pub async fn upload_file(
 }
 
 pub async fn download_file(state: &Arc<AppState>, key: &str) -> Result<(Vec<u8>, String)> {
+    download_file_from_bucket(state, &state.config.r2_bucket_name, key).await
+}
+
+/// Like [`download_file`] but against an explicit bucket — used to pull the
+/// shows-archive MP3 (in `r2_shows_bucket_name`) for SoundCloud upload.
+pub async fn download_file_from_bucket(
+    state: &Arc<AppState>,
+    bucket: &str,
+    key: &str,
+) -> Result<(Vec<u8>, String)> {
     let response = state
         .s3_client
         .get_object()
-        .bucket(&state.config.r2_bucket_name)
+        .bucket(bucket)
         .key(key)
         .send()
         .await


### PR DESCRIPTION
Follow-up to #260. Fixes two gaps found while testing a streamed show, plus implements "a newer recording replaces the show's SoundCloud track".

## Gap 1 — streamed shows never triggered auto-upload
Streamed live shows finalize via `recording::finalize_and_upload` (explicit stop / grace period / admin stop), **not** `handle_finalize_socket` where #260 put the trigger. So a streamed show's stop never fired the SoundCloud upload. Now `finalize_and_upload` also spawns `auto_upload_on_finalize` (detached, best-effort, skipped for incomplete captures).

## Gap 2 — no source for streamed recordings
Streamed recordings stay `raw` with only an `archive_key` in the **shows bucket** (`r2_shows_bucket_name`), no `final_key`. `upload_track` couldn't source them. Added a 3rd resolution tier:
1. `show.recording_key` (manual / pre-recorded, default bucket)
2. latest **finalized** version `final_key` (default bucket)
3. latest **archived** version `archive_key` (**shows bucket**) ← new
Plus `storage::download_file_from_bucket` and `db::get_latest_archived_recording_version`.

## Replace-on-re-record
The SoundCloud **API cannot replace a track's audio in place** (`asset_data` is upload-only; `PUT` only updates metadata/artwork — verified against SoundCloud docs). So to make a newer recording supersede the show's track without duplicates, `upload_track` now **deletes the show's existing track** (`delete_track`) then **creates a fresh one**.
- Tradeoff (chosen deliberately): new track URL each time, old plays/comments dropped — fine for auto-archived private shows.
- Deleting the old track also removes it from the show playlist, so the playlist step adds the replacement.
- Auto-upload is no longer gated on already-uploaded (that's the replace case); `should_auto_upload` is now `enabled && configured`.

## Tests
- `latest_archived_recording_version_prefers_newest_non_failed` (+ the existing finalized-version tests).
- `should_auto_upload` policy test updated to the 2-arg form.
- Full backend suite: 73 pass (only the pre-existing, unrelated `video::tests::test_brightness_analysis` fails on a clean tree).

## Notes
- Backend-only; no PR Rust CI (push-to-main only) — correctness from local `cargo build`/`clippy`/`test`.
- `SOUNDCLOUD_AUTO_UPLOAD` kill-switch (default on) still applies.
- Merging deploys to prod.