### PR TITLE
feat(dashboard): air time as start + duration; persist show duration

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -834,6 +834,28 @@ pub async fn update_recording_version_status(
     Ok(())
 }
 
+/// Store the probed duration (ms) on a recording version. Best-effort, called
+/// after finalize so the dashboard can render the show length — including for
+/// `failed`/short captures, whose length is the whole point of the alert.
+pub async fn set_recording_duration(
+    pool: &SqlitePool,
+    id: i64,
+    duration_ms: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE recording_versions
+        SET duration_ms = ?, updated_at = datetime('now')
+        WHERE id = ?
+        "#,
+    )
+    .bind(duration_ms)
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Mark a recording version as finalized
 pub async fn finalize_recording_version(
     pool: &SqlitePool,

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -514,6 +514,15 @@ async fn upload_artifact_and_record(
         }
     };
 
+    // Persist the probed duration (best-effort) so the dashboard can show the
+    // show length — including for `failed`/short captures, whose length is
+    // exactly what the "essentially empty" alert is about.
+    if let (Some(rid), Some(ms)) = (recording_id, local_duration_ms) {
+        if let Err(e) = crate::db::set_recording_duration(&state.db, rid, ms as i64).await {
+            tracing::warn!("Failed to store duration for recording {}: {}", rid, e);
+        }
+    }
+
     // Auto-publish the streamed broadcast to the curated shows archive
     // (moafunk-prod/shows/{type}/{date}-{title}/…mp3). Best-effort convenience
     // copy — any failure is logged but never fails the recording (the raw capture

--- a/frontend/src/admin/components/DurationField.vue
+++ b/frontend/src/admin/components/DurationField.vue
@@ -14,14 +14,15 @@ const emit = defineEmits<{
   'update:modelValue': [value: number];
 }>();
 
-const PRESETS = [30, 45, 60, 75, 90, 105, 120, 150, 180, 210, 240];
+const PRESETS = [30, 60, 90, 120, 180, 240, 300, 360, 420, 480, 540, 720];
 
 function label(min: number): string {
+  // Clean half-hour steps read as decimal hours (0.5h, 1.5h, 2h); anything
+  // off-grid (an injected loaded value) falls back to "Xh Ym".
+  if (min % 30 === 0) return `${min / 60}h`;
   const h = Math.floor(min / 60);
   const m = min % 60;
-  if (h && m) return `${h}h ${m}m`;
-  if (h) return `${h}h`;
-  return `${m}m`;
+  return h ? `${h}h ${m}m` : `${m}m`;
 }
 
 /** Presets plus the current value if it isn't one, so any loaded show fits. */

--- a/frontend/src/admin/components/DurationField.vue
+++ b/frontend/src/admin/components/DurationField.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+/**
+ * Show-length picker (minutes). Presets cover typical radio slots; a show
+ * loaded with an off-preset length has that value injected so it round-trips.
+ */
+const props = defineProps<{
+  /** Current duration in minutes. */
+  modelValue: number;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number];
+}>();
+
+const PRESETS = [30, 45, 60, 75, 90, 105, 120, 150, 180, 210, 240];
+
+function label(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+/** Presets plus the current value if it isn't one, so any loaded show fits. */
+const options = computed(() => {
+  const mins = PRESETS.includes(props.modelValue)
+    ? PRESETS
+    : [...PRESETS, props.modelValue].sort((a, b) => a - b);
+  return mins.map((m) => ({ value: m, text: label(m) }));
+});
+</script>
+
+<template>
+  <select
+    class="duration-select"
+    :value="modelValue"
+    @change="emit('update:modelValue', Number(($event.target as HTMLSelectElement).value))"
+  >
+    <option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.text }}</option>
+  </select>
+</template>
+
+<style scoped>
+.duration-select {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: 1em;
+}
+
+.duration-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+</style>

--- a/frontend/src/admin/components/show-cockpit/panels/LiveCard.vue
+++ b/frontend/src/admin/components/show-cockpit/panels/LiveCard.vue
@@ -79,10 +79,26 @@ const elapsed = computed(() =>
   props.airTarget ? fmtDuration(now.value - props.airTarget.getTime()) : '—'
 );
 
-/** Duration of the finished show — recording length if known, else scheduled length. */
+/** "HH:MM:SS" clock — used for the finished-show duration. */
+function fmtClock(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+/**
+ * Duration of the finished show. Prefers the recording's stored length; for
+ * legacy rows that predate duration persistence, a failed short capture still
+ * carries its length in the reason string ("… is only 3s …").
+ */
 const duration = computed(() => {
   const rec = props.latestRecording?.duration_ms;
-  if (rec) return fmtDuration(rec);
+  if (rec) return fmtClock(rec);
+  const shortMatch = props.latestRecording?.error_message?.match(/only (\d+)s/);
+  if (shortMatch) return fmtClock(Number(shortMatch[1]) * 1000);
   return '—';
 });
 

--- a/frontend/src/admin/components/show-cockpit/panels/ScheduleHostPanel.vue
+++ b/frontend/src/admin/components/show-cockpit/panels/ScheduleHostPanel.vue
@@ -4,6 +4,7 @@ import type { GuestCredentials, ShowDetail } from '../../../api';
 import { BaseButton } from '@shared/components';
 import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
+import DurationField from '../../DurationField.vue';
 
 /**
  * Air-date + assigned-host tile pair, extracted verbatim from ShowDetailPage's
@@ -23,9 +24,10 @@ const props = defineProps<{
   assigningHost: boolean;
   /** Credentials of a freshly created guest host (shown once). */
   guestCreds: GuestCredentials | null;
-  /** Datetime range editing state (from useDateTimeRange on the page). */
+  /** Datetime editing state (from useDateTimeRange on the page). */
   editStart: Date | null;
-  editEnd: Date | null;
+  /** Show length in minutes; the end is derived from start + duration. */
+  editDuration: number;
   editTimeValid: boolean;
   editTimeError: string | null;
   /** Host-assignment form state. */
@@ -36,7 +38,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:editStart': [value: Date | null];
-  'update:editEnd': [value: Date | null];
+  'update:editDuration': [value: number];
   'update:selectedHostId': [value: number | null];
   'update:hostEditMode': [value: 'existing' | 'guest'];
   'update:newGuestUsername': [value: string];
@@ -71,11 +73,24 @@ const airDateLabel = computed(() => {
   });
 });
 
+function durationLabel(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+/** Read-only air time as "start · duration" (duration inferred from start/end). */
 const airTimeRange = computed(() => {
-  if (!props.show.start_time) return '';
-  return props.show.end_time
-    ? `${props.show.start_time} – ${props.show.end_time}`
-    : props.show.start_time;
+  const start = props.show.start_time;
+  if (!start) return '';
+  if (!props.show.end_time) return start;
+  const [sh, sm] = start.split(':').map(Number);
+  const [eh, em] = props.show.end_time.split(':').map(Number);
+  let mins = eh * 60 + em - (sh * 60 + sm);
+  if (mins <= 0) mins += 24 * 60; // overnight
+  return `${start} · ${durationLabel(mins)}`;
 });
 </script>
 
@@ -92,7 +107,6 @@ const airTimeRange = computed(() => {
               :enable-time-picker="true"
               :dark="true"
               :minutes-increment="5"
-              :max-date="props.editEnd || undefined"
               :flow="{ steps: ['calendar', 'time'] }"
               :action-row="{
                 showCancel: false,
@@ -106,27 +120,14 @@ const airTimeRange = computed(() => {
             />
           </div>
           <div class="datetime-field">
-            <label class="form-label">End</label>
-            <VueDatePicker
-              :model-value="props.editEnd"
-              :enable-time-picker="true"
-              :dark="true"
-              :minutes-increment="5"
-              :min-date="props.editStart || undefined"
-              :flow="{ steps: ['calendar', 'time'] }"
-              :action-row="{
-                showCancel: false,
-                showPreview: false,
-                selectBtnLabel: 'Confirm',
-              }"
-              placeholder="End date & time"
-              text-input
-              teleport="body"
-              @update:model-value="emit('update:editEnd', $event)"
+            <label class="form-label">Duration</label>
+            <DurationField
+              :model-value="props.editDuration"
+              @update:model-value="emit('update:editDuration', $event)"
             />
           </div>
         </div>
-        <p v-if="props.editStart && props.editEnd && !props.editTimeValid" class="field-error">
+        <p v-if="props.editStart && !props.editTimeValid" class="field-error">
           {{ props.editTimeError }}
         </p>
       </template>

--- a/frontend/src/admin/components/show-wizard/WizardDate.vue
+++ b/frontend/src/admin/components/show-wizard/WizardDate.vue
@@ -3,9 +3,10 @@ import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
 import { useShowWizard } from '../../composables';
 import MonthCalendar from '../MonthCalendar.vue';
 import DayTimeline from './DayTimeline.vue';
+import DurationField from '../DurationField.vue';
 
 const wizard = useShowWizard();
-const { startDateTime, endDateTime, scheduledShows, conflictingShow } = wizard;
+const { startDateTime, endDateTime, durationMinutes, scheduledShows, conflictingShow } = wizard;
 
 // Match the timeline's height to the calendar's (which changes with 5/6-week
 // months) by measuring it live.
@@ -70,9 +71,9 @@ const endMinutes = computed(() =>
 function onDayClick(dateStr: string) {
   const [y, m, d] = dateStr.split('-').map(Number);
   const s = startDateTime.value;
-  const e = endDateTime.value;
+  // Move to the clicked day, preserving the start time (default 20:00). The
+  // duration — and thus the derived end — is left unchanged.
   startDateTime.value = new Date(y, m - 1, d, s ? s.getHours() : 20, s ? s.getMinutes() : 0);
-  endDateTime.value = new Date(y, m - 1, d, e ? e.getHours() : 22, e ? e.getMinutes() : 0);
 }
 
 /** Apply a window dragged/clicked on the timeline back onto the Date refs. */
@@ -82,25 +83,19 @@ function onTimelineUpdate({ start, end }: { start: number; end: number }) {
   endDateTime.value = new Date(dayBase.value + end * 60000);
 }
 
-function timeModel(target: 'start' | 'end') {
-  return computed<string>({
-    get() {
-      const d = target === 'start' ? startDateTime.value : endDateTime.value;
-      return d ? `${pad(d.getHours())}:${pad(d.getMinutes())}` : '';
-    },
-    set(value: string) {
-      if (!value || !selectedDateStr.value) return;
-      const [hh, mm] = value.split(':').map(Number);
-      const [y, m, d] = selectedDateStr.value.split('-').map(Number);
-      const next = new Date(y, m - 1, d, hh, mm);
-      if (target === 'start') startDateTime.value = next;
-      else endDateTime.value = next;
-    },
-  });
-}
-
-const startTime = timeModel('start');
-const endTime = timeModel('end');
+/** Start-time input (HH:MM); the end derives from start + duration. */
+const startTime = computed<string>({
+  get() {
+    const d = startDateTime.value;
+    return d ? `${pad(d.getHours())}:${pad(d.getMinutes())}` : '';
+  },
+  set(value: string) {
+    if (!value || !selectedDateStr.value) return;
+    const [hh, mm] = value.split(':').map(Number);
+    const [y, m, d] = selectedDateStr.value.split('-').map(Number);
+    startDateTime.value = new Date(y, m - 1, d, hh, mm);
+  },
+});
 </script>
 
 <template>
@@ -133,8 +128,8 @@ const endTime = timeModel('end');
           <input v-model="startTime" type="time" class="time-input" />
         </label>
         <label class="time-field">
-          <span>End</span>
-          <input v-model="endTime" type="time" class="time-input" />
+          <span>Duration</span>
+          <DurationField v-model="durationMinutes" />
         </label>
       </div>
       <p v-if="conflictingShow" class="field-error">

--- a/frontend/src/admin/composables/__tests__/useDateTimeRange.test.ts
+++ b/frontend/src/admin/composables/__tests__/useDateTimeRange.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { useDateTimeRange, DEFAULT_DURATION_MIN } from '../useDateTimeRange';
+
+describe('useDateTimeRange (start + duration)', () => {
+  it('defaults to the default duration and no start', () => {
+    const r = useDateTimeRange();
+    expect(r.durationMinutes.value).toBe(DEFAULT_DURATION_MIN);
+    expect(r.startDateTime.value).toBeNull();
+    expect(r.endDateTime.value).toBeNull();
+    expect(r.isValid.value).toBe(false);
+  });
+
+  it('derives the end and apiEndTime from start + duration', () => {
+    const r = useDateTimeRange();
+    r.startDateTime.value = new Date(2026, 5, 1, 20, 0);
+    r.setDuration(90);
+    expect(r.apiDate.value).toBe('2026-06-01');
+    expect(r.apiStartTime.value).toBe('20:00');
+    expect(r.apiEndTime.value).toBe('21:30');
+    expect(r.isValid.value).toBe(true);
+  });
+
+  it('keeps the duration fixed when the start moves', () => {
+    const r = useDateTimeRange();
+    r.startDateTime.value = new Date(2026, 5, 1, 20, 0);
+    r.setDuration(120);
+    // Push the start an hour later — the end should follow, length unchanged.
+    r.startDateTime.value = new Date(2026, 5, 1, 21, 0);
+    expect(r.durationMinutes.value).toBe(120);
+    expect(r.apiEndTime.value).toBe('23:00');
+  });
+
+  it('back-computes duration when the end is assigned directly', () => {
+    const r = useDateTimeRange();
+    r.startDateTime.value = new Date(2026, 5, 1, 20, 0);
+    r.endDateTime.value = new Date(2026, 5, 1, 22, 30);
+    expect(r.durationMinutes.value).toBe(150);
+  });
+
+  it('infers duration from an API start/end, wrapping overnight', () => {
+    const r = useDateTimeRange();
+    r.setFromApi('2026-06-01', '23:00', '01:00');
+    expect(r.durationMinutes.value).toBe(120);
+    expect(r.apiEndTime.value).toBe('01:00');
+    expect(r.isValid.value).toBe(true);
+  });
+
+  it('resets back to no start and the default duration', () => {
+    const r = useDateTimeRange();
+    r.setFromApi('2026-06-01', '20:00', '22:30');
+    r.reset();
+    expect(r.startDateTime.value).toBeNull();
+    expect(r.durationMinutes.value).toBe(DEFAULT_DURATION_MIN);
+  });
+});

--- a/frontend/src/admin/composables/useDateTimeRange.ts
+++ b/frontend/src/admin/composables/useDateTimeRange.ts
@@ -1,9 +1,16 @@
 import { ref, computed } from 'vue';
 
+/** Default show length when none is known yet (2 hours). */
+export const DEFAULT_DURATION_MIN = 120;
+
 /**
- * Composable to manage a start/end datetime range with validation.
- * Converts between Date objects (for the picker) and the API format
- * (date: YYYY-MM-DD, start_time: HH:MM, end_time: HH:MM).
+ * Composable to manage a show's air window as **start + duration**.
+ *
+ * Duration (minutes) is the source of truth; the end is derived
+ * (`end = start + duration`), so moving the start keeps the length fixed.
+ * Still converts to/from the API format (date: YYYY-MM-DD, start_time: HH:MM,
+ * end_time: HH:MM) — `apiEndTime` is computed from the derived end, so callers
+ * and the backend contract are unchanged.
  */
 export function useDateTimeRange(options?: {
   initialDate?: string;
@@ -11,22 +18,7 @@ export function useDateTimeRange(options?: {
   initialEndTime?: string;
 }) {
   const startDateTime = ref<Date | null>(null);
-  const endDateTime = ref<Date | null>(null);
-
-  // Initialize from API format if provided
-  if (options?.initialDate) {
-    const datePart = options.initialDate;
-    if (options.initialStartTime) {
-      startDateTime.value = parseDateTime(datePart, options.initialStartTime);
-    }
-    if (options.initialEndTime) {
-      endDateTime.value = parseDateTime(datePart, options.initialEndTime);
-      // If end is before or equal to start, assume next day
-      if (startDateTime.value && endDateTime.value && endDateTime.value <= startDateTime.value) {
-        endDateTime.value = new Date(endDateTime.value.getTime() + 24 * 60 * 60 * 1000);
-      }
-    }
-  }
+  const durationMinutes = ref<number>(DEFAULT_DURATION_MIN);
 
   /** Parse "YYYY-MM-DD" + "HH:MM" into a Date */
   function parseDateTime(date: string, time: string): Date {
@@ -50,65 +42,89 @@ export function useDateTimeRange(options?: {
     return `${hh}:${mm}`;
   }
 
-  /** Validation: start must be before end */
-  const isValid = computed(() => {
-    if (!startDateTime.value || !endDateTime.value) return false;
-    return startDateTime.value < endDateTime.value;
-  });
+  /**
+   * Minutes from `start` to `end`, wrapping past midnight: an end at or before
+   * the start is treated as the next day (overnight show).
+   */
+  function diffMinutes(start: Date, end: Date): number {
+    let ms = end.getTime() - start.getTime();
+    if (ms <= 0) ms += 24 * 60 * 60 * 1000;
+    return Math.round(ms / 60000);
+  }
 
-  const validationError = computed(() => {
-    if (!startDateTime.value || !endDateTime.value) return 'Both start and end are required';
-    if (startDateTime.value >= endDateTime.value) return 'Start must be before end';
-    return null;
-  });
-
-  /** API-ready values derived from the datetime pickers */
-  const apiDate = computed(() => {
-    if (!startDateTime.value) return '';
-    return formatDate(startDateTime.value);
-  });
-
-  const apiStartTime = computed(() => {
-    if (!startDateTime.value) return '';
-    return formatTime(startDateTime.value);
-  });
-
-  const apiEndTime = computed(() => {
-    if (!endDateTime.value) return '';
-    return formatTime(endDateTime.value);
-  });
-
-  /** Bulk set from API data */
-  function setFromApi(date: string, startTime?: string, endTime?: string) {
-    if (date && startTime) {
-      startDateTime.value = parseDateTime(date, startTime);
-    } else {
-      startDateTime.value = null;
-    }
-    if (date && endTime) {
-      endDateTime.value = parseDateTime(date, endTime);
-      if (startDateTime.value && endDateTime.value && endDateTime.value <= startDateTime.value) {
-        endDateTime.value = new Date(endDateTime.value.getTime() + 24 * 60 * 60 * 1000);
-      }
-    } else {
-      endDateTime.value = null;
+  // Initialize from API format if provided.
+  if (options?.initialDate && options.initialStartTime) {
+    startDateTime.value = parseDateTime(options.initialDate, options.initialStartTime);
+    if (options.initialEndTime) {
+      const end = parseDateTime(options.initialDate, options.initialEndTime);
+      durationMinutes.value = diffMinutes(startDateTime.value, end);
     }
   }
 
-  /** Reset both values */
+  /**
+   * The end of the window, derived from start + duration. Writable: assigning a
+   * Date back-computes the duration (used by the timeline drag + legacy pickers).
+   */
+  const endDateTime = computed<Date | null>({
+    get() {
+      if (!startDateTime.value) return null;
+      return new Date(startDateTime.value.getTime() + durationMinutes.value * 60000);
+    },
+    set(value: Date | null) {
+      if (!value || !startDateTime.value) return;
+      durationMinutes.value = diffMinutes(startDateTime.value, value);
+    },
+  });
+
+  /** Validation: a start must be set and the duration positive. */
+  const isValid = computed(() => !!startDateTime.value && durationMinutes.value > 0);
+
+  const validationError = computed(() => {
+    if (!startDateTime.value) return 'Start date & time is required';
+    if (durationMinutes.value <= 0) return 'Duration must be greater than zero';
+    return null;
+  });
+
+  /** API-ready values derived from the start + duration. */
+  const apiDate = computed(() => (startDateTime.value ? formatDate(startDateTime.value) : ''));
+
+  const apiStartTime = computed(() => (startDateTime.value ? formatTime(startDateTime.value) : ''));
+
+  const apiEndTime = computed(() => (endDateTime.value ? formatTime(endDateTime.value) : ''));
+
+  /** Set the show length in minutes (clamped to a non-negative whole number). */
+  function setDuration(minutes: number) {
+    durationMinutes.value = Math.max(0, Math.round(minutes));
+  }
+
+  /** Bulk set from API data. Duration is inferred from start/end. */
+  function setFromApi(date: string, startTime?: string, endTime?: string) {
+    if (date && startTime) {
+      startDateTime.value = parseDateTime(date, startTime);
+      if (endTime) {
+        durationMinutes.value = diffMinutes(startDateTime.value, parseDateTime(date, endTime));
+      }
+    } else {
+      startDateTime.value = null;
+    }
+  }
+
+  /** Reset to no start and the default duration. */
   function reset() {
     startDateTime.value = null;
-    endDateTime.value = null;
+    durationMinutes.value = DEFAULT_DURATION_MIN;
   }
 
   return {
     startDateTime,
     endDateTime,
+    durationMinutes,
     isValid,
     validationError,
     apiDate,
     apiStartTime,
     apiEndTime,
+    setDuration,
     setFromApi,
     reset,
   };

--- a/frontend/src/admin/composables/useShowWizard.ts
+++ b/frontend/src/admin/composables/useShowWizard.ts
@@ -397,6 +397,7 @@ export function useShowWizard() {
     coverPreviewUrl: readonly(coverPreviewUrl),
     startDateTime: range.startDateTime,
     endDateTime: range.endDateTime,
+    durationMinutes: range.durationMinutes,
     rangeValid: range.isValid,
     rangeError: range.validationError,
     scheduledShows: readonly(scheduledShows),

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -79,6 +79,7 @@ const endTimeForm = ref('');
 const {
   startDateTime: editStart,
   endDateTime: editEnd,
+  durationMinutes: editDuration,
   isValid: editTimeValid,
   validationError: editTimeError,
   apiDate: editDate,
@@ -1019,7 +1020,7 @@ onUnmounted(() => {
         <template #schedule>
           <ScheduleHostPanel
             v-model:edit-start="editStart"
-            v-model:edit-end="editEnd"
+            v-model:edit-duration="editDuration"
             v-model:selected-host-id="selectedHostId"
             v-model:host-edit-mode="hostEditMode"
             v-model:new-guest-username="newGuestUsername"


### PR DESCRIPTION
Enter a show's air window as **start + duration** (end computed behind the scenes, API contract unchanged) in both the creation wizard and the detail-page schedule editor. Duration presets 0.5h–12h.

Also fixes the finished-show duration: `recording_versions.duration_ms` was never persisted, so 'Show duration' always rendered a dash — now stored at finalize (incl. failed/short captures) and shown as HH:MM:SS, with a fallback that recovers a failed short capture's length from its reason string.

Tests: +6 useDateTimeRange cases; cargo/vite/lint green.