### PR TITLE
fix(dev): force APP_ENV=development in generated dev .env

### DIFF
--- a/backend/scripts/dev-secrets.sh
+++ b/backend/scripts/dev-secrets.sh
@@ -130,6 +130,12 @@ excluded=()
   # 3) Non-secret local defaults (the app also has built-in defaults; pinned here for clarity).
   echo "# --- local non-secret defaults ---"
   cat <<'DEFAULTS'
+# This script bootstraps LOCAL DEV, so force development mode. The app's built-in
+# default for APP_ENV is `production` (safe for real deploys); without this line a
+# freshly generated .env runs in production mode, which triggers the startup
+# dev-user purge (seed_dev_user) — and that FK-fails against any shows the dev user
+# created. Override APP_ENV in .env.local to deliberately test production mode.
+APP_ENV=development
 R2_BUCKET_NAME=unheard-artists-dev
 SOUNDCLOUD_REDIRECT_URI=http://localhost:8000/api/soundcloud/callback
 GITHUB_REPO=phaabe/live.moafunk.de


### PR DESCRIPTION
## Symptom
Running `dev-secrets.sh` then `cargo run` crashed the backend right after migrations:
```
Error: error returned from database: (code: 787) FOREIGN KEY constraint failed
```

## Root cause
`dev-secrets.sh` regenerates `backend/.env` but never emitted `APP_ENV`. The app's built-in default (`config.rs`) is `production` — correct for real deploys, but it means a freshly generated **dev** `.env` runs in production mode. In that mode `seed_dev_user` *deletes* the `dev` user on every startup; that user had created shows (`shows.created_by REFERENCES users(id)`, no `ON DELETE`), so the delete hit a FK constraint and aborted startup.

## Fix
Emit `APP_ENV=development` in the script's local-defaults block (this script exclusively bootstraps local dev). Developers can still override in `.env.local` to test production mode.

Unblocks: re-run `./scripts/dev-secrets.sh && cargo run`.