### PR TITLE
fix(stream): atomically claim prerecorded go-live to stop double-start

### DIFF
--- a/backend/src/handlers/api.rs
+++ b/backend/src/handlers/api.rs
@@ -5511,6 +5511,28 @@ pub async fn api_my_show_go_live(
 /// through FFmpeg via the stream bridge, and stamp `prerecorded_started_at` so
 /// it's never auto-started twice. Shared by the manual "Go Live" button
 /// (`api_my_show_go_live`) and [`crate::scheduler::check_prerecorded_show_start`].
+///
+/// The two callers can race (the client-side countdown in `FlowWaiting.vue`
+/// firing at the same moment the scheduler's poll picks up the same show), so
+/// the `prerecorded_started_at` claim is an atomic `UPDATE ... WHERE
+/// prerecorded_started_at IS NULL` done *before* FFmpeg is spawned, not after.
+/// Whoever affects the row wins; the loser no-ops instead of starting a second
+/// FFmpeg process (which previously produced a doubled/looped playback).
+/// Atomically claim a show's pre-recorded go-live: sets `prerecorded_started_at`
+/// only if it's still NULL, returning whether *this* call won the claim. Used to
+/// serialize the manual "Go Live" button against the auto-start scheduler, which
+/// can otherwise both observe `NULL` and both start FFmpeg for the same show.
+async fn claim_prerecorded_start(db: &sqlx::SqlitePool, show_id: i64) -> Result<bool> {
+    let claim = sqlx::query(
+        "UPDATE shows SET prerecorded_started_at = datetime('now') \
+         WHERE id = ? AND prerecorded_started_at IS NULL",
+    )
+    .bind(show_id)
+    .execute(db)
+    .await?;
+    Ok(claim.rows_affected() > 0)
+}
+
 pub async fn start_prerecorded_show_stream(
     state: &Arc<AppState>,
     show: &models::Show,
@@ -5527,6 +5549,34 @@ pub async fn start_prerecorded_show_stream(
         ));
     }
 
+    if !claim_prerecorded_start(&state.db, show.id).await? {
+        tracing::info!(
+            "Prerecorded stream for show_id={} already started elsewhere; skipping",
+            show.id
+        );
+        return Ok(());
+    }
+
+    // From here on, any failure must release the claim so a later retry
+    // (manual button or next scheduler tick) isn't permanently locked out.
+    if let Err(e) = start_claimed_prerecorded_stream(state, show, username, key).await {
+        sqlx::query("UPDATE shows SET prerecorded_started_at = NULL WHERE id = ?")
+            .bind(show.id)
+            .execute(&state.db)
+            .await
+            .ok();
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+async fn start_claimed_prerecorded_stream(
+    state: &Arc<AppState>,
+    show: &models::Show,
+    username: &str,
+    key: &str,
+) -> Result<()> {
     // Generate a long-lived presigned URL for FFmpeg to read from (4 hours)
     let presigned_url = storage::get_presigned_url(state, key, 4 * 3600).await?;
     let push_target = state.config.producer_target();
@@ -5547,11 +5597,6 @@ pub async fn start_prerecorded_show_stream(
     )
     .await
     .map_err(|e| AppError::Internal(format!("Failed to start prerecorded stream: {}", e)))?;
-
-    sqlx::query("UPDATE shows SET prerecorded_started_at = datetime('now') WHERE id = ?")
-        .bind(show.id)
-        .execute(&state.db)
-        .await?;
 
     // Notify via Telegram
     telegram_notify::notify_stream_start(state, username);
@@ -5692,7 +5737,39 @@ pub async fn require_show_editor(
 
 #[cfg(test)]
 mod tests {
-    use super::time_windows_overlap;
+    use super::{claim_prerecorded_start, time_windows_overlap};
+
+    async fn shows_test_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE shows (id INTEGER PRIMARY KEY, prerecorded_started_at TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO shows (id, prerecorded_started_at) VALUES (1, NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn only_one_of_two_racing_claims_wins() {
+        let pool = shows_test_pool().await;
+
+        // Simulates the manual "Go Live" button and the scheduler tick both
+        // observing `prerecorded_started_at IS NULL` and racing to claim it.
+        let first = claim_prerecorded_start(&pool, 1).await.unwrap();
+        let second = claim_prerecorded_start(&pool, 1).await.unwrap();
+
+        assert!(first, "the first caller should win the claim");
+        assert!(!second, "the second caller must not also start the stream");
+    }
+
+    #[tokio::test]
+    async fn claim_fails_gracefully_for_unknown_show() {
+        let pool = shows_test_pool().await;
+        assert!(!claim_prerecorded_start(&pool, 999).await.unwrap());
+    }
 
     #[test]
     fn distinct_windows_do_not_overlap() {


### PR DESCRIPTION
## What
- Closes the race where a pre-recorded show's stream could be started twice
  (manual "Go Live" button + auto-start scheduler both firing for the same show).
- `start_prerecorded_show_stream` now atomically claims the show via
  `UPDATE shows SET prerecorded_started_at = datetime('now') WHERE id = ? AND
  prerecorded_started_at IS NULL` *before* spawning FFmpeg; the loser of the
  race no-ops instead of starting a second FFmpeg process.
- Releases the claim if a downstream step (presigned URL, FFmpeg spawn) fails,
  so a real failure doesn't permanently lock the show out of retries.
- Adds unit tests (`claim_prerecorded_start`) proving only one of two racing
  callers wins the claim.

## Why
Follow-up to #240 (fixed in #241) and #242. After both landed, a production
report came in: a 5:30 pre-recorded file played for ~11 minutes — i.e. it was
started twice back-to-back. `prerecorded_started_at` was previously written
*after* FFmpeg spawned, so the manual button (via `FlowWaiting.vue`'s
client-side countdown) and the scheduler's poll could both observe `NULL` and
both start a stream. Closes #266.

## How
Extracted the atomic claim into `claim_prerecorded_start()` and the
presign+spawn logic into `start_claimed_prerecorded_stream()`, so
`start_prerecorded_show_stream()` now reads as: confirm upload → claim →
(on failure, release claim + propagate error) → notify.

## Test plan
- [x] `cargo build` — clean.
- [x] `cargo test --bin unheard-backend` — all pass except a pre-existing,
      unrelated `video::tests::test_brightness_analysis` failure (confirmed
      failing on `main` too, before this change).
- [x] `cargo clippy` — no new warnings.
- [x] GitNexus impact analysis on `start_prerecorded_show_stream` (HIGH risk,
      expected: its two known callers) and `detect_changes` — confirmed only
      this function's call chain changed.
- [ ] Manual: schedule a pre-recorded show a few minutes out, confirm upload,
      leave the waiting-room tab open through the countdown, and verify the
      stream starts exactly once (no doubled duration).

## Risk
Low. No signature/behavior change for either caller (`api_my_show_go_live`,
`scheduler::check_prerecorded_show_start`) — both already just propagate the
`Result`. Rollback is a plain revert if the atomic claim ever misfires.
