### PR TITLE
feat(soundcloud): let hosts use SoundCloud, not just admins

### DIFF
--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -4673,7 +4673,9 @@ pub async fn api_soundcloud_status(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    // Hosts and admins can view SoundCloud status (needed to render the card on
+    // their show's detail page).
+    require_show_creator(&state, &headers).await?;
     let status = crate::soundcloud::get_status(&state).await;
     Ok(Json(status))
 }
@@ -4684,7 +4686,8 @@ pub async fn api_soundcloud_auth(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    // Hosts may connect the station's SoundCloud account too.
+    require_show_creator(&state, &headers).await?;
     let url = crate::soundcloud::get_auth_url(&state)?;
     Ok(axum::response::Redirect::temporary(&url))
 }
@@ -4726,7 +4729,8 @@ pub async fn api_upload_to_soundcloud(
     Path(id): Path<i64>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    // The show's host (or its creator, or an admin) may upload its recording.
+    require_show_editor(&state, &headers, id).await?;
 
     if !crate::soundcloud::is_configured(&state) {
         return Err(AppError::BadRequest(
@@ -4764,7 +4768,8 @@ pub async fn api_set_soundcloud_privacy(
     headers: HeaderMap,
     Json(req): Json<SoundCloudPrivacyRequest>,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    // The show's host (or its creator, or an admin) may toggle its track privacy.
+    require_show_editor(&state, &headers, id).await?;
 
     if !crate::soundcloud::is_configured(&state) {
         return Err(AppError::BadRequest(
@@ -4783,7 +4788,9 @@ pub async fn api_soundcloud_disconnect(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
-    require_admin(&state, &headers).await?;
+    // Hosts and admins can reset the station's SoundCloud connection (used by the
+    // reconnect flow).
+    require_show_creator(&state, &headers).await?;
     crate::soundcloud::delete_stored_token(&state).await?;
     Ok(Json(serde_json::json!({ "success": true })))
 }

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -101,6 +101,8 @@ const isUnheard = computed(() => !show.value?.show_type || show.value.show_type 
 
 // Role-based access. Backend enforces the same rules; these only gate the UI.
 const isAdmin = computed(() => auth.user?.role === 'admin' || auth.user?.role === 'superadmin');
+// Hosts and admins can use SoundCloud (connect + upload their show's recording).
+const canUseSoundcloud = computed(() => isAdmin.value || auth.user?.role === 'host');
 const canEdit = computed(
   () =>
     isAdmin.value ||
@@ -1622,7 +1624,7 @@ onUnmounted(() => {
       </div>
 
       <!-- SoundCloud (non-UNHEARD shows; UNHEARD has its own in the recording card) -->
-      <div v-if="isAdmin && scStatus && !isUnheard" class="card">
+      <div v-if="canUseSoundcloud && scStatus && !isUnheard" class="card">
         <h2 class="section-title">SoundCloud</h2>
         <div class="soundcloud-section">
           <template v-if="!scStatus.configured">


### PR DESCRIPTION
Hosts couldn't use SoundCloud: every `/api/soundcloud/*` endpoint was `require_admin`, and the show-detail SoundCloud card was `isAdmin`-gated. So a host couldn't connect the account, see status, or upload their own show's recording.

## Change
**Backend** — relax the gates to match ownership:
- `status` / `auth` (connect) / `disconnect` → `require_show_creator` (host **or** admin; excludes guests).
- per-show `upload` / `privacy` → `require_show_editor(id)` (the show's assigned host, its creator, or an admin) — a host can only act on their own show.

**Frontend** — render the SoundCloud card for host-or-admin (`canUseSoundcloud`) instead of admin-only. The backend still enforces per-show ownership, so the UI gate is just cosmetic.

## Test
- `cargo build` + clippy clean; `npm run build` + Prettier clean.
- A host opening their own show now sees the SoundCloud card and can connect / upload; acting on a show they don't own returns 403.