### PR TITLE
feat(dashboard): cockpit + tabbed show shells behind ?layout

### DIFF
--- a/frontend/src/admin/components/show-cockpit/panels/WrapUpPanel.vue
+++ b/frontend/src/admin/components/show-cockpit/panels/WrapUpPanel.vue
@@ -1,0 +1,302 @@
+<script setup lang="ts">
+import type { LatestRecording, ShowDetail, SoundCloudStatus } from '../../../api';
+import { BaseButton } from '@shared/components';
+import AudioPlayer from '../../AudioPlayer.vue';
+
+/**
+ * Wrap-up panel: the post-broadcast surface — live-capture recording status +
+ * SoundCloud publish. Extracted verbatim from ShowDetailPage's shared lower
+ * cards (Live Recording + the non-UNHEARD SoundCloud card).
+ *
+ * All state and side-effects stay on the owning page; this panel renders and
+ * emits the actions. Only rendered for external shows (UNHEARD keeps its own
+ * recording/SoundCloud UI inside its Final Recording card).
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  latestRecording: LatestRecording | null;
+  recordingState: 'ready' | 'processing' | 'failed' | null;
+  /** Whether the viewer may use SoundCloud (connect + upload their show). */
+  canUseSoundcloud: boolean;
+  scStatus: SoundCloudStatus | null;
+  uploadingToSoundCloud: boolean;
+  togglingSoundCloudPrivacy: boolean;
+}>();
+
+const emit = defineEmits<{
+  'upload-soundcloud': [];
+  'toggle-privacy': [];
+  'connect-soundcloud': [];
+  'reconnect-soundcloud': [];
+}>();
+
+const RECORDING_STATE_LABELS: Record<'ready' | 'processing' | 'failed', string> = {
+  ready: 'Ready',
+  processing: 'Processing…',
+  failed: 'Failed',
+};
+
+function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+</script>
+
+<template>
+  <div class="wrapup-panel">
+    <!-- Live Recording -->
+    <div v-if="props.latestRecording && props.recordingState" class="card">
+      <h2 class="section-title">Live Recording</h2>
+      <div class="live-recording-head">
+        <span :class="['rec-badge', props.recordingState]">
+          {{ RECORDING_STATE_LABELS[props.recordingState] }}
+        </span>
+        <span class="live-recording-meta">
+          {{ props.latestRecording.version }}
+          <span v-if="props.latestRecording.duration_ms">
+            · {{ formatDurationMs(props.latestRecording.duration_ms) }}</span
+          >
+        </span>
+      </div>
+
+      <p v-if="props.recordingState === 'failed'" class="live-recording-error">
+        {{ props.latestRecording.error_message || 'Recording failed.' }}
+      </p>
+      <p v-else-if="props.recordingState === 'processing'" class="text-muted live-recording-hint">
+        The recording is being processed. A download will appear here once it's ready.
+      </p>
+
+      <template v-else-if="props.latestRecording.download_url">
+        <AudioPlayer
+          :key="props.latestRecording.download_url"
+          :src="props.latestRecording.download_url"
+        />
+        <div class="recording-actions">
+          <a :href="props.latestRecording.download_url" class="dl-btn recording" download>
+            ⬇️ Download recording
+          </a>
+        </div>
+      </template>
+    </div>
+
+    <!-- SoundCloud -->
+    <div v-if="props.canUseSoundcloud && props.scStatus" class="card">
+      <h2 class="section-title">SoundCloud</h2>
+      <div class="soundcloud-section">
+        <template v-if="!props.scStatus.configured">
+          <p class="empty-state">
+            SoundCloud isn't configured. Set SOUNDCLOUD_CLIENT_ID / SOUNDCLOUD_CLIENT_SECRET.
+          </p>
+        </template>
+        <template v-else-if="!props.scStatus.authorized">
+          <p class="text-muted soundcloud-hint">
+            Connect the station's SoundCloud account to enable uploads.
+          </p>
+          <BaseButton size="sm" variant="primary" @click="emit('connect-soundcloud')">
+            🔗 Connect SoundCloud
+          </BaseButton>
+        </template>
+        <template v-else-if="show.soundcloud_url">
+          <div class="soundcloud-status">
+            <span class="soundcloud-label">☁️ SoundCloud</span>
+            <a :href="show.soundcloud_url" target="_blank" rel="noopener" class="soundcloud-link">
+              {{ show.soundcloud_public ? '🔓 Public' : '🔒 Private' }}
+            </a>
+            <span v-if="show.soundcloud_uploaded_at" class="text-muted soundcloud-timestamp">
+              Uploaded {{ show.soundcloud_uploaded_at }}
+            </span>
+          </div>
+          <div class="soundcloud-actions">
+            <BaseButton
+              size="sm"
+              :variant="show.soundcloud_public ? 'ghost' : 'success'"
+              :loading="props.togglingSoundCloudPrivacy"
+              @click="emit('toggle-privacy')"
+            >
+              {{ show.soundcloud_public ? 'Make Private' : 'Make Public' }}
+            </BaseButton>
+            <BaseButton
+              size="sm"
+              variant="ghost"
+              :loading="props.uploadingToSoundCloud"
+              @click="emit('upload-soundcloud')"
+            >
+              Re-upload
+            </BaseButton>
+            <BaseButton
+              v-if="props.scStatus.auth_url"
+              size="sm"
+              variant="ghost"
+              @click="emit('reconnect-soundcloud')"
+            >
+              🔗 Reconnect
+            </BaseButton>
+          </div>
+        </template>
+        <template v-else>
+          <p class="text-muted soundcloud-hint">
+            Finalized recordings upload here automatically. You can also upload now.
+          </p>
+          <div class="soundcloud-actions">
+            <BaseButton
+              size="sm"
+              variant="ghost"
+              :loading="props.uploadingToSoundCloud"
+              @click="emit('upload-soundcloud')"
+            >
+              ☁️ Upload to SoundCloud
+            </BaseButton>
+            <BaseButton
+              v-if="props.scStatus.auth_url"
+              size="sm"
+              variant="ghost"
+              @click="emit('reconnect-soundcloud')"
+            >
+              🔗 Reconnect
+            </BaseButton>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <p v-if="!props.latestRecording && !(props.canUseSoundcloud && props.scStatus)" class="empty-state">
+      Nothing to wrap up yet — the recording and publish options appear after the show.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.wrapup-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.wrapup-panel .card {
+  margin-bottom: 0;
+}
+
+.section-title {
+  font-size: 1.2em;
+  margin-bottom: var(--spacing-md);
+  padding-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.live-recording-head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.live-recording-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.live-recording-hint,
+.live-recording-error {
+  margin-top: var(--spacing-sm);
+}
+
+.live-recording-error {
+  color: #ef4444;
+}
+
+.rec-badge {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.rec-badge.ready {
+  background: rgba(34, 197, 94, 0.1);
+  color: #22c55e;
+}
+
+.rec-badge.processing {
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
+.rec-badge.failed {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+
+.recording-actions {
+  margin-top: var(--spacing-md);
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-sm);
+}
+
+.recording-actions > * {
+  flex: 1;
+}
+
+.dl-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  transition: all var(--transition-fast);
+  background-color: #666666;
+  color: #ffffff;
+  white-space: nowrap;
+}
+
+.dl-btn:hover {
+  opacity: 0.8;
+}
+
+.dl-btn.recording {
+  background-color: #8b5cf6;
+}
+
+.soundcloud-section {
+  margin-top: 0;
+}
+
+.soundcloud-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-sm);
+}
+
+.soundcloud-label {
+  font-weight: 600;
+}
+
+.soundcloud-link {
+  color: var(--color-primary);
+}
+
+.soundcloud-timestamp {
+  font-size: var(--font-size-sm);
+}
+
+.soundcloud-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.empty-state {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--spacing-md) 0;
+}
+
+.text-muted {
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/admin/components/show-cockpit/panels/index.ts
+++ b/frontend/src/admin/components/show-cockpit/panels/index.ts
@@ -11,5 +11,6 @@
  */
 export { default as IdentityPanel } from './IdentityPanel.vue';
 export { default as ScheduleHostPanel } from './ScheduleHostPanel.vue';
+export { default as WrapUpPanel } from './WrapUpPanel.vue';
 export { default as MediaPanel } from '../../show-detail/ShowMediaCard.vue';
 export { default as PromotionPanel } from '../../show-detail/ShowSocialChannels.vue';

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -14,7 +14,9 @@ import AudioPlayer from '../components/AudioPlayer.vue';
 import ShowDeadlineBanner from '../components/show-detail/ShowDeadlineBanner.vue';
 import ShowMediaCard from '../components/show-detail/ShowMediaCard.vue';
 import ShowSocialChannels from '../components/show-detail/ShowSocialChannels.vue';
-import { IdentityPanel, ScheduleHostPanel } from '../components/show-cockpit/panels';
+import { IdentityPanel, ScheduleHostPanel, WrapUpPanel } from '../components/show-cockpit/panels';
+import { CockpitShell, TabbedShell, type ShellLayout } from './show-cockpit';
+import { useShowPhase } from '../composables/useShowPhase';
 import { useFlash } from '../composables/useFlash';
 import { useDataInvalidation } from '../composables/useDataInvalidation';
 import { useDateTimeRange } from '../composables/useDateTimeRange';
@@ -126,6 +128,34 @@ const mediaMode = ref<'live' | 'upload'>('upload');
 
 /** The assigned host may manage media (matches the backend require_user_show check). */
 const canManageMedia = computed(() => !!show.value && show.value.host_user_id === auth.user?.id);
+
+// ── Dashboard shell A/B (cockpit vs tabs) ──────────────────────────────────
+// docs/stream-rework/show-cockpit-plan.md — the layout is chosen via ?layout=,
+// remembered in localStorage, and toggleable from the header. Guests get a
+// trimmed view (no promotion / wrap-up).
+const LAYOUT_STORAGE_KEY = 'showDashboardLayout';
+
+function initialLayout(): ShellLayout {
+  const q = route.query.layout;
+  if (q === 'cockpit' || q === 'tabs') return q;
+  const stored = localStorage.getItem(LAYOUT_STORAGE_KEY);
+  return stored === 'cockpit' || stored === 'tabs' ? stored : 'cockpit';
+}
+
+const layout = ref<ShellLayout>(initialLayout());
+const shellComponent = computed(() => (layout.value === 'tabs' ? TabbedShell : CockpitShell));
+
+function setLayout(next: ShellLayout) {
+  layout.value = next;
+  localStorage.setItem(LAYOUT_STORAGE_KEY, next);
+  // Keep the URL shareable/refresh-stable without polluting history.
+  router.replace({ query: { ...route.query, layout: next } });
+}
+
+const { phase } = useShowPhase(show);
+
+/** Guests see a trimmed dashboard: no promotion / wrap-up surfaces. */
+const isGuest = computed(() => auth.user?.role === 'guest');
 
 const airTarget = computed(() => {
   if (!show.value?.date || !show.value?.start_time) return null;
@@ -950,6 +980,22 @@ onUnmounted(() => {
             <h1 class="page-title">Episode overview</h1>
           </div>
           <div class="dash-header-actions">
+            <div class="layout-toggle" role="group" aria-label="Dashboard layout">
+              <button
+                type="button"
+                :class="['layout-chip', { active: layout === 'cockpit' }]"
+                @click="setLayout('cockpit')"
+              >
+                Cockpit
+              </button>
+              <button
+                type="button"
+                :class="['layout-chip', { active: layout === 'tabs' }]"
+                @click="setLayout('tabs')"
+              >
+                Tabs
+              </button>
+            </div>
             <BaseButton
               v-if="canEdit && !editMode"
               variant="ghost"
@@ -969,49 +1015,54 @@ onUnmounted(() => {
       </div>
 
       <!-- ===================== External / brunchtime dashboard ===================== -->
-      <template v-if="!isUnheard">
-        <!-- Deadline banner: countdown to air for live, or upload-status for upload mode -->
-        <ShowDeadlineBanner
-          v-if="mediaMode === 'live' || !show.prerecorded_confirmed_at"
-          :show="show"
-          :mode="mediaMode"
-          :air-target="airTarget"
-          :can-act="canManageMedia"
-          @action="launchFlow"
-        />
+      <!-- One route, two swappable layouts over the same shared panels (see
+           docs/stream-rework/show-cockpit-plan.md). The shell only arranges
+           slots + drives phase emphasis; all state/handlers stay here. -->
+      <component :is="shellComponent" v-if="!isUnheard" :phase="phase" :hide-aftershow="isGuest">
+        <template #banner>
+          <ShowDeadlineBanner
+            v-if="mediaMode === 'live' || !show.prerecorded_confirmed_at"
+            :show="show"
+            :mode="mediaMode"
+            :air-target="airTarget"
+            :can-act="canManageMedia"
+            @action="launchFlow"
+          />
+        </template>
 
-        <!-- Hero: cover + title + description -->
-        <IdentityPanel
-          v-model:title="titleForm"
-          v-model:description="descriptionForm"
-          :show="show"
-          :edit-mode="editMode"
-          :can-edit="canEdit"
-          :uploading-cover="uploadingCover"
-          @cover-selected="uploadCoverFile"
-        />
+        <template #identity>
+          <IdentityPanel
+            v-model:title="titleForm"
+            v-model:description="descriptionForm"
+            :show="show"
+            :edit-mode="editMode"
+            :can-edit="canEdit"
+            :uploading-cover="uploadingCover"
+            @cover-selected="uploadCoverFile"
+          />
+        </template>
 
-        <!-- Grid: air date + assigned host -->
-        <ScheduleHostPanel
-          v-model:edit-start="editStart"
-          v-model:edit-end="editEnd"
-          v-model:selected-host-id="selectedHostId"
-          v-model:host-edit-mode="hostEditMode"
-          v-model:new-guest-username="newGuestUsername"
-          :show="show"
-          :edit-mode="editMode"
-          :can-edit-host="canEditHost"
-          :assigning-host="assigningHost"
-          :guest-creds="guestCreds"
-          :edit-time-valid="editTimeValid"
-          :edit-time-error="editTimeError"
-          @assign-host="assignHost"
-          @create-guest="createGuestHost"
-          @unassign-host="unassignHost"
-        />
+        <template #schedule>
+          <ScheduleHostPanel
+            v-model:edit-start="editStart"
+            v-model:edit-end="editEnd"
+            v-model:selected-host-id="selectedHostId"
+            v-model:host-edit-mode="hostEditMode"
+            v-model:new-guest-username="newGuestUsername"
+            :show="show"
+            :edit-mode="editMode"
+            :can-edit-host="canEditHost"
+            :assigning-host="assigningHost"
+            :guest-creds="guestCreds"
+            :edit-time-valid="editTimeValid"
+            :edit-time-error="editTimeError"
+            @assign-host="assignHost"
+            @create-guest="createGuestHost"
+            @unassign-host="unassignHost"
+          />
+        </template>
 
-        <!-- Grid: media + social -->
-        <div class="dash-grid">
+        <template #media>
           <ShowMediaCard
             :show="show"
             :mode="mediaMode"
@@ -1020,9 +1071,28 @@ onUnmounted(() => {
             @select-upload="mediaMode = 'upload'"
             @launch="launchFlow"
           />
+        </template>
+
+        <template #promotion>
           <ShowSocialChannels />
-        </div>
-      </template>
+        </template>
+
+        <template #wrapup>
+          <WrapUpPanel
+            :show="show"
+            :latest-recording="latestRecording"
+            :recording-state="recordingState"
+            :can-use-soundcloud="canUseSoundcloud"
+            :sc-status="scStatus"
+            :uploading-to-sound-cloud="uploadingToSoundCloud"
+            :toggling-sound-cloud-privacy="togglingSoundCloudPrivacy"
+            @upload-soundcloud="uploadToSoundCloud"
+            @toggle-privacy="toggleSoundCloudPrivacy"
+            @connect-soundcloud="connectSoundCloud"
+            @reconnect-soundcloud="disconnectAndReconnectSoundCloud"
+          />
+        </template>
+      </component>
 
       <div v-if="isUnheard" class="top-grid">
         <div class="main-column">
@@ -1397,8 +1467,8 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Live Recording (streamed shows, any type) -->
-      <div v-if="latestRecording && recordingState" class="card">
+      <!-- Live Recording (UNHEARD only; external shows surface it in WrapUpPanel) -->
+      <div v-if="isUnheard && latestRecording && recordingState" class="card">
         <h2 class="section-title">Live Recording</h2>
         <div class="live-recording-head">
           <span :class="['rec-badge', recordingState]">
@@ -1427,86 +1497,6 @@ onUnmounted(() => {
             </a>
           </div>
         </template>
-      </div>
-
-      <!-- SoundCloud (non-UNHEARD shows; UNHEARD has its own in the recording card) -->
-      <div v-if="canUseSoundcloud && scStatus && !isUnheard" class="card">
-        <h2 class="section-title">SoundCloud</h2>
-        <div class="soundcloud-section">
-          <template v-if="!scStatus.configured">
-            <p class="empty-state">
-              SoundCloud isn't configured. Set SOUNDCLOUD_CLIENT_ID / SOUNDCLOUD_CLIENT_SECRET.
-            </p>
-          </template>
-          <template v-else-if="!scStatus.authorized">
-            <p class="text-muted soundcloud-hint">
-              Connect the station's SoundCloud account to enable uploads.
-            </p>
-            <BaseButton size="sm" variant="primary" @click="connectSoundCloud">
-              🔗 Connect SoundCloud
-            </BaseButton>
-          </template>
-          <template v-else-if="show.soundcloud_url">
-            <div class="soundcloud-status">
-              <span class="soundcloud-label">☁️ SoundCloud</span>
-              <a :href="show.soundcloud_url" target="_blank" rel="noopener" class="soundcloud-link">
-                {{ show.soundcloud_public ? '🔓 Public' : '🔒 Private' }}
-              </a>
-              <span v-if="show.soundcloud_uploaded_at" class="text-muted soundcloud-timestamp">
-                Uploaded {{ show.soundcloud_uploaded_at }}
-              </span>
-            </div>
-            <div class="soundcloud-actions">
-              <BaseButton
-                size="sm"
-                :variant="show.soundcloud_public ? 'ghost' : 'success'"
-                :loading="togglingSoundCloudPrivacy"
-                @click="toggleSoundCloudPrivacy"
-              >
-                {{ show.soundcloud_public ? 'Make Private' : 'Make Public' }}
-              </BaseButton>
-              <BaseButton
-                size="sm"
-                variant="ghost"
-                :loading="uploadingToSoundCloud"
-                @click="uploadToSoundCloud"
-              >
-                Re-upload
-              </BaseButton>
-              <BaseButton
-                v-if="scStatus.auth_url"
-                size="sm"
-                variant="ghost"
-                @click="disconnectAndReconnectSoundCloud"
-              >
-                🔗 Reconnect
-              </BaseButton>
-            </div>
-          </template>
-          <template v-else>
-            <p class="text-muted soundcloud-hint">
-              Finalized recordings upload here automatically. You can also upload now.
-            </p>
-            <div class="soundcloud-actions">
-              <BaseButton
-                size="sm"
-                variant="ghost"
-                :loading="uploadingToSoundCloud"
-                @click="uploadToSoundCloud"
-              >
-                ☁️ Upload to SoundCloud
-              </BaseButton>
-              <BaseButton
-                v-if="scStatus.auth_url"
-                size="sm"
-                variant="ghost"
-                @click="disconnectAndReconnectSoundCloud"
-              >
-                🔗 Reconnect
-              </BaseButton>
-            </div>
-          </template>
-        </div>
       </div>
 
       <!-- Assigned Artists Section (UNHEARD only, admin only) -->
@@ -1776,8 +1766,33 @@ onUnmounted(() => {
 
 .dash-header-actions {
   display: flex;
+  align-items: center;
   gap: var(--spacing-sm);
   flex: 0 0 auto;
+}
+
+.layout-toggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.layout-chip {
+  padding: 4px 12px;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+
+.layout-chip.active {
+  background: var(--color-primary);
+  color: var(--color-bg);
 }
 
 .dash-grid {

--- a/frontend/src/admin/pages/show-cockpit/CockpitShell.vue
+++ b/frontend/src/admin/pages/show-cockpit/CockpitShell.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import type { ShowPhase } from '../../composables/useShowPhase';
+
+/**
+ * Phase-aware "cockpit" dashboard shell — one of the two layouts under A/B
+ * (docs/stream-rework/show-cockpit-plan.md). Pure presentation: renders the
+ * banner plus all panel slots in a single scroll, grouped under soft-phase
+ * headers, emphasising the current phase and auto-scrolling to it. Nothing is
+ * locked — every group stays visible and interactive. All data/handlers live
+ * on ShowDetailPage.
+ *
+ * Slots: banner, identity, schedule, media, promotion, wrapup.
+ */
+const props = defineProps<{
+  phase: ShowPhase;
+  /** Hide promotion + wrap-up groups (e.g. for guests). */
+  hideAftershow?: boolean;
+}>();
+
+const RAIL: { key: ShowPhase; label: string }[] = [
+  { key: 'prep', label: 'Prep' },
+  { key: 'broadcast', label: 'Broadcast' },
+  { key: 'wrapup', label: 'Wrap-up' },
+];
+
+const rail = computed(() => (props.hideAftershow ? RAIL.slice(0, 2) : RAIL));
+const currentIndex = computed(() => RAIL.findIndex((r) => r.key === props.phase));
+
+const prepGroup = ref<HTMLElement | null>(null);
+const broadcastGroup = ref<HTMLElement | null>(null);
+const wrapupGroup = ref<HTMLElement | null>(null);
+
+function groupEl(phase: ShowPhase): HTMLElement | null {
+  if (phase === 'prep') return prepGroup.value;
+  if (phase === 'broadcast') return broadcastGroup.value;
+  return wrapupGroup.value;
+}
+
+function scrollToPhase(phase: ShowPhase) {
+  groupEl(phase)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// Bring the current phase into view on load and whenever it advances, so the
+// host lands on what matters now without losing access to the rest.
+onMounted(() => nextTick(() => groupEl(props.phase)?.scrollIntoView({ block: 'start' })));
+watch(
+  () => props.phase,
+  (p) => nextTick(() => scrollToPhase(p))
+);
+</script>
+
+<template>
+  <div class="cockpit-shell">
+    <slot name="banner" />
+
+    <!-- Phase rail -->
+    <nav class="phase-rail" aria-label="Show phase">
+      <button
+        v-for="(step, i) in rail"
+        :key="step.key"
+        type="button"
+        :class="[
+          'rail-step',
+          { active: step.key === phase, done: i < currentIndex },
+        ]"
+        @click="scrollToPhase(step.key)"
+      >
+        <span class="rail-dot"></span>
+        <span class="rail-label">{{ step.label }}</span>
+      </button>
+    </nav>
+
+    <!-- PREP -->
+    <section ref="prepGroup" :class="['phase-group', { current: phase === 'prep' }]">
+      <p class="phase-heading">Prep</p>
+      <slot name="identity" />
+      <slot name="schedule" />
+      <template v-if="!hideAftershow">
+        <slot name="promotion" />
+      </template>
+    </section>
+
+    <!-- BROADCAST -->
+    <section ref="broadcastGroup" :class="['phase-group', { current: phase === 'broadcast' }]">
+      <p class="phase-heading">Broadcast</p>
+      <slot name="media" />
+    </section>
+
+    <!-- WRAP-UP -->
+    <section
+      v-if="!hideAftershow"
+      ref="wrapupGroup"
+      :class="['phase-group', { current: phase === 'wrapup' }]"
+    >
+      <p class="phase-heading">Wrap-up</p>
+      <slot name="wrapup" />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.cockpit-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.phase-rail {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding: var(--spacing-sm) 0;
+  background: var(--color-bg);
+}
+
+.rail-step {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 4px 10px;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.rail-step:not(:last-child)::after {
+  content: '';
+  width: 24px;
+  height: 1px;
+  background: var(--color-border);
+  margin-left: var(--spacing-xs);
+}
+
+.rail-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--color-border);
+}
+
+.rail-step.done .rail-dot {
+  background: var(--color-success);
+  border-color: var(--color-success);
+}
+
+.rail-step.active {
+  color: var(--color-primary);
+}
+
+.rail-step.active .rail-dot {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.phase-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding-left: var(--spacing-md);
+  border-left: 3px solid transparent;
+  opacity: 0.6;
+  transition: opacity var(--transition-fast), border-color var(--transition-fast);
+  scroll-margin-top: 60px;
+}
+
+.phase-group.current {
+  opacity: 1;
+  border-left-color: var(--color-primary);
+}
+
+.phase-heading {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/admin/pages/show-cockpit/TabbedShell.vue
+++ b/frontend/src/admin/pages/show-cockpit/TabbedShell.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import type { ShowPhase } from '../../composables/useShowPhase';
+
+/**
+ * Tabbed dashboard shell — one of the two layouts under A/B
+ * (docs/stream-rework/show-cockpit-plan.md). Pure presentation: it arranges
+ * the panels passed via named slots into tabs, and picks a default tab from
+ * the show's soft phase. All data/handlers live on ShowDetailPage.
+ *
+ * Slots: banner, identity, schedule, media, promotion, wrapup.
+ */
+const props = defineProps<{
+  phase: ShowPhase;
+  /** Hide promotion + wrap-up tabs (e.g. for guests). */
+  hideAftershow?: boolean;
+}>();
+
+type TabKey = 'details' | 'broadcast' | 'promotion' | 'wrapup';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'details', label: 'Details' },
+  { key: 'broadcast', label: 'Broadcast' },
+  { key: 'promotion', label: 'Promotion' },
+  { key: 'wrapup', label: 'Wrap-up' },
+];
+
+/** Which tab a phase opens on by default. */
+const PHASE_TAB: Record<ShowPhase, TabKey> = {
+  prep: 'details',
+  broadcast: 'broadcast',
+  wrapup: 'wrapup',
+};
+
+const active = ref<TabKey>(PHASE_TAB[props.phase]);
+
+// Only re-sync the active tab when the phase actually changes (not on every
+// unrelated re-render), so a user's manual tab choice isn't yanked away.
+watch(
+  () => props.phase,
+  (p) => {
+    if (props.hideAftershow && (PHASE_TAB[p] === 'promotion' || PHASE_TAB[p] === 'wrapup')) {
+      active.value = 'details';
+    } else {
+      active.value = PHASE_TAB[p];
+    }
+  }
+);
+
+const visibleTabs = () =>
+  props.hideAftershow ? TABS.filter((t) => t.key === 'details' || t.key === 'broadcast') : TABS;
+</script>
+
+<template>
+  <div class="tabbed-shell">
+    <div class="tab-bar" role="tablist">
+      <button
+        v-for="t in visibleTabs()"
+        :key="t.key"
+        type="button"
+        role="tab"
+        :aria-selected="active === t.key"
+        :class="['tab', { active: active === t.key }]"
+        @click="active = t.key"
+      >
+        {{ t.label }}
+      </button>
+    </div>
+
+    <div class="tab-panel" role="tabpanel">
+      <template v-if="active === 'details'">
+        <slot name="identity" />
+        <slot name="schedule" />
+      </template>
+
+      <template v-else-if="active === 'broadcast'">
+        <slot name="banner" />
+        <slot name="media" />
+      </template>
+
+      <template v-else-if="active === 'promotion'">
+        <slot name="promotion" />
+      </template>
+
+      <template v-else-if="active === 'wrapup'">
+        <slot name="wrapup" />
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tab-bar {
+  display: flex;
+  gap: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--spacing-lg);
+  overflow-x: auto;
+}
+
+.tab {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab:hover {
+  color: var(--color-text);
+}
+
+.tab.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+</style>

--- a/frontend/src/admin/pages/show-cockpit/index.ts
+++ b/frontend/src/admin/pages/show-cockpit/index.ts
@@ -1,0 +1,10 @@
+/**
+ * The two dashboard shells under A/B (docs/stream-rework/show-cockpit-plan.md).
+ * Both consume the same named slots (banner, identity, schedule, media,
+ * promotion, wrapup) + a `phase` prop; ShowDetailPage picks between them via
+ * the `?layout=` query. One is deleted once the A/B is decided (plan PR 6).
+ */
+export { default as CockpitShell } from './CockpitShell.vue';
+export { default as TabbedShell } from './TabbedShell.vue';
+
+export type ShellLayout = 'cockpit' | 'tabs';


### PR DESCRIPTION
## What — PR 2 of the show-cockpit plan

**Stacked on #268** (base `refactor/show-panels`). This is the deliverable you asked to see: the two dashboard layouts you can flip between on `/shows/:id`.

One route, two swappable shells over the shared panels from PR 1, chosen via `?layout=cockpit|tabs` (persisted to localStorage, **Cockpit / Tabs toggle in the header**):

- **`CockpitShell`** — sticky phase rail (Prep → Broadcast → Wrap-up) + all panels in one scroll, grouped under phase headers; the current phase is emphasised (accent left border, others dimmed) and auto-scrolled into view.
- **`TabbedShell`** — Details / Broadcast / Promotion / Wrap-up tabs; default tab derived from the show's phase, all tabs stay clickable.
- Both are **pure presentation** — they arrange named slots (`banner`, `identity`, `schedule`, `media`, `promotion`, `wrapup`) + a `phase` prop. All state/handlers stay on `ShowDetailPage`; `useShowPhase` (PR 1) drives the phase. Slot-based → zero prop-drilling through the shells.
- **`WrapUpPanel`** — Live Recording + SoundCloud publish, extracted verbatim. The shared Live Recording card is now gated to `isUnheard` (UNHEARD keeps its own); the external SoundCloud card moved into the panel.
- **Soft phases** — nothing is locked; every panel reachable in both shells.
- **Guests** — trimmed view (`hide-aftershow`): no promotion / wrap-up.

UNHEARD branch untouched.

## Try it

```
# on branch feat/cockpit-shells
cd backend && cargo run     # terminal 1
cd frontend && npm run dev  # terminal 2
```
Open an **external** show → use the **Cockpit / Tabs** toggle top-right. `?layout=` is also shareable in the URL.

## Verification

- vitest **76/76** · `vite build` ✓ · `detect_changes` low-risk, 0 flows
- `tsc`: +7 `TS2307 .vue module` noise lines from the two new barrels (same pre-existing class as `shared/components/index.ts`)
- ⚠️ **Manual check requested:** click through both layouts on an external show (view + edit + Save + Go-live handoff); confirm the guest-trimmed view. I couldn't drive the full stack in-session.

## Open item to confirm (from the plan)

Guest gating currently = hide promotion + wrap-up, Identity/Schedule still editable if the guest is the assigned host. The plan floated 'read-only Identity/Schedule for guests' — flag if you want that tighter.

## Next

PR 3: `scheduled_announcements` table + admin policy config (backend).