### PR TITLE
refactor(dashboard): extract shared show panels + phase composable

### DIFF
--- a/frontend/src/admin/__tests__/showTime.test.ts
+++ b/frontend/src/admin/__tests__/showTime.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { berlinToUtcDate, isShowEnded, isShowRunning, nextDayDateStr } from '../showTime';
+
+/** Freeze wall-clock at a UTC instant. */
+function freezeAtUtc(iso: string) {
+  vi.setSystemTime(new Date(iso));
+}
+
+describe('showTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('berlinToUtcDate', () => {
+    it('converts Berlin summer time (CEST, UTC+2)', () => {
+      expect(berlinToUtcDate('2026-07-04', '20:00').toISOString()).toBe(
+        '2026-07-04T18:00:00.000Z'
+      );
+    });
+
+    it('converts Berlin winter time (CET, UTC+1)', () => {
+      expect(berlinToUtcDate('2026-01-15', '20:00').toISOString()).toBe(
+        '2026-01-15T19:00:00.000Z'
+      );
+    });
+  });
+
+  describe('nextDayDateStr', () => {
+    it('increments across a month boundary', () => {
+      expect(nextDayDateStr('2026-06-30')).toBe('2026-07-01');
+    });
+  });
+
+  describe('isShowRunning', () => {
+    const show = { date: '2026-07-04', start_time: '20:00', end_time: '22:00' };
+
+    it('is false before air time', () => {
+      freezeAtUtc('2026-07-04T17:59:00Z'); // 19:59 Berlin
+      expect(isShowRunning(show)).toBe(false);
+    });
+
+    it('is true during the show', () => {
+      freezeAtUtc('2026-07-04T19:00:00Z'); // 21:00 Berlin
+      expect(isShowRunning(show)).toBe(true);
+    });
+
+    it('is false after the scheduled end', () => {
+      freezeAtUtc('2026-07-04T20:01:00Z'); // 22:01 Berlin
+      expect(isShowRunning(show)).toBe(false);
+    });
+
+    it('handles overnight shows (end <= start rolls to the next day)', () => {
+      const overnight = { date: '2026-07-04', start_time: '23:00', end_time: '01:00' };
+      freezeAtUtc('2026-07-04T22:30:00Z'); // 00:30 Berlin on the 5th
+      expect(isShowRunning(overnight)).toBe(true);
+    });
+
+    it('is false without a start or end time', () => {
+      freezeAtUtc('2026-07-04T19:00:00Z');
+      expect(isShowRunning({ date: '2026-07-04', start_time: '20:00' })).toBe(false);
+      expect(isShowRunning({ date: '2026-07-04', end_time: '22:00' })).toBe(false);
+    });
+  });
+
+  describe('isShowEnded', () => {
+    const show = { date: '2026-07-04', start_time: '20:00', end_time: '22:00' };
+
+    it('is false while the show is still running', () => {
+      freezeAtUtc('2026-07-04T19:00:00Z'); // 21:00 Berlin
+      expect(isShowEnded(show)).toBe(false);
+    });
+
+    it('is true after the scheduled end', () => {
+      freezeAtUtc('2026-07-04T20:01:00Z'); // 22:01 Berlin
+      expect(isShowEnded(show)).toBe(true);
+    });
+
+    it('handles overnight shows — not ended just after midnight', () => {
+      const overnight = { date: '2026-07-04', start_time: '23:00', end_time: '01:00' };
+      freezeAtUtc('2026-07-04T22:30:00Z'); // 00:30 Berlin on the 5th
+      expect(isShowEnded(overnight)).toBe(false);
+    });
+
+    it('is false without an end time', () => {
+      freezeAtUtc('2026-07-05T12:00:00Z');
+      expect(isShowEnded({ date: '2026-07-04', start_time: '20:00' })).toBe(false);
+    });
+  });
+});

--- a/frontend/src/admin/components/show-cockpit/panels/IdentityPanel.vue
+++ b/frontend/src/admin/components/show-cockpit/panels/IdentityPanel.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { ShowDetail } from '../../../api';
+import { FormInput } from '@shared/components';
+
+/**
+ * Hero panel: cover image + title + description with inline editing.
+ *
+ * Extracted verbatim from ShowDetailPage's external/brunchtime dashboard.
+ * Edit state (editMode + form values) stays on the owning page/shell so the
+ * combined Save/Cancel header keeps working unchanged; this panel only renders
+ * and forwards input.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  /** Whether the combined dashboard edit mode is active. */
+  editMode: boolean;
+  /** Whether the viewer may edit (gates the cover-replace button). */
+  canEdit: boolean;
+  /** Cover upload in flight (disables the replace button). */
+  uploadingCover: boolean;
+  /** Title form value while editing. */
+  title: string;
+  /** Description form value while editing. */
+  description: string;
+}>();
+
+const emit = defineEmits<{
+  'update:title': [value: string];
+  'update:description': [value: string];
+  /** A new cover file was picked. */
+  'cover-selected': [file: File];
+}>();
+
+const coverInput = ref<HTMLInputElement | null>(null);
+
+function onCoverChange(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) {
+    emit('cover-selected', file);
+  }
+  input.value = '';
+}
+</script>
+
+<template>
+  <div class="card hero-card">
+    <div class="hero-cover">
+      <img v-if="show.cover_url" :src="show.cover_url" alt="Cover" class="hero-cover-img" />
+      <div v-else class="hero-cover-placeholder">
+        <span class="hero-cover-ico">🎙</span>
+        <span>COVER</span>
+      </div>
+      <button
+        v-if="canEdit"
+        type="button"
+        class="cover-replace"
+        :disabled="uploadingCover"
+        @click="coverInput?.click()"
+      >
+        ⬆ {{ show.cover_url ? 'Replace' : 'Upload' }}
+      </button>
+      <input
+        ref="coverInput"
+        type="file"
+        accept="image/*"
+        class="upload-input"
+        @change="onCoverChange"
+      />
+    </div>
+
+    <div class="hero-body">
+      <p class="dash-label">TITLE</p>
+      <FormInput
+        v-if="editMode"
+        :model-value="props.title"
+        required
+        @update:model-value="emit('update:title', $event)"
+      />
+      <h2 v-else class="hero-title">{{ show.title }}</h2>
+
+      <p class="dash-label">DESCRIPTION</p>
+      <textarea
+        v-if="editMode"
+        :value="props.description"
+        class="text-field"
+        rows="4"
+        placeholder="Brief description..."
+        @input="emit('update:description', ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+      <p v-else-if="show.description" class="hero-desc">{{ show.description }}</p>
+      <p v-else class="empty-state">No description.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.hero-card {
+  display: flex;
+  gap: var(--spacing-xl);
+  align-items: flex-start;
+}
+
+.hero-cover {
+  position: relative;
+  flex: 0 0 auto;
+  width: 200px;
+  height: 200px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-surface-alt);
+}
+
+.hero-cover-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero-cover-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  color: #fff;
+  background: repeating-linear-gradient(
+    45deg,
+    var(--color-primary) 0,
+    var(--color-primary) 10px,
+    var(--color-surface-alt) 10px,
+    var(--color-surface-alt) 20px
+  );
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.hero-cover-ico {
+  font-size: 2rem;
+}
+
+.cover-replace {
+  position: absolute;
+  left: var(--spacing-sm);
+  bottom: var(--spacing-sm);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 6px 10px;
+  font-size: var(--font-size-sm);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+}
+
+.cover-replace:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.hero-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hero-title {
+  margin: 0 0 var(--spacing-lg);
+  font-size: 1.8em;
+  font-weight: 700;
+}
+
+.hero-desc {
+  margin: 0;
+  line-height: var(--line-height-relaxed, 1.6);
+  color: var(--color-text);
+}
+
+.dash-label {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.upload-input {
+  display: none;
+}
+
+.text-field {
+  width: 100%;
+  padding: 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 1em;
+  font-family: var(--font-family);
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.text-field:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.empty-state {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--spacing-md) 0;
+}
+
+@media (max-width: 768px) {
+  .hero-card {
+    flex-direction: column;
+  }
+
+  .hero-cover {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+  }
+}
+</style>

--- a/frontend/src/admin/components/show-cockpit/panels/ScheduleHostPanel.vue
+++ b/frontend/src/admin/components/show-cockpit/panels/ScheduleHostPanel.vue
@@ -1,0 +1,403 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { GuestCredentials, ShowDetail } from '../../../api';
+import { BaseButton } from '@shared/components';
+import { VueDatePicker } from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
+
+/**
+ * Air-date + assigned-host tile pair, extracted verbatim from ShowDetailPage's
+ * external/brunchtime dashboard.
+ *
+ * The datetime range and host-assignment form state stay on the owning
+ * page/shell (they feed the combined Save flow and the API handlers there);
+ * this panel renders them via v-model pairs and emits the assignment actions.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  /** Whether the combined dashboard edit mode is active. */
+  editMode: boolean;
+  /** Whether the viewer may (re)assign the host. */
+  canEditHost: boolean;
+  /** Host assignment request in flight. */
+  assigningHost: boolean;
+  /** Credentials of a freshly created guest host (shown once). */
+  guestCreds: GuestCredentials | null;
+  /** Datetime range editing state (from useDateTimeRange on the page). */
+  editStart: Date | null;
+  editEnd: Date | null;
+  editTimeValid: boolean;
+  editTimeError: string | null;
+  /** Host-assignment form state. */
+  selectedHostId: number | null;
+  hostEditMode: 'existing' | 'guest';
+  newGuestUsername: string;
+}>();
+
+const emit = defineEmits<{
+  'update:editStart': [value: Date | null];
+  'update:editEnd': [value: Date | null];
+  'update:selectedHostId': [value: number | null];
+  'update:hostEditMode': [value: 'existing' | 'guest'];
+  'update:newGuestUsername': [value: string];
+  /** Assign the selected existing user as host. */
+  'assign-host': [];
+  /** Create a one-off guest with the entered username and assign them. */
+  'create-guest': [];
+  /** Remove the current host. */
+  'unassign-host': [];
+}>();
+
+const hasHost = computed(() => !!props.show.host_user_id);
+
+const hostInitials = computed(() => {
+  const name = props.show.host_username;
+  if (!name) return '?';
+  return name
+    .split(/\s+/)
+    .map((p) => p[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+});
+
+const airDateLabel = computed(() => {
+  if (!props.show.date) return '—';
+  return new Date(props.show.date + 'T12:00:00').toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+});
+
+const airTimeRange = computed(() => {
+  if (!props.show.start_time) return '';
+  return props.show.end_time
+    ? `${props.show.start_time} – ${props.show.end_time}`
+    : props.show.start_time;
+});
+</script>
+
+<template>
+  <div class="dash-grid">
+    <div class="card info-tile">
+      <h2 class="section-title"><span class="ico">📅</span> Air date</h2>
+      <template v-if="editMode">
+        <div class="edit-row edit-row-datetime">
+          <div class="datetime-field">
+            <label class="form-label">Start</label>
+            <VueDatePicker
+              :model-value="props.editStart"
+              :enable-time-picker="true"
+              :dark="true"
+              :minutes-increment="5"
+              :max-date="props.editEnd || undefined"
+              :flow="{ steps: ['calendar', 'time'] }"
+              :action-row="{
+                showCancel: false,
+                showPreview: false,
+                selectBtnLabel: 'Confirm',
+              }"
+              placeholder="Start date & time"
+              text-input
+              teleport="body"
+              @update:model-value="emit('update:editStart', $event)"
+            />
+          </div>
+          <div class="datetime-field">
+            <label class="form-label">End</label>
+            <VueDatePicker
+              :model-value="props.editEnd"
+              :enable-time-picker="true"
+              :dark="true"
+              :minutes-increment="5"
+              :min-date="props.editStart || undefined"
+              :flow="{ steps: ['calendar', 'time'] }"
+              :action-row="{
+                showCancel: false,
+                showPreview: false,
+                selectBtnLabel: 'Confirm',
+              }"
+              placeholder="End date & time"
+              text-input
+              teleport="body"
+              @update:model-value="emit('update:editEnd', $event)"
+            />
+          </div>
+        </div>
+        <p v-if="props.editStart && props.editEnd && !props.editTimeValid" class="field-error">
+          {{ props.editTimeError }}
+        </p>
+      </template>
+      <template v-else>
+        <p class="tile-value">{{ airDateLabel }}</p>
+        <p class="tile-sub">{{ airTimeRange }}</p>
+      </template>
+    </div>
+
+    <div class="card info-tile">
+      <h2 class="section-title"><span class="ico">👤</span> Assigned host</h2>
+      <div v-if="hasHost" class="host-row">
+        <span class="host-avatar">{{ hostInitials }}</span>
+        <div>
+          <p class="tile-value">{{ show.host_username }}</p>
+          <p class="tile-sub">Host</p>
+        </div>
+      </div>
+      <p v-else class="empty-state">No host assigned.</p>
+
+      <!-- Admins and the show's creator may (re)assign the host inline,
+           either to an existing user or to a freshly created guest. -->
+      <div v-if="canEditHost && editMode" class="host-edit">
+        <div class="host-edit-toggle">
+          <button
+            type="button"
+            :class="['toggle-chip', { active: props.hostEditMode === 'existing' }]"
+            @click="emit('update:hostEditMode', 'existing')"
+          >
+            Existing user
+          </button>
+          <button
+            type="button"
+            :class="['toggle-chip', { active: props.hostEditMode === 'guest' }]"
+            @click="emit('update:hostEditMode', 'guest')"
+          >
+            Create guest
+          </button>
+        </div>
+
+        <template v-if="props.hostEditMode === 'existing'">
+          <template v-if="show.available_hosts && show.available_hosts.length > 0">
+            <select
+              :value="props.selectedHostId"
+              class="select-input"
+              @change="
+                emit(
+                  'update:selectedHostId',
+                  ($event.target as HTMLSelectElement).value
+                    ? Number(($event.target as HTMLSelectElement).value)
+                    : null
+                )
+              "
+            >
+              <option :value="null" disabled>
+                {{ hasHost ? '-- Reassign host --' : '-- Select a host --' }}
+              </option>
+              <option v-for="h in show.available_hosts" :key="h.id" :value="h.id">
+                {{ h.username }}
+              </option>
+            </select>
+            <BaseButton
+              variant="success"
+              size="sm"
+              :disabled="!props.selectedHostId || assigningHost"
+              :loading="assigningHost"
+              @click="emit('assign-host')"
+            >
+              {{ hasHost ? 'Reassign' : 'Assign' }}
+            </BaseButton>
+            <BaseButton v-if="hasHost" variant="ghost" size="sm" @click="emit('unassign-host')">
+              Remove
+            </BaseButton>
+          </template>
+          <p v-else class="text-muted assign-note">No assignable users available.</p>
+        </template>
+
+        <template v-else>
+          <input
+            :value="props.newGuestUsername"
+            type="text"
+            class="select-input"
+            placeholder="Guest username"
+            autocomplete="off"
+            @input="emit('update:newGuestUsername', ($event.target as HTMLInputElement).value)"
+          />
+          <BaseButton
+            variant="success"
+            size="sm"
+            :disabled="!props.newGuestUsername.trim() || assigningHost"
+            :loading="assigningHost"
+            @click="emit('create-guest')"
+          >
+            Create &amp; assign
+          </BaseButton>
+          <p class="text-muted assign-note">
+            The guest can only log in on the show date and is deleted afterwards.
+          </p>
+          <p v-if="guestCreds" class="guest-creds">
+            Username <code>{{ guestCreds.username }}</code> · one-time password
+            <code>{{ guestCreds.password }}</code> (shown once)
+          </p>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dash-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-lg);
+  align-items: stretch;
+  margin-bottom: var(--spacing-lg);
+}
+
+.dash-grid > .card {
+  margin-bottom: 0;
+}
+
+.section-title {
+  font-size: 1.2em;
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.info-tile .section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.tile-value {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.tile-sub {
+  margin: 2px 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.host-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.host-avatar {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-full);
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  font-weight: 700;
+}
+
+.edit-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.edit-row-datetime {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.datetime-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.field-error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.host-edit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.host-edit-toggle {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-basis: 100%;
+}
+
+.toggle-chip {
+  padding: 4px 12px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.toggle-chip.active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.guest-creds {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.guest-creds code {
+  font-family: monospace;
+  background: var(--color-surface-alt);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+}
+
+.select-input {
+  flex: 1;
+  padding: 8px 10px;
+  background: #ffec44;
+  border: 1px solid #111;
+  border-radius: var(--radius-md);
+  color: #111;
+  font-size: 1em;
+  font-family: var(--font-family);
+}
+
+.select-input:focus {
+  outline: none;
+  border-color: #111;
+  box-shadow: 0 0 0 2px rgba(255, 236, 68, 0.35);
+}
+
+.assign-note {
+  margin-bottom: var(--spacing-md);
+}
+
+.empty-state {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--spacing-md) 0;
+}
+
+@media (max-width: 768px) {
+  .dash-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/admin/components/show-cockpit/panels/index.ts
+++ b/frontend/src/admin/components/show-cockpit/panels/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Shell-agnostic panels for the per-show host dashboard
+ * (docs/stream-rework/show-cockpit-plan.md). Rendered today by
+ * ShowDetailPage's external/brunchtime branch; the cockpit/tabbed shells
+ * (PR 2) compose the same panels.
+ *
+ * MediaPanel and PromotionPanel already existed as standalone cards with
+ * panel-shaped APIs (props + emits, own scoped styles) — they are re-exported
+ * under their panel names rather than wrapped. PromotionPanel is a static
+ * placeholder until the announcement composer lands (plan PR 4).
+ */
+export { default as IdentityPanel } from './IdentityPanel.vue';
+export { default as ScheduleHostPanel } from './ScheduleHostPanel.vue';
+export { default as MediaPanel } from '../../show-detail/ShowMediaCard.vue';
+export { default as PromotionPanel } from '../../show-detail/ShowSocialChannels.vue';

--- a/frontend/src/admin/composables/__tests__/useShowPhase.test.ts
+++ b/frontend/src/admin/composables/__tests__/useShowPhase.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import { useShowPhase, type PhaseSource, type ShowPhase } from '../useShowPhase';
+
+function freezeAtUtc(iso: string) {
+  vi.setSystemTime(new Date(iso));
+}
+
+/** Run useShowPhase inside an effect scope and return the current phase. */
+function phaseFor(show: PhaseSource | null, tickMs?: number): ShowPhase {
+  const scope = effectScope();
+  const result = scope.run(() => useShowPhase(ref(show), { tickMs }).phase.value);
+  scope.stop();
+  return result as ShowPhase;
+}
+
+// 20:00–22:00 Berlin on 2026-07-04 (CEST, UTC+2) → 18:00–20:00 UTC
+const SHOW: PhaseSource = { date: '2026-07-04', start_time: '20:00', end_time: '22:00' };
+
+describe('useShowPhase', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is prep before air time', () => {
+    freezeAtUtc('2026-07-04T12:00:00Z');
+    expect(phaseFor(SHOW)).toBe('prep');
+  });
+
+  it('is broadcast between air time and scheduled end', () => {
+    freezeAtUtc('2026-07-04T19:00:00Z'); // 21:00 Berlin
+    expect(phaseFor(SHOW)).toBe('broadcast');
+  });
+
+  it('is wrapup after the scheduled end', () => {
+    freezeAtUtc('2026-07-04T20:30:00Z'); // 22:30 Berlin
+    expect(phaseFor(SHOW)).toBe('wrapup');
+  });
+
+  it('is wrapup as soon as a recording exists, even mid-broadcast', () => {
+    freezeAtUtc('2026-07-04T19:00:00Z'); // 21:00 Berlin, show still running
+    expect(phaseFor({ ...SHOW, latest_recording: { status: 'raw' } })).toBe('wrapup');
+  });
+
+  it('is broadcast during an overnight show just after midnight', () => {
+    const overnight: PhaseSource = { date: '2026-07-04', start_time: '23:00', end_time: '01:00' };
+    freezeAtUtc('2026-07-04T22:30:00Z'); // 00:30 Berlin on the 5th
+    expect(phaseFor(overnight)).toBe('broadcast');
+  });
+
+  it('defaults to prep with no show', () => {
+    freezeAtUtc('2026-07-04T12:00:00Z');
+    expect(phaseFor(null)).toBe('prep');
+  });
+
+  it('transitions on the internal tick without a show mutation', () => {
+    freezeAtUtc('2026-07-04T17:59:30Z'); // 19:59:30 Berlin — 30s before air
+    const scope = effectScope();
+    const phase = scope.run(() => useShowPhase(ref<PhaseSource>(SHOW), { tickMs: 1000 }).phase)!;
+    expect(phase.value).toBe('prep');
+
+    vi.advanceTimersByTime(60_000); // now 20:00:30 Berlin — on air
+    expect(phase.value).toBe('broadcast');
+    scope.stop();
+  });
+
+  it('clears its interval when the scope is disposed', () => {
+    freezeAtUtc('2026-07-04T12:00:00Z');
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    const scope = effectScope();
+    scope.run(() => useShowPhase(ref<PhaseSource>(SHOW)));
+    scope.stop();
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -31,6 +31,7 @@ export {
   shoikaFontsPromise,
 } from './useOverlayRenderer';
 export { useHostFlow, type FlowStep, type UploadMode, type UploadProgress } from './useHostFlow';
+export { useShowPhase, type ShowPhase, type PhaseSource } from './useShowPhase';
 export { useStreamTest, type StreamTestState, type UseStreamTestOptions } from './useStreamTest';
 export {
   useShowWizard,

--- a/frontend/src/admin/composables/useHostFlow.ts
+++ b/frontend/src/admin/composables/useHostFlow.ts
@@ -1,5 +1,6 @@
 import { ref, computed, readonly } from 'vue';
 import { hostFlowApi, streamApi, type MyShowInfo, type UploadResult } from '../api';
+import { berlinToUtcDate, isShowEnded, isShowRunning } from '../showTime';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -135,51 +136,9 @@ async function fetchMyShow(): Promise<void> {
   }
 }
 
-/**
- * Get the current Berlin wall-clock time as an ISO-comparable string (YYYY-MM-DDTHH:MM:SS).
- * Uses sv-SE locale which formats as "YYYY-MM-DD HH:MM:SS".
- */
-function getBerlinNowISO(): string {
-  return new Date().toLocaleString('sv-SE', { timeZone: 'Europe/Berlin' }).replace(' ', 'T');
-}
-
-/**
- * Convert a Berlin wall-clock date + time to a proper UTC Date object.
- * Useful for countdown arithmetic (target.getTime() - Date.now()).
- */
-function berlinToUtcDate(dateStr: string, timeStr: string): Date {
-  // Interpret as UTC first, then adjust by the Berlin-UTC offset
-  const asUtc = new Date(`${dateStr}T${timeStr}:00Z`);
-  const berlinMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'Europe/Berlin' })).getTime();
-  const utcMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'UTC' })).getTime();
-  const berlinOffsetMs = berlinMs - utcMs;
-  return new Date(asUtc.getTime() - berlinOffsetMs);
-}
-
-function nextDayDateStr(dateStr: string): string {
-  const d = new Date(`${dateStr}T00:00:00`);
-  d.setDate(d.getDate() + 1);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-}
-
-/** Check if a show is currently running (between start and end time in Berlin TZ) */
-function isShowRunning(s: MyShowInfo): boolean {
-  if (!s.date || !s.start_time || !s.end_time) return false;
-  const nowStr = getBerlinNowISO();
-  const startStr = `${s.date}T${s.start_time}:00`;
-  const endDateStr = s.end_time <= s.start_time ? nextDayDateStr(s.date) : s.date;
-  const endStr = `${endDateStr}T${s.end_time}:00`;
-  return nowStr >= startStr && nowStr <= endStr;
-}
-
-/** Check if a show has ended (end date/time is past) */
-function isShowEnded(s: MyShowInfo): boolean {
-  if (!s.date || !s.end_time) return false;
-  const nowStr = getBerlinNowISO();
-  const endDateStr = s.start_time && s.end_time <= s.start_time ? nextDayDateStr(s.date) : s.date;
-  const endStr = `${endDateStr}T${s.end_time}:00`;
-  return nowStr > endStr;
-}
+// Berlin-time schedule helpers (getBerlinNowISO / berlinToUtcDate / isShowRunning /
+// isShowEnded) now live in ../showTime and are re-exported from this composable's
+// return object unchanged.
 
 /** Select a show and determine the starting step based on its state */
 function selectShow(selectedShow: MyShowInfo): void {

--- a/frontend/src/admin/composables/useShowPhase.ts
+++ b/frontend/src/admin/composables/useShowPhase.ts
@@ -1,0 +1,52 @@
+import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from 'vue';
+import { isShowEnded, isShowRunning, type ShowSchedule } from '../showTime';
+
+/**
+ * Soft lifecycle phase of a show, per docs/stream-rework/show-cockpit-plan.md:
+ * - `prep`      — before air time
+ * - `broadcast` — between air time and scheduled end
+ * - `wrapup`    — past scheduled end, or a live recording already exists
+ *
+ * Phases drive emphasis / default tab only — they never lock a panel.
+ */
+export type ShowPhase = 'prep' | 'broadcast' | 'wrapup';
+
+/** Minimal show shape the phase derivation needs (ShowDetail satisfies this). */
+export interface PhaseSource extends ShowSchedule {
+  latest_recording?: unknown;
+}
+
+export interface UseShowPhase {
+  phase: ComputedRef<ShowPhase>;
+}
+
+/**
+ * Derive the current phase of a show, re-evaluated on a timer so the UI
+ * transitions Prep → Broadcast → Wrap-up without a reload.
+ *
+ * Must be called inside an active effect scope (component `setup` or
+ * `effectScope()`); the internal interval is cleaned up on scope dispose.
+ */
+export function useShowPhase(
+  show: Ref<PhaseSource | null | undefined>,
+  opts: { tickMs?: number } = {}
+): UseShowPhase {
+  // Bumped on an interval purely to invalidate the computed — wall-clock time
+  // is an implicit input that Vue can't track.
+  const tick = ref(0);
+  const timer = setInterval(() => {
+    tick.value++;
+  }, opts.tickMs ?? 30_000);
+  onScopeDispose(() => clearInterval(timer));
+
+  const phase = computed<ShowPhase>(() => {
+    void tick.value;
+    const s = show.value;
+    if (!s) return 'prep';
+    if (s.latest_recording || isShowEnded(s)) return 'wrapup';
+    if (isShowRunning(s)) return 'broadcast';
+    return 'prep';
+  });
+
+  return { phase };
+}

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -14,12 +14,14 @@ import AudioPlayer from '../components/AudioPlayer.vue';
 import ShowDeadlineBanner from '../components/show-detail/ShowDeadlineBanner.vue';
 import ShowMediaCard from '../components/show-detail/ShowMediaCard.vue';
 import ShowSocialChannels from '../components/show-detail/ShowSocialChannels.vue';
+import { IdentityPanel, ScheduleHostPanel } from '../components/show-cockpit/panels';
 import { useFlash } from '../composables/useFlash';
 import { useDataInvalidation } from '../composables/useDataInvalidation';
 import { useDateTimeRange } from '../composables/useDateTimeRange';
 import { useHostFlow } from '../composables/useHostFlow';
 import { useAuthStore } from '../stores/auth';
 import { resolveMediaMode } from '../showMediaMode';
+import { berlinToUtcDate } from '../showTime';
 import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 
@@ -109,7 +111,6 @@ const canEdit = computed(
     show.value?.host_user_id === auth.user?.id ||
     show.value?.created_by === auth.user?.id
 );
-const hasHost = computed(() => !!show.value?.host_user_id);
 const uploadingCover = ref(false);
 
 // The show's creator (a host) may toggle the host between themselves and a
@@ -122,50 +123,13 @@ const canEditHost = computed(
 // ── Dashboard (external/brunchtime) state ──────────────────────────────────
 const editMode = ref(false);
 const mediaMode = ref<'live' | 'upload'>('upload');
-const extCoverInput = ref<HTMLInputElement | null>(null);
 
 /** The assigned host may manage media (matches the backend require_user_show check). */
 const canManageMedia = computed(() => !!show.value && show.value.host_user_id === auth.user?.id);
 
-const hostInitials = computed(() => {
-  const name = show.value?.host_username;
-  if (!name) return '?';
-  return name
-    .split(/\s+/)
-    .map((p) => p[0])
-    .slice(0, 2)
-    .join('')
-    .toUpperCase();
-});
-
-/** Convert a Berlin wall-clock date + time to a UTC Date for countdown math. */
-function berlinToUtcDate(dateStr: string, timeStr: string): Date {
-  const asUtc = new Date(`${dateStr}T${timeStr}:00Z`);
-  const berlinMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'Europe/Berlin' })).getTime();
-  const utcMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'UTC' })).getTime();
-  return new Date(asUtc.getTime() - (berlinMs - utcMs));
-}
-
 const airTarget = computed(() => {
   if (!show.value?.date || !show.value?.start_time) return null;
   return berlinToUtcDate(show.value.date, show.value.start_time);
-});
-
-const airDateLabel = computed(() => {
-  if (!show.value?.date) return '—';
-  return new Date(show.value.date + 'T12:00:00').toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-});
-
-const airTimeRange = computed(() => {
-  if (!show.value?.start_time) return '';
-  return show.value.end_time
-    ? `${show.value.start_time} – ${show.value.end_time}`
-    : show.value.start_time;
 });
 
 /** Format a date string + time string into a readable datetime */
@@ -901,11 +865,9 @@ async function deleteRecording() {
   }
 }
 
-// Manual cover upload (for non-UNHEARD shows)
-async function handleCoverUpload(event: Event) {
-  const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (!file || !show.value) return;
+// Manual cover upload (for non-UNHEARD shows); the panel owns the file input.
+async function uploadCoverFile(file: File) {
+  if (!show.value) return;
 
   uploadingCover.value = true;
   try {
@@ -919,7 +881,6 @@ async function handleCoverUpload(event: Event) {
     flash.error(e instanceof Error ? e.message : 'Failed to upload cover');
   } finally {
     uploadingCover.value = false;
-    input.value = '';
   }
 }
 
@@ -1020,189 +981,34 @@ onUnmounted(() => {
         />
 
         <!-- Hero: cover + title + description -->
-        <div class="card hero-card">
-          <div class="hero-cover">
-            <img v-if="show.cover_url" :src="show.cover_url" alt="Cover" class="hero-cover-img" />
-            <div v-else class="hero-cover-placeholder">
-              <span class="hero-cover-ico">🎙</span>
-              <span>COVER</span>
-            </div>
-            <button
-              v-if="canEdit"
-              type="button"
-              class="cover-replace"
-              :disabled="uploadingCover"
-              @click="extCoverInput?.click()"
-            >
-              ⬆ {{ show.cover_url ? 'Replace' : 'Upload' }}
-            </button>
-            <input
-              ref="extCoverInput"
-              type="file"
-              accept="image/*"
-              class="upload-input"
-              @change="handleCoverUpload"
-            />
-          </div>
-
-          <div class="hero-body">
-            <p class="dash-label">TITLE</p>
-            <FormInput v-if="editMode" v-model="titleForm" required />
-            <h2 v-else class="hero-title">{{ show.title }}</h2>
-
-            <p class="dash-label">DESCRIPTION</p>
-            <textarea
-              v-if="editMode"
-              v-model="descriptionForm"
-              class="text-field"
-              rows="4"
-              placeholder="Brief description..."
-            ></textarea>
-            <p v-else-if="show.description" class="hero-desc">{{ show.description }}</p>
-            <p v-else class="empty-state">No description.</p>
-          </div>
-        </div>
+        <IdentityPanel
+          v-model:title="titleForm"
+          v-model:description="descriptionForm"
+          :show="show"
+          :edit-mode="editMode"
+          :can-edit="canEdit"
+          :uploading-cover="uploadingCover"
+          @cover-selected="uploadCoverFile"
+        />
 
         <!-- Grid: air date + assigned host -->
-        <div class="dash-grid">
-          <div class="card info-tile">
-            <h2 class="section-title"><span class="ico">📅</span> Air date</h2>
-            <template v-if="editMode">
-              <div class="edit-row edit-row-datetime">
-                <div class="datetime-field">
-                  <label class="form-label">Start</label>
-                  <VueDatePicker
-                    v-model="editStart"
-                    :enable-time-picker="true"
-                    :dark="true"
-                    :minutes-increment="5"
-                    :max-date="editEnd || undefined"
-                    :flow="{ steps: ['calendar', 'time'] }"
-                    :action-row="{
-                      showCancel: false,
-                      showPreview: false,
-                      selectBtnLabel: 'Confirm',
-                    }"
-                    placeholder="Start date & time"
-                    text-input
-                    teleport="body"
-                  />
-                </div>
-                <div class="datetime-field">
-                  <label class="form-label">End</label>
-                  <VueDatePicker
-                    v-model="editEnd"
-                    :enable-time-picker="true"
-                    :dark="true"
-                    :minutes-increment="5"
-                    :min-date="editStart || undefined"
-                    :flow="{ steps: ['calendar', 'time'] }"
-                    :action-row="{
-                      showCancel: false,
-                      showPreview: false,
-                      selectBtnLabel: 'Confirm',
-                    }"
-                    placeholder="End date & time"
-                    text-input
-                    teleport="body"
-                  />
-                </div>
-              </div>
-              <p v-if="editStart && editEnd && !editTimeValid" class="field-error">
-                {{ editTimeError }}
-              </p>
-            </template>
-            <template v-else>
-              <p class="tile-value">{{ airDateLabel }}</p>
-              <p class="tile-sub">{{ airTimeRange }}</p>
-            </template>
-          </div>
-
-          <div class="card info-tile">
-            <h2 class="section-title"><span class="ico">👤</span> Assigned host</h2>
-            <div v-if="hasHost" class="host-row">
-              <span class="host-avatar">{{ hostInitials }}</span>
-              <div>
-                <p class="tile-value">{{ show.host_username }}</p>
-                <p class="tile-sub">Host</p>
-              </div>
-            </div>
-            <p v-else class="empty-state">No host assigned.</p>
-
-            <!-- Admins and the show's creator may (re)assign the host inline,
-                 either to an existing user or to a freshly created guest. -->
-            <div v-if="canEditHost && editMode" class="host-edit">
-              <div class="host-edit-toggle">
-                <button
-                  type="button"
-                  :class="['toggle-chip', { active: hostEditMode === 'existing' }]"
-                  @click="hostEditMode = 'existing'"
-                >
-                  Existing user
-                </button>
-                <button
-                  type="button"
-                  :class="['toggle-chip', { active: hostEditMode === 'guest' }]"
-                  @click="hostEditMode = 'guest'"
-                >
-                  Create guest
-                </button>
-              </div>
-
-              <template v-if="hostEditMode === 'existing'">
-                <template v-if="show.available_hosts && show.available_hosts.length > 0">
-                  <select v-model="selectedHostId" class="select-input">
-                    <option :value="null" disabled>
-                      {{ hasHost ? '-- Reassign host --' : '-- Select a host --' }}
-                    </option>
-                    <option v-for="h in show.available_hosts" :key="h.id" :value="h.id">
-                      {{ h.username }}
-                    </option>
-                  </select>
-                  <BaseButton
-                    variant="success"
-                    size="sm"
-                    :disabled="!selectedHostId || assigningHost"
-                    :loading="assigningHost"
-                    @click="assignHost"
-                  >
-                    {{ hasHost ? 'Reassign' : 'Assign' }}
-                  </BaseButton>
-                  <BaseButton v-if="hasHost" variant="ghost" size="sm" @click="unassignHost">
-                    Remove
-                  </BaseButton>
-                </template>
-                <p v-else class="text-muted assign-note">No assignable users available.</p>
-              </template>
-
-              <template v-else>
-                <input
-                  v-model="newGuestUsername"
-                  type="text"
-                  class="select-input"
-                  placeholder="Guest username"
-                  autocomplete="off"
-                />
-                <BaseButton
-                  variant="success"
-                  size="sm"
-                  :disabled="!newGuestUsername.trim() || assigningHost"
-                  :loading="assigningHost"
-                  @click="createGuestHost"
-                >
-                  Create &amp; assign
-                </BaseButton>
-                <p class="text-muted assign-note">
-                  The guest can only log in on the show date and is deleted afterwards.
-                </p>
-                <p v-if="guestCreds" class="guest-creds">
-                  Username <code>{{ guestCreds.username }}</code> · one-time password
-                  <code>{{ guestCreds.password }}</code> (shown once)
-                </p>
-              </template>
-            </div>
-          </div>
-        </div>
+        <ScheduleHostPanel
+          v-model:edit-start="editStart"
+          v-model:edit-end="editEnd"
+          v-model:selected-host-id="selectedHostId"
+          v-model:host-edit-mode="hostEditMode"
+          v-model:new-guest-username="newGuestUsername"
+          :show="show"
+          :edit-mode="editMode"
+          :can-edit-host="canEditHost"
+          :assigning-host="assigningHost"
+          :guest-creds="guestCreds"
+          :edit-time-valid="editTimeValid"
+          :edit-time-error="editTimeError"
+          @assign-host="assignHost"
+          @create-guest="createGuestHost"
+          @unassign-host="unassignHost"
+        />
 
         <!-- Grid: media + social -->
         <div class="dash-grid">
@@ -1974,14 +1780,6 @@ onUnmounted(() => {
   flex: 0 0 auto;
 }
 
-.dash-label {
-  margin: 0 0 var(--spacing-xs);
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: var(--color-text-muted);
-}
-
 .dash-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1994,144 +1792,12 @@ onUnmounted(() => {
   margin-bottom: 0;
 }
 
-.hero-card {
-  display: flex;
-  gap: var(--spacing-xl);
-  align-items: flex-start;
-}
-
-.hero-cover {
-  position: relative;
-  flex: 0 0 auto;
-  width: 200px;
-  height: 200px;
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  background: var(--color-surface-alt);
-}
-
-.hero-cover-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.hero-cover-placeholder {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  color: #fff;
-  background: repeating-linear-gradient(
-    45deg,
-    var(--color-primary) 0,
-    var(--color-primary) 10px,
-    var(--color-surface-alt) 10px,
-    var(--color-surface-alt) 20px
-  );
-  font-weight: 700;
-  letter-spacing: 0.1em;
-}
-
-.hero-cover-ico {
-  font-size: 2rem;
-}
-
-.cover-replace {
-  position: absolute;
-  left: var(--spacing-sm);
-  bottom: var(--spacing-sm);
-  border: none;
-  border-radius: var(--radius-md);
-  padding: 6px 10px;
-  font-size: var(--font-size-sm);
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
-  cursor: pointer;
-}
-
-.cover-replace:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
-.hero-body {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.hero-title {
-  margin: 0 0 var(--spacing-lg);
-  font-size: 1.8em;
-  font-weight: 700;
-}
-
-.hero-desc {
-  margin: 0;
-  line-height: var(--line-height-relaxed, 1.6);
-  color: var(--color-text);
-}
-
-.info-tile .section-title {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  font-size: var(--font-size-sm);
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.tile-value {
-  margin: 0;
-  font-size: var(--font-size-xl);
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.tile-sub {
-  margin: 2px 0 0;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-}
-
-.host-row {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
-}
-
-.host-avatar {
-  flex: 0 0 auto;
-  width: 44px;
-  height: 44px;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius-full);
-  background: var(--color-success-bg);
-  color: var(--color-success);
-  font-weight: 700;
-}
+/* Hero + air-date/host tile styles moved into
+   components/show-cockpit/panels/{IdentityPanel,ScheduleHostPanel}.vue */
 
 @media (max-width: 768px) {
   .dash-grid {
     grid-template-columns: 1fr;
-  }
-
-  .hero-card {
-    flex-direction: column;
-  }
-
-  .hero-cover {
-    width: 100%;
-    height: auto;
-    aspect-ratio: 1;
   }
 }
 
@@ -2553,50 +2219,7 @@ onUnmounted(() => {
   margin-bottom: var(--spacing-md);
 }
 
-.host-edit {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--spacing-sm);
-  margin-top: var(--spacing-md);
-}
-
-.host-edit-toggle {
-  display: flex;
-  gap: var(--spacing-xs);
-  flex-basis: 100%;
-}
-
-.toggle-chip {
-  padding: 4px 12px;
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-}
-
-.toggle-chip.active {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-}
-
-.guest-creds {
-  flex-basis: 100%;
-  margin: 0;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-}
-
-.guest-creds code {
-  font-family: monospace;
-  background: var(--color-surface-alt);
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
-  color: var(--color-text);
-}
+/* Host-assignment editor styles moved into ScheduleHostPanel.vue */
 
 .select-input {
   flex: 1;

--- a/frontend/src/admin/showTime.ts
+++ b/frontend/src/admin/showTime.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared Berlin-wall-clock time helpers for show scheduling.
+ *
+ * Shows are stored as a Berlin-local `date` (YYYY-MM-DD) plus `start_time` /
+ * `end_time` (HH:MM). These helpers are the single source of truth for
+ * "is this show running / ended" and for converting that wall-clock schedule
+ * into UTC instants for countdown arithmetic. Previously duplicated in
+ * `useHostFlow` and `ShowDetailPage`.
+ */
+
+/** The minimal schedule shape shared by `MyShowInfo` and `ShowDetail`. */
+export interface ShowSchedule {
+  date: string;
+  start_time?: string;
+  end_time?: string;
+}
+
+/**
+ * Get the current Berlin wall-clock time as an ISO-comparable string (YYYY-MM-DDTHH:MM:SS).
+ * Uses sv-SE locale which formats as "YYYY-MM-DD HH:MM:SS".
+ */
+export function getBerlinNowISO(): string {
+  return new Date().toLocaleString('sv-SE', { timeZone: 'Europe/Berlin' }).replace(' ', 'T');
+}
+
+/**
+ * Convert a Berlin wall-clock date + time to a proper UTC Date object.
+ * Useful for countdown arithmetic (target.getTime() - Date.now()).
+ */
+export function berlinToUtcDate(dateStr: string, timeStr: string): Date {
+  // Interpret as UTC first, then adjust by the Berlin-UTC offset
+  const asUtc = new Date(`${dateStr}T${timeStr}:00Z`);
+  const berlinMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'Europe/Berlin' })).getTime();
+  const utcMs = new Date(asUtc.toLocaleString('en-US', { timeZone: 'UTC' })).getTime();
+  const berlinOffsetMs = berlinMs - utcMs;
+  return new Date(asUtc.getTime() - berlinOffsetMs);
+}
+
+/** The day after a YYYY-MM-DD date string, as YYYY-MM-DD. */
+export function nextDayDateStr(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00`);
+  d.setDate(d.getDate() + 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** Check if a show is currently running (between start and end time in Berlin TZ). */
+export function isShowRunning(s: ShowSchedule): boolean {
+  if (!s.date || !s.start_time || !s.end_time) return false;
+  const nowStr = getBerlinNowISO();
+  const startStr = `${s.date}T${s.start_time}:00`;
+  const endDateStr = s.end_time <= s.start_time ? nextDayDateStr(s.date) : s.date;
+  const endStr = `${endDateStr}T${s.end_time}:00`;
+  return nowStr >= startStr && nowStr <= endStr;
+}
+
+/** Check if a show has ended (end date/time is past, handling overnight shows). */
+export function isShowEnded(s: ShowSchedule): boolean {
+  if (!s.date || !s.end_time) return false;
+  const nowStr = getBerlinNowISO();
+  const endDateStr = s.start_time && s.end_time <= s.start_time ? nextDayDateStr(s.date) : s.date;
+  const endStr = `${endDateStr}T${s.end_time}:00`;
+  return nowStr > endStr;
+}


### PR DESCRIPTION
## What

PR 1 of the show-cockpit plan ([`docs/stream-rework/show-cockpit-plan.md`](../blob/main/docs/stream-rework/show-cockpit-plan.md)) — **strictly behavior-preserving** extraction, no UI change.

- **`showTime.ts`** — single source for the Berlin-wall-clock schedule helpers (`getBerlinNowISO` / `berlinToUtcDate` / `isShowRunning` / `isShowEnded`), previously duplicated in `useHostFlow` and `ShowDetailPage`. `useHostFlow`'s returned API is unchanged (10 direct callers unaffected — verified via GitNexus impact analysis).
- **`useShowPhase`** — soft lifecycle phase derivation (`prep` / `broadcast` / `wrapup`) with ticking re-evaluation; consumed by the cockpit/tabbed shells in PR 2.
- **`components/show-cockpit/panels/`** — `IdentityPanel` (hero cover/title/description) and `ScheduleHostPanel` (air date + host/guest assignment) extracted verbatim from `ShowDetailPage`'s external branch, incl. their scoped styles. Edit/form state stays on the page via `v-model` pairs, so the combined Save flow and API handlers are untouched. `MediaPanel`/`PromotionPanel` are barrel aliases of the existing `ShowMediaCard`/`ShowSocialChannels` cards (they already had panel-shaped APIs — no wrapper indirection).

Deliberately **not** in this PR (per plan): no `WrapUpPanel` (new UI for external shows → PR 2), UNHEARD branch untouched.

## Verification

- Vitest **76/76** (20 new: `showTime` boundary cases incl. overnight end≤start + DST, `useShowPhase` phase transitions incl. tick-driven prep→broadcast)
- ESLint clean on touched TS (repo lint doesn't cover `.vue`)
- `vite build` ✓ (the effective SFC gate — `tsc` doesn't check `.vue` here)
- `tsc`: +4 `TS2307 .vue module` lines from the new panels barrel — same pre-existing noise class as `shared/components/index.ts` (27 baseline errors on main). A one-line `declare module '*.vue'` shim would clear all 31; left out of scope.
- GitNexus `detect_changes`: risk **low**, 0 affected execution flows
- ⚠️ **Manual check requested:** eyeball `/shows/:id` for one external show (view + edit mode) — extraction is verbatim but I could not drive the full stack in-session.

## Next

PR 2: cockpit + tabbed shells behind `?layout=` (+ WrapUpPanel, guest gating).