### PR TITLE
feat(admin_dashboard): show dashboard redesign + live panel restyle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ GitNexus clusters: Handlers (backend), Pages / Composables / Components (Vue adm
 - **Commits**: Conventional Commits with scope — `feat(stream): …`, `fix(imgGen): …`. Subject ≤ 72 chars, imperative. Use `/git.commit`.
 - **Branches**: never commit on `main` — branch first (`/git.branch` or `git switch -c <type>/<slug>`). Enforced by `branch-guard.sh`.
 - **Merging is PR-only.** Never `git merge <ref>` locally — open a PR (`/git.pr`) and squash-merge (`gh pr merge --squash --delete-branch`). Enforced by `merge-guard.sh`.
-- **Issues**: one ticket → `/project.issue "<task>"`; a big task → the `decompose-issue` workflow. Label taxonomy: exactly one `type::backend` / `type::admin_dashboard`, plus the most specific `project::*` (Stream, recording, Instagram, Telegram, Soundcloud, ImgGen, Upload, Backup, Infrastructure, ExternalShows, Ai, unheard-artist-form, UNHEARD).
+- **Issues**: one ticket → `/project.issue "<task>"`; a big task → the `decompose-issue` workflow. **Labels:** one or more `type::*` (layer) — `backend` / `frontend` / `ci` — plus the most specific `project::*` (area): `Stream`, `recording`, `Instagram`, `Telegram`, `Soundcloud`, `ImgGen`, `Upload`, `Backup`, `Infrastructure`, `ExternalShows`, `Ai`, `unheard-artist-form`, `UNHEARD`, `auth`, `calendar`, `public-pages`, `downloads`, `admin_dashboard`. Use `later` for deferred/backlog items. **Milestones** are the epics: *Webbased Streaming*, *Webbased Recording (UNHEARD)*, *UNHEARD User Story*, *External Shows User Story*, *Infrastructure & Secrets*, *Public Website*.
 - **GitNexus-first**: before grepping, query the graph (see the managed block below). Impact-analyse before editing a symbol; `detect_changes` before committing.
 
 ## GitNexus index — fresh & clean (how it works here)

--- a/docs/stream-rework/live-panel-2.0-prototype.html
+++ b/docs/stream-rework/live-panel-2.0-prototype.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Live Panel 2.0 — interactive prototype</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.30.0/dist/tabler-icons.min.css" />
+<style>
+  /* Dark-theme tokens mapped from frontend/src/shared/styles/tokens.css */
+  :root {
+    --surface-0: #000;
+    --surface-1: #1a1a2e;
+    --surface-2: #0f0f23;
+    --border: #333;
+    --border-strong: #444;
+    --border-stronger: #555;
+    --text-primary: #eee;
+    --text-secondary: #9a9ab0;
+    --text-muted: #777;
+    --text-accent: #3b82f6;
+    --text-danger: #ef4444;
+    --text-success: #22c55e;
+    --text-warning: #f59e0b;
+    --bg-accent: rgba(59, 130, 246, 0.15);
+    --bg-danger: #3b1818;
+    --bg-success: #183b18;
+    --bg-warning: #3b2f18;
+    --fill-danger: #ef4444;
+    --fill-success: #22c55e;
+    --fill-primary: #eee;
+    --on-danger: #fff;
+    --font-mono: 'Courier New', Courier, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 2rem 1rem 4rem;
+    background: var(--surface-0);
+    color: var(--text-primary);
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+  }
+  .wrap { max-width: 720px; margin: 0 auto; }
+  .note { font-size: 12px; color: var(--text-muted); margin: 0 0 1rem; }
+  button {
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 13px;
+    padding: 6px 12px;
+    cursor: pointer;
+  }
+  button:hover { background: var(--surface-1); }
+  input[type='text'] {
+    background: var(--surface-1);
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 13px;
+    padding: 7px 10px;
+  }
+  input[type='range'] { accent-color: #ffec44; }
+  input[type='checkbox'] { accent-color: #ffec44; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="note">Live Panel 2.0 prototype (design session 2026-07-06) — everything animates:
+  faders shape the analyzers, "Simulate congestion" drives the verdict &amp; auto bitrate
+  step-down, timers tick, chat input posts as host. Spec: <code>live-panel-2.0.md</code></p>
+
+  <div style="background:var(--surface-2); border:1px solid var(--border); border-radius:12px; overflow:hidden; margin-bottom:12px;">
+    <div style="display:flex; align-items:center; gap:10px; padding:10px 16px; flex-wrap:wrap;">
+      <span style="width:10px; height:10px; border-radius:50%; background:var(--fill-danger); flex-shrink:0;" id="liveDot"></span>
+      <span style="font-size:14px; font-weight:500; color:var(--text-danger); letter-spacing:1px;">LIVE</span>
+      <span style="font-size:12px; padding:2px 10px; border-radius:999px; background:var(--bg-danger); color:var(--text-danger);">REC <span id="recT" style="font-family:var(--font-mono);">42:13</span></span>
+      <span style="font-size:12px; color:var(--text-secondary);"><i class="ti ti-users"></i> 23</span>
+      <span style="flex:1;"></span>
+      <span style="font-size:12px; color:var(--text-secondary);">On air</span>
+      <span style="font-size:17px; font-family:var(--font-mono);" id="elapsed">0:42:13</span>
+      <span style="color:var(--border-stronger);">·</span>
+      <span style="font-size:12px; color:var(--text-secondary);">Ends in</span>
+      <span style="font-size:17px; font-family:var(--font-mono);" id="remaining">1:17:47</span>
+      <button style="padding:5px 8px;" aria-label="Reconnect stream" title="Reconnect stream"><i class="ti ti-refresh"></i></button>
+      <button style="padding:5px 8px;" aria-label="Stream settings" title="Stop and change settings"><i class="ti ti-settings"></i></button>
+      <button style="background:var(--fill-danger); color:var(--on-danger); border:none;"><i class="ti ti-player-stop"></i> Stop</button>
+    </div>
+    <div style="height:4px; background:var(--surface-1);">
+      <div id="progress" style="width:35%; height:4px; background:var(--fill-danger);"></div>
+    </div>
+  </div>
+
+  <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:12px; margin-bottom:12px;">
+    <div style="background:var(--surface-2); border:1px solid var(--border); border-radius:12px; padding:1rem 1.25rem;">
+      <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:10px;">
+        <p style="margin:0; font-size:13px; font-weight:500; color:var(--text-secondary);"><i class="ti ti-microphone"></i> Input — your source</p>
+        <span style="font-size:11px; font-family:var(--font-mono); color:var(--text-muted);" id="inPeak">-8.2 dB</span>
+      </div>
+      <div id="eqIn" style="display:flex; align-items:flex-end; gap:2px; height:56px;" role="img" aria-label="Input spectrum analyzer"></div>
+      <div style="display:flex; align-items:center; gap:10px; margin-top:12px;">
+        <label for="gainIn" style="font-size:12px; color:var(--text-secondary); white-space:nowrap;">Input gain</label>
+        <input id="gainIn" type="range" min="0" max="150" value="100" step="1" style="flex:1;" />
+        <span style="font-size:12px; font-family:var(--font-mono); min-width:38px; text-align:right;" id="gainInVal">100%</span>
+      </div>
+    </div>
+
+    <div style="background:var(--surface-2); border:1px solid var(--border); border-radius:12px; padding:1rem 1.25rem;">
+      <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:10px;">
+        <p style="margin:0; font-size:13px; font-weight:500; color:var(--text-secondary);"><i class="ti ti-broadcast"></i> Stream — what listeners hear</p>
+        <span style="font-size:11px; color:var(--text-muted);">~6 s behind</span>
+      </div>
+      <div id="eqOut" style="display:flex; align-items:flex-end; gap:2px; height:56px;" role="img" aria-label="Stream spectrum analyzer"></div>
+      <div style="display:flex; align-items:center; gap:10px; margin-top:12px;">
+        <label for="volMon" style="font-size:12px; color:var(--text-secondary); white-space:nowrap;"><i class="ti ti-headphones"></i> Monitor</label>
+        <input id="volMon" type="range" min="0" max="100" value="70" step="1" style="flex:1;" />
+        <span style="font-size:12px; font-family:var(--font-mono); min-width:38px; text-align:right;" id="volMonVal">70%</span>
+      </div>
+    </div>
+  </div>
+
+  <div style="background:var(--surface-2); border:1px solid var(--border); border-radius:12px; padding:1rem 1.25rem; margin-bottom:12px;">
+    <div style="display:flex; align-items:center; gap:10px; margin-bottom:12px;">
+      <p style="margin:0; flex:1; font-size:13px; font-weight:500; color:var(--text-secondary);"><i class="ti ti-wifi"></i> Connection &amp; upload</p>
+      <span id="verdict" style="font-size:12px; padding:2px 10px; border-radius:999px; background:var(--bg-success); color:var(--text-success);">Good — 4.1× headroom</span>
+      <button id="simBtn" style="font-size:11px; padding:3px 8px;">Simulate congestion</button>
+    </div>
+
+    <div style="display:grid; grid-template-columns:2fr 1fr; gap:14px; align-items:stretch;">
+      <div>
+        <canvas id="tpChart" width="420" height="96" style="width:100%; height:96px; display:block;"></canvas>
+        <div style="display:flex; justify-content:space-between; margin-top:2px;">
+          <span style="font-size:10px; color:var(--text-muted); font-family:var(--font-mono);">-60 s</span>
+          <span style="font-size:11px; color:var(--text-muted);"><span style="display:inline-block; width:12px; height:2px; background:#1D9E75; vertical-align:middle; margin-right:4px;"></span>upload · <span style="display:inline-block; width:12px; border-top:2px dashed #D85A30; vertical-align:middle; margin:0 4px 3px;"></span>needed</span>
+          <span style="font-size:10px; color:var(--text-muted); font-family:var(--font-mono);">now</span>
+        </div>
+      </div>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px; align-content:start;">
+        <div style="background:var(--surface-1); border-radius:8px; padding:6px 10px;">
+          <p style="margin:0; font-size:10px; color:var(--text-secondary);">Upload</p>
+          <p style="margin:1px 0 0; font-size:14px; font-weight:500; font-family:var(--font-mono);" id="mRate">812k</p>
+        </div>
+        <div style="background:var(--surface-1); border-radius:8px; padding:6px 10px;">
+          <p style="margin:0; font-size:10px; color:var(--text-secondary);">Buffer</p>
+          <p style="margin:1px 0 0; font-size:14px; font-weight:500; font-family:var(--font-mono);" id="mBuf">0.2 s</p>
+        </div>
+        <div style="background:var(--surface-1); border-radius:8px; padding:6px 10px;">
+          <p style="margin:0; font-size:10px; color:var(--text-secondary);">RTT</p>
+          <p style="margin:1px 0 0; font-size:14px; font-weight:500; font-family:var(--font-mono);" id="mRtt">38 ms</p>
+        </div>
+        <div style="background:var(--surface-1); border-radius:8px; padding:6px 10px;">
+          <p style="margin:0; font-size:10px; color:var(--text-secondary);">Late</p>
+          <p style="margin:1px 0 0; font-size:14px; font-weight:500; font-family:var(--font-mono);" id="mDrop">0</p>
+        </div>
+      </div>
+    </div>
+
+    <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap; border-top:1px solid var(--border); padding-top:12px; margin-top:12px;">
+      <span style="font-size:12px; color:var(--text-secondary); white-space:nowrap;">Upload quality</span>
+      <div id="qSeg" style="display:inline-flex; border:1px solid var(--border-strong); border-radius:8px; overflow:hidden;">
+        <button data-q="auto" style="border:none; border-radius:0; font-size:12px; padding:5px 12px; background:var(--bg-accent); color:var(--text-accent);">Auto</button>
+        <button data-q="320" style="border:none; border-radius:0; font-size:12px; padding:5px 12px; background:transparent; color:var(--text-secondary);">320</button>
+        <button data-q="192" style="border:none; border-radius:0; font-size:12px; padding:5px 12px; background:transparent; color:var(--text-secondary);">192</button>
+        <button data-q="128" style="border:none; border-radius:0; font-size:12px; padding:5px 12px; background:transparent; color:var(--text-secondary);">128</button>
+        <button data-q="96" style="border:none; border-radius:0; font-size:12px; padding:5px 12px; background:transparent; color:var(--text-secondary);">96 kbps</button>
+      </div>
+      <span id="qNote" style="flex:1; min-width:150px; font-size:11px; color:var(--text-muted);">Auto steps down when the buffer grows · switch = &lt;1 s encoder restart, covered by the relay</span>
+    </div>
+  </div>
+
+  <div style="background:var(--surface-2); border:1px solid var(--border); border-radius:12px; display:flex; flex-direction:column; overflow:hidden;">
+    <div style="display:flex; align-items:center; gap:8px; padding:10px 16px; border-bottom:1px solid var(--border);">
+      <i class="ti ti-brand-telegram" style="font-size:16px; color:var(--text-accent);"></i>
+      <p style="margin:0; flex:1; font-size:13px; font-weight:500;">Live chat · Moafunk channel</p>
+      <span style="font-size:11px; padding:2px 8px; border-radius:999px; background:var(--bg-success); color:var(--text-success);">Connected</span>
+    </div>
+    <div id="chatLog" style="min-height:150px; max-height:200px; overflow-y:auto; padding:10px 16px; display:flex; flex-direction:column; gap:8px;">
+      <div><p style="margin:0; font-size:11px; color:var(--text-accent); font-weight:500;">nadja</p><p style="margin:0; font-size:13px;">this track is insane 🔥</p></div>
+      <div><p style="margin:0; font-size:11px; color:var(--text-accent); font-weight:500;">kojo_b</p><p style="margin:0; font-size:13px;">track ID please?</p></div>
+      <div><p style="margin:0; font-size:11px; color:var(--text-accent); font-weight:500;">esra.wav</p><p style="margin:0; font-size:13px;">greetings from Wedding ✌️</p></div>
+    </div>
+    <div style="display:flex; gap:8px; padding:10px 16px; border-top:1px solid var(--border);">
+      <input id="chatInput" type="text" placeholder="Reply as host…" style="flex:1;" />
+      <button id="chatSend" aria-label="Send message"><i class="ti ti-send"></i></button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var N = 28;
+  function buildBars(id, color) {
+    var el = document.getElementById(id);
+    var bars = [];
+    for (var i = 0; i < N; i++) {
+      var b = document.createElement('div');
+      b.style.cssText = 'flex:1; height:8%; background:' + color + '; border-radius:1px; transition:height 90ms linear;';
+      el.appendChild(b);
+      bars.push(b);
+    }
+    return bars;
+  }
+  var inBars = buildBars('eqIn', '#1D9E75');
+  var outBars = buildBars('eqOut', '#7F77DD');
+  var t = 0, outQueue = [], gain = 1, mon = 0.7;
+
+  function frame() {
+    t += 0.09;
+    var snap = [];
+    for (var i = 0; i < N; i++) {
+      var base = Math.max(0.06, Math.sin(t + i * 0.55) * 0.3 + 0.42 - i * 0.008 + Math.random() * 0.22);
+      var v = Math.min(1, base * gain);
+      snap.push(v);
+      inBars[i].style.height = Math.round(v * 100) + '%';
+    }
+    outQueue.push(snap);
+    if (outQueue.length > 14) {
+      var old = outQueue.shift();
+      for (var j = 0; j < N; j++) outBars[j].style.height = Math.round(Math.min(1, old[j]) * mon * 100 + 4) + '%';
+    }
+    document.getElementById('inPeak').textContent = (Math.sin(t * 0.7) * 4 - 7).toFixed(1) + ' dB';
+    setTimeout(frame, 100);
+  }
+  frame();
+
+  var gi = document.getElementById('gainIn'), gv = document.getElementById('gainInVal');
+  gi.addEventListener('input', function () { gain = gi.value / 100; gv.textContent = gi.value + '%'; });
+  var vm = document.getElementById('volMon'), vv = document.getElementById('volMonVal');
+  vm.addEventListener('input', function () { mon = vm.value / 100; vv.textContent = vm.value + '%'; });
+
+  var el = 2533, rem = 4667, total = 7200, recS = 2533;
+  function fmt(s) {
+    var h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), x = s % 60;
+    return h + ':' + String(m).padStart(2, '0') + ':' + String(x).padStart(2, '0');
+  }
+  function fmtM(s) { return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0'); }
+
+  var canvas = document.getElementById('tpChart');
+  var ctx = canvas.getContext('2d');
+  var W = canvas.width, H = canvas.height, MAX = 1000;
+  var data = [];
+  for (var k = 0; k < 60; k++) data.push(780 + Math.random() * 80);
+  var mode = 'auto', target = 192, congested = false, congestTicks = 0, buf = 0.2, drops = 0;
+
+  function need() { return target * 1.15; }
+
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    ctx.strokeStyle = 'rgba(128,128,128,0.25)';
+    ctx.lineWidth = 1;
+    [0.25, 0.5, 0.75].forEach(function (f) { ctx.beginPath(); ctx.moveTo(0, H * f); ctx.lineTo(W, H * f); ctx.stroke(); });
+    var ny = H - (need() / MAX) * H;
+    ctx.strokeStyle = '#D85A30'; ctx.setLineDash([5, 4]);
+    ctx.beginPath(); ctx.moveTo(0, ny); ctx.lineTo(W, ny); ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.strokeStyle = '#1D9E75'; ctx.lineWidth = 2; ctx.beginPath();
+    data.forEach(function (v, i) {
+      var x = (i / (data.length - 1)) * W;
+      var y = H - (Math.min(v, MAX) / MAX) * H;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+    ctx.fillStyle = '#777'; ctx.font = '10px monospace';
+    ctx.fillText(Math.round(need()) + ' kbps', 6, ny - 4);
+  }
+
+  function setSeg(active) {
+    document.querySelectorAll('#qSeg button').forEach(function (b) {
+      var on = b.dataset.q === active;
+      b.style.background = on ? 'var(--bg-accent)' : 'transparent';
+      b.style.color = on ? 'var(--text-accent)' : 'var(--text-secondary)';
+    });
+  }
+  document.querySelectorAll('#qSeg button').forEach(function (b) {
+    b.addEventListener('click', function () {
+      mode = b.dataset.q;
+      if (mode !== 'auto') target = Number(mode);
+      setSeg(mode);
+      document.getElementById('qNote').textContent = mode === 'auto'
+        ? 'Auto steps down when the buffer grows · switch = <1 s encoder restart, covered by the relay'
+        : 'Fixed ' + target + ' kbps Opus · encoder restarted (<1 s gap, covered by the relay)';
+    });
+  });
+  document.getElementById('simBtn').addEventListener('click', function () {
+    congested = !congested; congestTicks = 0;
+    this.textContent = congested ? 'End congestion' : 'Simulate congestion';
+    if (!congested && mode === 'auto') target = 192;
+  });
+
+  setInterval(function () {
+    el++; rem = Math.max(0, rem - 1); recS++;
+    document.getElementById('elapsed').textContent = fmt(el);
+    document.getElementById('remaining').textContent = fmt(rem);
+    document.getElementById('recT').textContent = fmtM(recS);
+    document.getElementById('progress').style.width = Math.round((el / total) * 100) + '%';
+    document.getElementById('liveDot').style.opacity = el % 2 ? '0.35' : '1';
+
+    var v;
+    if (congested) {
+      congestTicks++;
+      v = 120 + Math.random() * 90;
+      buf = Math.min(9.9, buf + 0.4 + Math.random() * 0.4);
+      if (buf > 1.5) drops++;
+      if (mode === 'auto' && congestTicks === 6 && target > 96) {
+        target = target === 320 ? 192 : target === 192 ? 128 : 96;
+        congestTicks = 0;
+      }
+    } else {
+      v = 760 + Math.random() * 120;
+      buf = Math.max(0.1, buf - 0.6);
+    }
+    data.push(v); data.shift();
+    var rate = Math.round(data[data.length - 1]);
+    var headroom = rate / need();
+    document.getElementById('mRate').textContent = rate + 'k';
+    document.getElementById('mBuf').textContent = buf.toFixed(1) + ' s';
+    document.getElementById('mRtt').textContent = (congested ? 180 + Math.round(Math.random() * 120) : 30 + Math.round(Math.random() * 15)) + ' ms';
+    document.getElementById('mDrop').textContent = drops;
+    var vd = document.getElementById('verdict');
+    if (headroom > 2 && buf < 0.5) {
+      vd.textContent = 'Good — ' + headroom.toFixed(1) + '× headroom';
+      vd.style.background = 'var(--bg-success)'; vd.style.color = 'var(--text-success)';
+    } else if (headroom > 1.1) {
+      vd.textContent = 'Tight — ' + headroom.toFixed(1) + '× headroom';
+      vd.style.background = 'var(--bg-warning)'; vd.style.color = 'var(--text-warning)';
+    } else {
+      vd.textContent = 'Too slow — lower the quality';
+      vd.style.background = 'var(--bg-danger)'; vd.style.color = 'var(--text-danger)';
+    }
+    if (mode === 'auto') setSeg('auto');
+    draw();
+  }, 1000);
+  draw();
+
+  var log = document.getElementById('chatLog'), inp = document.getElementById('chatInput');
+  function send() {
+    var text = inp.value.trim();
+    if (!text) return;
+    var d = document.createElement('div');
+    var name = document.createElement('p');
+    name.style.cssText = 'margin:0; font-size:11px; color:var(--text-success); font-weight:500;';
+    name.textContent = 'anton-host (host)';
+    var msg = document.createElement('p');
+    msg.style.cssText = 'margin:0; font-size:13px;';
+    msg.textContent = text;
+    d.appendChild(name); d.appendChild(msg);
+    log.appendChild(d);
+    log.scrollTop = log.scrollHeight;
+    inp.value = '';
+  }
+  document.getElementById('chatSend').addEventListener('click', send);
+  inp.addEventListener('keydown', function (e) { if (e.key === 'Enter') send(); });
+})();
+</script>
+</body>
+</html>

--- a/docs/stream-rework/live-panel-2.0.md
+++ b/docs/stream-rework/live-panel-2.0.md
@@ -1,0 +1,144 @@
+# Live Panel 2.0 — design handoff
+
+> **Status:** approved design, not yet implemented (design session 2026-07-06, Cowork).
+> Interactive prototype: [`live-panel-2.0-prototype.html`](./live-panel-2.0-prototype.html) — open in a browser.
+> Builds on the show-dashboard redesign shipped on branch `feat/show-dashboard-redesign`.
+
+## Context
+
+The show dashboard (`/shows/:id`) was redesigned in this session (branch
+`feat/show-dashboard-redesign`, 5 commits, un-pushed at time of writing):
+
+1. `refactor(stream): extract LiveSetupTest from FlowLive` — device setup + `/test`
+   rehearsal now a shared component, rendered inline on the dashboard.
+2. `feat(admin_dashboard): redesigned show dashboard for all show types` — header →
+   status strip → phase panel (prep / launchpad / post-production) + announcements.
+3. `style(stream): metric-card telemetry panels on the live panel`
+4. `feat(admin_dashboard): inline meta editing, clickable announcement slots` —
+   schedule & host modal from the header meta line; announcement rows open composers.
+5. `feat(stream): redesign the live panel (waiting room + on-air card)` — current
+   FlowOnAir restyle (interim state; **this doc describes its successor**).
+
+Live Panel 2.0 replaces the streaming phase of `FlowOnAir.vue` (`/stream/on-air`).
+The waiting phase (countdown card) stays as shipped in commit 5.
+
+## Design decisions (locked)
+
+- **Stop streaming is the only prominent stream control.** It lives in the status
+  bar. Reconnect and "stop & change settings" are small icon buttons next to it.
+  The record toggle becomes the REC chip state — no separate control card.
+- **Reading order:** status bar → analyzers → connection & upload → live chat.
+- Upload bitrate is user-selectable and can auto-degrade; lowering it only degrades
+  the *source* feed — as long as it stays above the Icecast mount's output encoding,
+  listeners hear no difference, so Auto may be aggressive.
+- The `/test` rehearsal is the pre-air bandwidth check: the same connection metrics
+  run during the prep test broadcast, so the dashboard can say "connection good
+  enough" *before* air time.
+
+## Layout spec
+
+### 1. Status bar (full-width card)
+
+- Left: pulsing LIVE dot · `LIVE` label · REC chip (`REC 42:13`, red pill, ticks) ·
+  listener count (`👥 23`).
+- Right: `On air` elapsed (mono) · `Ends in` remaining (mono) · icon button
+  *Reconnect stream* · icon button *Stop and change settings* · **danger button
+  `⏹ Stop`**.
+- Bottom edge: 4 px show-progress bar (elapsed / scheduled duration).
+- Remaining-time warning states carry over from the current end-time banner
+  (amber < 5 min, auto-stop at 0).
+
+### 2. Analyzers (two cards, side by side; stack < ~600 px)
+
+| | Input — your source | Stream — what listeners hear |
+|---|---|---|
+| Visual | ~28-band spectrum, teal | Same, purple, labeled "~6 s behind" |
+| Meter | live peak dB readout (top right) | — |
+| Fader | **Input gain** (0–150 %) | **Monitor volume** (0–100 %) |
+
+### 3. Connection & upload (full-width card)
+
+- Header row: title · **verdict pill** (`Good — 4.1× headroom` green /
+  `Tight — 1.3×` amber / `Too slow — lower the quality` red) · (prototype only:
+  "Simulate congestion" button).
+- Left ⅔: 60 s throughput sparkline (measured upload, solid teal) vs. **"needed
+  for target" dashed line** (target bitrate × ~1.15 container overhead).
+- Right ⅓: metric tiles — Upload (kbps) · Buffer (s) · RTT (ms) · Late (count).
+- Footer: **Upload quality** segmented control `Auto | 320 | 192 | 128 | 96 kbps`
+  + note: "Auto steps down when the buffer grows · switch = <1 s encoder restart,
+  covered by the relay".
+
+### 4. Live chat (full-width card)
+
+- Header: Telegram icon · "Live chat · Moafunk channel" · `Connected` pill.
+- Scrolling message list (username accent-colored; host replies green with
+  "(host)" suffix).
+- Footer: text input ("Reply as host…") + send button.
+
+## Implementation map
+
+| Element | How | Code pointers |
+|---|---|---|
+| Input spectrum | Web Audio `AnalyserNode` on the capture stream | `useAudioCapture` (`mediaStream`/`processedStream`), extend `DbMeter.vue` / `useDbMeter` |
+| Stream spectrum | `AnalyserNode` on the preview `<audio>` element | `StreamPreviewPlayer.vue`; **requires CORS headers on Icecast mounts** (`docs/stream-rework/prod/icecast.xml`) |
+| Input gain | `GainNode` in the capture's processed chain | `useAudioCapture`; a volume slider existed in `FlowStreaming.vue` (unrouted, reference only) |
+| Monitor volume | `.volume` on the preview element | `StreamPreviewPlayer.vue` |
+| Upload rate (encoded) | sum `MediaRecorder.ondataavailable` chunk bytes/s | recorder lives in `FlowOnAir.vue` / `LiveSetupTest.vue` |
+| Upload rate (egress) & buffer | diff `WebSocket.bufferedAmount` per tick; buffer(s) = bufferedAmount / current byte-rate. **Best congestion signal, zero backend changes.** | `useStreamSocket.ts` |
+| RTT + late chunks | timestamped ack (or ping/pong) frames on the stream WS | backend `handlers/` stream WS + `useStreamSocket.ts` |
+| Bitrate switch | `audioBitsPerSecond` is fixed at `MediaRecorder` construction (currently hard-coded 192000) → stop + recreate recorder with new value; sub-second gap covered by harbor `mksafe` (`docs/stream-rework/prod/moafunk.liq`) | `FlowOnAir.vue`, `LiveSetupTest.vue` |
+| Auto bitrate | step down one notch when buffered seconds > threshold for N ticks; step up after stable period | new composable, e.g. `useUploadHealth.ts` |
+| Telegram chat | backend bot reads the channel's discussion group (webhook/getUpdates) → fan out over a panel WS; host replies via bot API | backend `telegram.rs`; new WS endpoint |
+| Timers / progress | already present (`elapsedText`, `remainingText`) | `FlowOnAir.vue` |
+| Listeners / quality | already polled Icecast telemetry | `FlowOnAir.vue` (`metrics`, 10 s poll) |
+
+## Tickets
+
+Milestone **Live Panel 2.0** + 6 issues. The session's GitHub connector had a stale
+token, so run this instead (labels follow CLAUDE.md conventions):
+
+```bash
+gh api repos/phaabe/live.moafunk.de/milestones -f title="Live Panel 2.0" \
+  -f description="Redesigned on-air cockpit (design session 2026-07-06): compact status bar with Stop as the only prominent control, input + stream spectrum analyzers with gain/monitor faders, connection & upload quality card (throughput vs target, WS buffer, RTT, verdict), selectable + auto upload bitrate, Telegram live chat bridge."
+
+gh issue create -t "Live panel 2.0: shell — compact status bar, card layout" \
+  -l "type::frontend" -l "project::Stream" -m "Live Panel 2.0" \
+  -b "Restructure /stream/on-air into the new cockpit: status bar (LIVE dot, REC chip w/ elapsed, listeners, on-air elapsed, ends-in, progress bar) with Stop streaming as the only prominent control (reconnect + stop-&-change-settings as icon buttons); card slots below: analyzers (2-col), connection & upload (full width), live chat (full width). Record toggle folds into the REC chip. Existing handlers/polling reused. Spec: docs/stream-rework/live-panel-2.0.md"
+
+gh issue create -t "Live panel 2.0: input & stream spectrum analyzers with faders" \
+  -l "type::frontend" -l "project::Stream" -m "Live Panel 2.0" \
+  -b "Two Web-Audio AnalyserNode spectra: input (audioCapture.mediaStream, extends DbMeter) and stream (StreamPreviewPlayer audio element — needs CORS on Icecast mounts). Input gain fader = GainNode in useAudioCapture's processed chain; monitor fader = preview element volume. Stream analyzer labeled '~6 s behind'. Spec: docs/stream-rework/live-panel-2.0.md"
+
+gh issue create -t "Live panel 2.0: connection & upload quality card (browser-side)" \
+  -l "type::frontend" -l "project::Stream" -m "Live Panel 2.0" \
+  -b "Measure upload health in the browser: encoded rate from MediaRecorder chunk sizes, real egress via ws.bufferedAmount drain, send buffer in seconds, late-chunk counter. Throughput sparkline vs 'needed for target' line + Good/Tight/Too-slow verdict pill. Also surface the verdict during the /test rehearsal in the prep panel ('connection good enough' before air time). No backend changes required. Spec: docs/stream-rework/live-panel-2.0.md"
+
+gh issue create -t "Live panel 2.0: selectable + auto upload bitrate" \
+  -l "type::frontend" -l "project::Stream" -m "Live Panel 2.0" \
+  -b "Quality selector (Auto / 320 / 192 / 128 / 96 kbps Opus). audioBitsPerSecond is fixed at MediaRecorder construction (currently hard-coded 192k) → switching restarts the recorder; sub-second gap is covered by the harbor's mksafe. Auto mode: step down when buffered seconds exceed a threshold for N ticks, step back up after a stable period. Spec: docs/stream-rework/live-panel-2.0.md"
+
+gh issue create -t "Live panel 2.0: stream WS ack/RTT + late-chunk telemetry" \
+  -l "type::backend" -l "project::Stream" -m "Live Panel 2.0" \
+  -b "Add timestamped ack (or ping/pong) frames to the existing stream WebSocket so the panel can display round-trip time and confirm chunk delivery; expose per-connection counters for late/dropped chunks. Spec: docs/stream-rework/live-panel-2.0.md"
+
+gh issue create -t "Live panel 2.0: Telegram live chat bridge" \
+  -l "type::backend" -l "project::Telegram" -m "Live Panel 2.0" \
+  -b "Bridge the channel's discussion group into the live panel: bot reads new messages (webhook or getUpdates) → fan out over a panel WebSocket; host replies posted via the bot API with a host badge. Panel UI: message list + text input (frontend part in the shell issue). Spec: docs/stream-rework/live-panel-2.0.md"
+```
+
+## Suggested order
+
+1. Shell (pure layout, no new data) → 2. analyzers + faders → 3. connection card
+(browser-only metrics; reuse during prep test) → 4. bitrate switch + auto →
+5. backend WS telemetry → 6. Telegram bridge (biggest new subsystem, independent).
+
+## Environment notes (from this session)
+
+- `frontend/.env.local` (created, gitignored): `VITE_STREAM_ICECAST_TEST_URL=https://radio.live.moafunk.de/test.mp3`
+  makes the rehearsal playback use the real test mount in local dev.
+- For the rehearsal *push* leg, the local backend needs
+  `ICECAST_TEST_URL=icecast://source:<HARBOR_TEST_PASSWORD>@radio.live.moafunk.de:8005/test`
+  in `backend/.env.local` — password from the prod `stream.env`; port 8005 may need
+  an SSH tunnel (`ssh -L 8005:127.0.0.1:8005 <box>`).
+- The whole session's dashboard work sits on `feat/show-dashboard-redesign` —
+  push + PR (squash-merge) before starting Live Panel 2.0 on a fresh branch.

--- a/docs/stream-rework/phaabe-dns-handoff.md
+++ b/docs/stream-rework/phaabe-dns-handoff.md
@@ -1,0 +1,85 @@
+# For phaabe — DNS handoff for the Hetzner migration
+
+**TL;DR:** Everything for moving the backend + streaming onto one new Hetzner
+box is built and tested in parallel. **Production is untouched and stays that
+way until we deliberately flip.** The only thing I can't do myself is DNS —
+the `moafunk.de` zone lives in **your** Hetzner account. I need you to either
+hand me a DNS API token (preferred) or make two small record changes. ~5 minutes.
+
+---
+
+## Background (30 seconds)
+
+- The backend + admin (`admin.live.moafunk.de`) currently run on **AWS Lightsail**
+  (`18.157.219.113`); the live audio stream runs on the **old NMS relay**
+  (`stream.moafunk.de` → `78.47.222.82`).
+- We've stood up a **single new Hetzner box** (`178.104.160.103`, in Anton's
+  Hetzner account) that runs both the backend and the new Icecast/Liquidsoap
+  streaming stack. It's validated and running in parallel — **no public traffic
+  yet, DNS still points everything at the old boxes.**
+- To cut over we need to repoint DNS. The zone is on Hetzner's nameservers
+  (`helium/hydrogen/oxygen.ns.hetzner`) under your account, so it's your call.
+
+---
+
+## What I need — pick ONE
+
+### ✅ Option A (preferred): give me a Hetzner DNS API token
+
+This lets me make the change *now* (lower a TTL, harmless) and do the actual
+cutover flip at the exact right moment, without you having to be online for it.
+
+1. Open **dns.hetzner.com** (it now opens inside the Hetzner Cloud Console).
+2. Top-right **account / profile menu → "API tokens"** (may be under
+   *Security* / *API tokens* — the menu moved when DNS merged into the console).
+3. **Create an access token** (give it a name like `moafunk-migration`).
+   It grants read/write to your DNS zones — that's what's needed.
+4. **Send it to me securely — not in plain chat/email.** Easiest:
+   **Bitwarden Send** (https://send.bitwarden.com) with a 1-view / 1-day expiry,
+   or drop it in the shared `live.moafunk.de` Bitwarden Secrets Manager project
+   if you have access. You can **delete/revoke the token right after** the
+   cutover — I'll tell you when we're done.
+
+That's it. I handle the rest.
+
+### Option B: make the two changes yourself
+
+Both are on **one record** — the `admin.live` **A record** in the `moafunk.de`
+zone (currently `admin.live.moafunk.de → 18.157.219.113`).
+
+1. **Now (do this anytime — zero impact):** change that record's **TTL → `60`**.
+   Leave the value as `18.157.219.113`. This just makes the later flip propagate
+   in ~1 minute instead of hours; nothing moves.
+2. **At cutover (I'll ping you, we'll do it together in a quiet window):**
+   change the **value** `18.157.219.113` → **`178.104.160.103`**. Keep TTL 60.
+   If anything looks wrong we change it straight back — Lightsail stays running
+   as the instant rollback.
+
+> **Don't touch** any other record. `live.moafunk.de` (the public site → GitHub
+> Pages) and everything else stay exactly as they are.
+
+---
+
+## Heads-up for later (no action needed now)
+
+- **Public stream record:** when we flip the listener stream too, we'll add/point
+  one record (e.g. `radio.live.moafunk.de → 178.104.160.103`, or repoint
+  `stream.moafunk.de`) at the new box. A DNS token (Option A) covers this
+  automatically; with Option B I'll send you the exact record.
+- **Lightsail DB:** the one-time cutover copies the live SQLite DB off the
+  Lightsail box. Anton has the Lightsail SSH key via Bitwarden — please confirm
+  it's still the current key, or be ready to help for ~5 minutes.
+- **Decommission:** after a few real shows on the new box, we retire the
+  **Lightsail instance** and the **old NMS relay** (`78.47.222.82`). Anton will
+  coordinate — nothing to do until then.
+
+## What does NOT change
+
+Domain registration, the GitHub repo, GHCR, Cloudflare R2 storage, the public
+site (`live.moafunk.de` → GitHub Pages), and every DNS record except the single
+`admin.live` flip above. Low blast radius, fully reversible.
+
+---
+
+*Questions → ping Anton. Nothing here affects the live site or stream until we
+deliberately run the cutover together.*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -649,20 +649,22 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -731,20 +733,22 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -842,286 +846,389 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1727,10 +1834,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1812,10 +1920,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2353,20 +2462,22 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2581,10 +2692,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flv.js": {
       "version": "1.6.2",
@@ -2732,20 +2844,22 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3157,9 +3271,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -3268,12 +3382,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3316,15 +3431,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3517,10 +3633,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3568,9 +3685,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3585,8 +3702,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3748,10 +3866,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3763,28 +3882,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -4520,10 +4642,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/frontend/src/admin/components/LiveSetupTest.vue
+++ b/frontend/src/admin/components/LiveSetupTest.vue
@@ -1,0 +1,540 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
+import DbMeter from '@admin/components/DbMeter.vue';
+import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
+import { config } from '@/config';
+
+/**
+ * Live preparation: audio input selection + level meter + rehearsal broadcast
+ * against the private Icecast `/test` mount.
+ *
+ * Extracted from FlowLive so it can render both inline on the show dashboard
+ * and inside the fullscreen /stream/live step. All logic is identical; the
+ * host confirming "sounds good" emits `passed` and the parent decides where
+ * to navigate. Uses the useAudioCapture / useHostFlow singletons, so capture
+ * survives into the on-air step regardless of which surface ran the test.
+ */
+const emit = defineEmits<{
+  /** The host confirmed the test stream sounds right (test marked passed). */
+  passed: [];
+}>();
+
+const flow = useHostFlow();
+
+// The private Icecast `/test` mount the rehearsal plays back from. Same MP3 the
+// public `/live.mp3` would serve, but non-public. Empty (e.g. local dev) → the
+// real test can't run; the dev-skip below covers that case.
+const previewUrl = config.stream.icecastTestUrl;
+
+// ─── Device selection ────────────────────────────────────────────────────────
+const audioCapture = useAudioCapture();
+const selectedDevice = ref('');
+
+let deviceRefreshInterval: ReturnType<typeof setInterval> | null = null;
+
+function onDeviceChange() {
+  audioCapture.listDevices();
+}
+
+onMounted(async () => {
+  // First refresh prompts for permission so device labels are populated.
+  await audioCapture.refreshDevices();
+  // The capture singleton persists across navigations; mirror a still-active
+  // device in the dropdown instead of showing "no input selected".
+  const activeId = audioCapture.selectedDeviceId.value;
+  if (audioCapture.isCapturing.value && activeId && activeId !== 'screen') {
+    selectedDevice.value = activeId;
+  }
+  navigator.mediaDevices.addEventListener('devicechange', onDeviceChange);
+  deviceRefreshInterval = setInterval(() => audioCapture.listDevices(), 3000);
+});
+
+async function handleDeviceSelect() {
+  if (!selectedDevice.value) return;
+  await audioCapture.captureDevice(selectedDevice.value);
+  // A change of input invalidates any previous successful test.
+  resetTest();
+}
+
+async function handleScreenShare() {
+  const ok = await audioCapture.captureScreenAudio();
+  if (ok) {
+    selectedDevice.value = '';
+    resetTest();
+  }
+}
+
+const capturedLabel = computed(() => {
+  if (audioCapture.selectedDeviceId.value === 'screen') return 'Screen Audio';
+  return (
+    audioCapture.devices.value.find((d) => d.deviceId === audioCapture.selectedDeviceId.value)
+      ?.label || 'Audio input'
+  );
+});
+
+// ─── Test broadcast (real producer → /test harbour → Icecast /test.mp3) ──────
+type TestPhase = 'ready' | 'connecting' | 'live' | 'error';
+const testPhase = ref<TestPhase>('ready');
+const testError = ref<string | null>(null);
+const sentChunks = ref(0);
+const testActive = computed(() => testPhase.value === 'connecting' || testPhase.value === 'live');
+
+const streamSocket = useStreamSocket({
+  onLive: () => {
+    testPhase.value = 'live';
+  },
+  onError: (msg) => {
+    testPhase.value = 'error';
+    testError.value = msg;
+    stopTestRecording();
+  },
+  onDisconnected: () => {
+    if (testPhase.value === 'live' || testPhase.value === 'connecting') {
+      testPhase.value = 'ready';
+      stopTestRecording();
+    }
+  },
+});
+
+// Dedicated MediaRecorder on the capture stream — independent of the
+// singleton capture's main onData wiring, so it never disturbs the real
+// go-live pipeline.
+let testRecorder: MediaRecorder | null = null;
+
+function startTestRecording(): boolean {
+  const stream = audioCapture.processedStream.value || audioCapture.mediaStream.value;
+  if (!stream) {
+    testPhase.value = 'error';
+    testError.value = 'No audio stream available. Select an audio device first.';
+    return false;
+  }
+
+  const tracks = stream.getAudioTracks();
+  if (tracks.length === 0 || tracks.every((t) => t.readyState !== 'live')) {
+    testPhase.value = 'error';
+    testError.value = 'Audio device is no longer active. Re-select your device.';
+    return false;
+  }
+
+  const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+    ? 'audio/webm;codecs=opus'
+    : 'audio/webm';
+
+  testRecorder = new MediaRecorder(stream, { mimeType, audioBitsPerSecond: 192000 });
+
+  testRecorder.ondataavailable = async (event) => {
+    if (event.data.size > 0) {
+      const buffer = await event.data.arrayBuffer();
+      streamSocket.send(buffer);
+      sentChunks.value++;
+    }
+  };
+
+  testRecorder.onerror = () => {
+    testError.value = 'Audio recorder error';
+    testPhase.value = 'error';
+  };
+
+  testRecorder.start(250);
+  return true;
+}
+
+function stopTestRecording() {
+  if (testRecorder && testRecorder.state !== 'inactive') {
+    testRecorder.stop();
+  }
+  testRecorder = null;
+}
+
+async function runTest() {
+  if (!previewUrl) {
+    testPhase.value = 'error';
+    testError.value = 'Test stream is not configured on this server.';
+    return;
+  }
+
+  testError.value = null;
+  testPhase.value = 'connecting';
+  sentChunks.value = 0;
+
+  try {
+    // Connect in TEST mode → backend pushes to `/test`, not `/live`.
+    await streamSocket.connect(false, undefined, true);
+    if (!startTestRecording()) {
+      streamSocket.stopStream();
+    }
+  } catch {
+    testPhase.value = 'error';
+    testError.value = 'Failed to connect to the test stream.';
+    stopTestRecording();
+  }
+}
+
+/** Stop the rehearsal broadcast (keeps the audio capture for the next step). */
+function stopTestBroadcast() {
+  stopTestRecording();
+  streamSocket.stopStream();
+}
+
+/** Reset test state (e.g. after switching inputs). */
+function resetTest() {
+  stopTestBroadcast();
+  testPhase.value = 'ready';
+  testError.value = null;
+  sentChunks.value = 0;
+  flow.setLiveTestPassed(false);
+}
+
+function retryTest() {
+  resetTest();
+}
+
+function markTestPassed() {
+  stopTestBroadcast();
+  flow.setLiveTestPassed(true);
+  emit('passed');
+}
+
+const isDev = import.meta.env.DEV;
+
+onUnmounted(() => {
+  navigator.mediaDevices.removeEventListener('devicechange', onDeviceChange);
+  if (deviceRefreshInterval) {
+    clearInterval(deviceRefreshInterval);
+    deviceRefreshInterval = null;
+  }
+  // Never leave a producer pushing to `/test` after navigating away.
+  if (testActive.value) {
+    stopTestBroadcast();
+  }
+  // NOTE: do NOT call audioCapture.stopCapture() here —
+  // the singleton capture persists into the on-air step.
+});
+</script>
+
+<template>
+  <div class="live-setup">
+    <!-- ─── Device selection ─── -->
+    <div class="ls-device-row">
+      <select v-model="selectedDevice" class="ls-select" @change="handleDeviceSelect">
+        <option value="">-- Select audio input --</option>
+        <option
+          v-for="device in audioCapture.devices.value"
+          :key="device.deviceId"
+          :value="device.deviceId"
+        >
+          {{ device.label }}
+        </option>
+      </select>
+      <button
+        class="ls-btn-icon"
+        type="button"
+        title="Refresh devices"
+        @click="audioCapture.listDevices()"
+      >
+        🔄
+      </button>
+    </div>
+
+    <button class="ls-link" type="button" @click="handleScreenShare">
+      🖥️ Share screen audio instead
+    </button>
+
+    <div v-if="audioCapture.isCapturing.value" class="ls-capture">
+      <p class="ls-capture-status">
+        <span class="ls-dot active"></span>
+        Capturing — <strong>{{ capturedLabel }}</strong>
+      </p>
+      <DbMeter :media-stream="audioCapture.mediaStream.value" label="Input Level" />
+    </div>
+
+    <p v-if="audioCapture.error.value" class="ls-error">{{ audioCapture.error.value }}</p>
+
+    <!-- ─── Test broadcast ─── -->
+    <div class="ls-test">
+      <div class="ls-test-head">
+        <p class="ls-test-title">Test broadcast</p>
+        <p class="ls-test-hint">Private /test mount — listeners can't hear this</p>
+      </div>
+
+      <div v-if="testPhase === 'ready'" class="ls-test-state">
+        <button
+          class="ls-btn-primary"
+          type="button"
+          :disabled="!audioCapture.isCapturing.value || !previewUrl"
+          @click="runTest"
+        >
+          🎤 Start test
+        </button>
+        <p v-if="!audioCapture.isCapturing.value" class="ls-muted">Select an audio input first.</p>
+        <p v-else-if="!previewUrl" class="ls-muted">
+          Test stream isn't configured on this server.
+        </p>
+      </div>
+
+      <div v-else-if="testPhase === 'connecting'" class="ls-test-state">
+        <p class="ls-muted">Connecting to the test stream…</p>
+      </div>
+
+      <div v-else-if="testPhase === 'live'" class="ls-test-state">
+        <p class="ls-onair">
+          <span class="ls-dot rec"></span>
+          Test broadcast live
+          <span class="ls-muted">· {{ sentChunks }} chunks sent</span>
+        </p>
+
+        <!-- Runs a few seconds behind — use headphones. -->
+        <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
+
+        <div class="ls-test-actions">
+          <p class="ls-question">Does it sound clear on the test stream?</p>
+          <button class="ls-btn-secondary" type="button" @click="retryTest">⏹ Stop test</button>
+          <button class="ls-btn-success" type="button" @click="markTestPassed">
+            ✓ Yes, ready to go live
+          </button>
+        </div>
+      </div>
+
+      <div v-else-if="testPhase === 'error'" class="ls-test-state">
+        <p class="ls-error">{{ testError || 'An error occurred during the test.' }}</p>
+        <button class="ls-btn-secondary" type="button" @click="retryTest">Try again</button>
+      </div>
+    </div>
+
+    <button
+      v-if="isDev && !flow.liveTestPassed.value"
+      class="ls-dev-skip"
+      type="button"
+      @click="markTestPassed"
+    >
+      🛠 Skip test (dev)
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.live-setup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  font-family: var(--font-ui);
+}
+
+.ls-device-row {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.ls-select {
+  flex: 1;
+  min-width: 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+}
+
+.ls-btn-icon {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+}
+
+.ls-link {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.ls-capture {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+}
+
+.ls-capture-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-success);
+}
+
+.ls-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-text-muted);
+  flex: 0 0 auto;
+}
+
+.ls-dot.active {
+  background: var(--color-success);
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+}
+
+.ls-dot.rec {
+  width: 10px;
+  height: 10px;
+  background: var(--color-error);
+  animation: ls-pulse 1s ease-in-out infinite;
+}
+
+@keyframes ls-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.ls-test {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-md);
+  margin-top: var(--spacing-xs);
+}
+
+.ls-test-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-sm);
+}
+
+.ls-test-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ls-test-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.ls-test-state {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.ls-onair {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-error);
+}
+
+.ls-test-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.ls-question {
+  margin: 0;
+  flex: 1 1 auto;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.ls-btn-primary {
+  align-self: flex-start;
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  border: none;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ls-btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ls-btn-secondary {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.ls-btn-secondary:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-light);
+}
+
+.ls-btn-success {
+  background: var(--color-success);
+  color: #fff;
+  border: none;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ls-btn-success:hover {
+  background: #16a34a;
+}
+
+.ls-muted {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.ls-error {
+  margin: 0;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.ls-dev-skip {
+  align-self: flex-start;
+  margin-top: var(--spacing-xs);
+  background: var(--color-warning);
+  color: #000;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: 2px dashed #000;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/admin/components/show-detail/AnnouncementsCard.vue
+++ b/frontend/src/admin/components/show-detail/AnnouncementsCard.vue
@@ -1,25 +1,21 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { ShowDetail } from '../../api';
-import { BaseButton } from '@shared/components';
 import type { ShowPhase } from '../../composables/useShowPhase';
 
 /**
  * Announcements checklist of the redesigned show dashboard: the four
- * scheduled slots (IG/TG × pre/post) as an actionable list, plus the two
- * immediate legacy actions the backend supports today (Instagram post,
- * Telegram preview).
+ * scheduled slots (IG/TG × pre/post) as clickable rows that open the
+ * matching composer (Instagram preview modal / Telegram composer).
  *
- * The slot rows stay inert until the scheduled-announcements backend lands
- * (docs/adr/0001-scheduled-announcements-model.md); the chips and hint make
- * that state explicit instead of hiding it.
+ * Scheduling stays inert until the scheduled-announcements backend lands
+ * (docs/adr/0001-scheduled-announcements-model.md); until then composing
+ * offers the immediate legacy actions inside the modals, and the chips make
+ * the not-yet-scheduled state explicit.
  */
 const props = defineProps<{
   show: ShowDetail;
   phase: ShowPhase;
-  /** Admin-only legacy actions (matches the backend require_admin gate). */
-  canPost: boolean;
-  sendingTelegramPreview: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -32,55 +28,58 @@ const emit = defineEmits<{
 interface SlotRow {
   icon: string;
   label: string;
+  channel: 'instagram' | 'telegram';
 }
 
 const slots: SlotRow[] = [
-  { icon: '📸', label: 'Story · pre-announcement' },
-  { icon: '📸', label: 'Story · post-announcement' },
-  { icon: '📱', label: 'Post · pre-announcement' },
-  { icon: '📱', label: 'Post · post-announcement' },
+  { icon: '📸', label: 'Story · pre-announcement', channel: 'instagram' },
+  { icon: '📸', label: 'Story · post-announcement', channel: 'instagram' },
+  { icon: '📱', label: 'Post · pre-announcement', channel: 'telegram' },
+  { icon: '📱', label: 'Post · post-announcement', channel: 'telegram' },
 ];
 
-const chipLabel = computed(() => (props.phase === 'wrapup' ? 'Not sent' : 'Not scheduled'));
-
+/** Legacy immediate IG post — surfaced on the Instagram rows. */
 const igPosted = computed(() => !!props.show.instagram_posted_at);
+
+function chipFor(row: SlotRow): { label: string; sent: boolean } {
+  if (row.channel === 'instagram' && igPosted.value) {
+    return { label: 'Posted ✓', sent: true };
+  }
+  return { label: props.phase === 'wrapup' ? 'Not sent' : 'Not scheduled', sent: false };
+}
+
+function compose(row: SlotRow) {
+  if (row.channel === 'instagram') {
+    emit('compose-instagram');
+  } else {
+    emit('compose-telegram');
+  }
+}
 </script>
 
 <template>
   <div class="card ann-card">
     <div class="ann-head">
       <h2 class="ann-title">Announcements</h2>
-      <span class="ann-count">0 / 4</span>
+      <span class="ann-count">{{ igPosted ? '1' : '0' }} / 4</span>
     </div>
 
-    <div v-for="row in slots" :key="row.label" class="ann-row">
+    <button
+      v-for="row in slots"
+      :key="row.label"
+      type="button"
+      class="ann-row"
+      :title="`Compose ${row.channel} announcement`"
+      @click="compose(row)"
+    >
       <span class="ann-label">{{ row.icon }} {{ row.label }}</span>
-      <span class="ann-chip">{{ chipLabel }}</span>
-    </div>
+      <span class="ann-chip" :class="{ sent: chipFor(row).sent }">{{ chipFor(row).label }}</span>
+      <span class="ann-chevron">›</span>
+    </button>
 
-    <p class="ann-hint">Scheduling &amp; composing announcements arrives in a later update.</p>
-
-    <template v-if="canPost">
-      <div class="ann-divider"></div>
-      <p class="ann-subtitle">Post now</p>
-      <div class="ann-row">
-        <span class="ann-label">📸 Instagram</span>
-        <BaseButton size="sm" :variant="igPosted ? 'ghost' : 'primary'" @click="emit('compose-instagram')">
-          {{ igPosted ? 'Posted ✓ · again?' : 'Compose' }}
-        </BaseButton>
-      </div>
-      <div class="ann-row">
-        <span class="ann-label">📱 Telegram</span>
-        <BaseButton
-          size="sm"
-          variant="ghost"
-          :loading="sendingTelegramPreview"
-          @click="emit('compose-telegram')"
-        >
-          Compose
-        </BaseButton>
-      </div>
-    </template>
+    <p class="ann-hint">
+      Click a slot to compose &amp; preview. Scheduling arrives in a later update.
+    </p>
   </div>
 </template>
 
@@ -120,15 +119,27 @@ const igPosted = computed(() => !!props.show.instagram_posted_at);
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-sm);
-  padding: var(--spacing-xs) 0;
+  padding: var(--spacing-sm) var(--spacing-xs);
+  border: none;
   border-bottom: 1px solid var(--color-border);
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
 }
 
-.ann-row:last-child {
+.ann-row:hover {
+  background: var(--color-surface-hover);
+}
+
+.ann-row:last-of-type {
   border-bottom: none;
 }
 
 .ann-label {
+  flex: 1 1 auto;
+  font-family: var(--font-ui);
   font-size: var(--font-size-sm);
   color: var(--color-text);
 }
@@ -143,24 +154,22 @@ const igPosted = computed(() => !!props.show.instagram_posted_at);
   color: var(--color-text-muted);
 }
 
+.ann-chip.sent {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.ann-chevron {
+  flex: 0 0 auto;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-lg);
+  line-height: 1;
+}
+
 .ann-hint {
   margin: var(--spacing-xs) 0 0;
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   font-style: italic;
-}
-
-.ann-divider {
-  border-top: 1px solid var(--color-border);
-  margin: var(--spacing-sm) 0;
-}
-
-.ann-subtitle {
-  margin: 0 0 var(--spacing-xs);
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
 }
 </style>

--- a/frontend/src/admin/components/show-detail/AnnouncementsCard.vue
+++ b/frontend/src/admin/components/show-detail/AnnouncementsCard.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ShowDetail } from '../../api';
+import { BaseButton } from '@shared/components';
+import type { ShowPhase } from '../../composables/useShowPhase';
+
+/**
+ * Announcements checklist of the redesigned show dashboard: the four
+ * scheduled slots (IG/TG × pre/post) as an actionable list, plus the two
+ * immediate legacy actions the backend supports today (Instagram post,
+ * Telegram preview).
+ *
+ * The slot rows stay inert until the scheduled-announcements backend lands
+ * (docs/adr/0001-scheduled-announcements-model.md); the chips and hint make
+ * that state explicit instead of hiding it.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  phase: ShowPhase;
+  /** Admin-only legacy actions (matches the backend require_admin gate). */
+  canPost: boolean;
+  sendingTelegramPreview: boolean;
+}>();
+
+const emit = defineEmits<{
+  /** Open the Instagram composer/preview modal. */
+  'compose-instagram': [];
+  /** Open the Telegram composer/preview modal. */
+  'compose-telegram': [];
+}>();
+
+interface SlotRow {
+  icon: string;
+  label: string;
+}
+
+const slots: SlotRow[] = [
+  { icon: '📸', label: 'Story · pre-announcement' },
+  { icon: '📸', label: 'Story · post-announcement' },
+  { icon: '📱', label: 'Post · pre-announcement' },
+  { icon: '📱', label: 'Post · post-announcement' },
+];
+
+const chipLabel = computed(() => (props.phase === 'wrapup' ? 'Not sent' : 'Not scheduled'));
+
+const igPosted = computed(() => !!props.show.instagram_posted_at);
+</script>
+
+<template>
+  <div class="card ann-card">
+    <div class="ann-head">
+      <h2 class="ann-title">Announcements</h2>
+      <span class="ann-count">0 / 4</span>
+    </div>
+
+    <div v-for="row in slots" :key="row.label" class="ann-row">
+      <span class="ann-label">{{ row.icon }} {{ row.label }}</span>
+      <span class="ann-chip">{{ chipLabel }}</span>
+    </div>
+
+    <p class="ann-hint">Scheduling &amp; composing announcements arrives in a later update.</p>
+
+    <template v-if="canPost">
+      <div class="ann-divider"></div>
+      <p class="ann-subtitle">Post now</p>
+      <div class="ann-row">
+        <span class="ann-label">📸 Instagram</span>
+        <BaseButton size="sm" :variant="igPosted ? 'ghost' : 'primary'" @click="emit('compose-instagram')">
+          {{ igPosted ? 'Posted ✓ · again?' : 'Compose' }}
+        </BaseButton>
+      </div>
+      <div class="ann-row">
+        <span class="ann-label">📱 Telegram</span>
+        <BaseButton
+          size="sm"
+          variant="ghost"
+          :loading="sendingTelegramPreview"
+          @click="emit('compose-telegram')"
+        >
+          Compose
+        </BaseButton>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.ann-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  min-height: 100%;
+  font-family: var(--font-ui);
+}
+
+.ann-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-xs);
+}
+
+.ann-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.ann-count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.ann-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ann-row:last-child {
+  border-bottom: none;
+}
+
+.ann-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.ann-chip {
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.ann-hint {
+  margin: var(--spacing-xs) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.ann-divider {
+  border-top: 1px solid var(--color-border);
+  margin: var(--spacing-sm) 0;
+}
+
+.ann-subtitle {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/admin/components/show-detail/PrepUploadInline.vue
+++ b/frontend/src/admin/components/show-detail/PrepUploadInline.vue
@@ -1,0 +1,347 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { BaseButton, BaseModal } from '@shared/components';
+import AudioPlayer from '../AudioPlayer.vue';
+import { useHostFlow } from '../../composables/useHostFlow';
+
+/**
+ * Inline pre-recorded preparation for the show dashboard: dropzone → chunked
+ * upload progress → preview + confirm, absorbing the old fullscreen
+ * /stream/upload and /stream/confirm steps.
+ *
+ * Reuses the useHostFlow singleton (upload/confirm/delete + progress); the
+ * owning page selects the show in the flow before rendering this panel and
+ * refreshes its own copy of the show on `changed`.
+ */
+const props = defineProps<{
+  showId: number;
+}>();
+
+const emit = defineEmits<{
+  /** Upload/confirm/delete completed — the page should reload the show. */
+  changed: [];
+}>();
+
+const flow = useHostFlow();
+
+const isDragging = ref(false);
+const confirming = ref(false);
+const deleting = ref(false);
+const showDeleteModal = ref(false);
+const localError = ref<string | null>(null);
+const fileInput = ref<HTMLInputElement | null>(null);
+
+/** Guard: the flow singleton must have this show selected. */
+const flowReady = computed(() => flow.show.value?.id === props.showId);
+
+const hasUpload = computed(() => flowReady.value && flow.hasUpload.value);
+const isConfirmed = computed(() => flowReady.value && flow.isConfirmed.value);
+const uploading = computed(() => flow.uploading.value);
+const progress = computed(() => flow.uploadProgress.value);
+
+const ACCEPTED = ['.mp3', '.wav', '.flac', '.ogg', '.m4a'];
+
+function isAccepted(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return ACCEPTED.some((ext) => name.endsWith(ext));
+}
+
+async function handleFile(file: File) {
+  localError.value = null;
+  if (!isAccepted(file)) {
+    localError.value = `Unsupported file type. Accepted: ${ACCEPTED.join(', ')}`;
+    return;
+  }
+  try {
+    await flow.uploadFile(file);
+    emit('changed');
+  } catch (e) {
+    localError.value = e instanceof Error ? e.message : 'Upload failed';
+  }
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault();
+  isDragging.value = false;
+  const file = e.dataTransfer?.files?.[0];
+  if (file) handleFile(file);
+}
+
+function onFileSelect(e: Event) {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) handleFile(file);
+  input.value = '';
+}
+
+async function confirm() {
+  confirming.value = true;
+  localError.value = null;
+  try {
+    await flow.confirmUpload();
+    emit('changed');
+  } catch (e) {
+    localError.value = e instanceof Error ? e.message : 'Confirmation failed';
+  } finally {
+    confirming.value = false;
+  }
+}
+
+async function deleteUpload() {
+  deleting.value = true;
+  localError.value = null;
+  try {
+    await flow.deleteUpload();
+    showDeleteModal.value = false;
+    emit('changed');
+  } catch (e) {
+    localError.value = e instanceof Error ? e.message : 'Delete failed';
+  } finally {
+    deleting.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="prep-upload">
+    <p v-if="!flowReady" class="pu-hint">Loading your show…</p>
+
+    <!-- Uploading: chunked progress -->
+    <div v-else-if="uploading" class="pu-progress">
+      <span class="pu-file-ico">🎵</span>
+      <div class="pu-progress-body">
+        <p class="pu-filename">
+          Uploading…
+          <span v-if="progress?.totalChunks && progress.totalChunks > 1" class="pu-meta">
+            chunk {{ progress.chunkIndex }} / {{ progress.totalChunks }}
+          </span>
+          <span v-else-if="progress?.phase === 'finalizing'" class="pu-meta">finalizing</span>
+        </p>
+        <div class="pu-bar">
+          <div class="pu-bar-fill" :style="{ width: (progress?.percent ?? 0) + '%' }"></div>
+        </div>
+      </div>
+      <span class="pu-percent">{{ progress?.percent ?? 0 }}%</span>
+    </div>
+
+    <!-- No upload yet: dropzone -->
+    <template v-else-if="!hasUpload">
+      <div
+        class="pu-dropzone"
+        :class="{ dragging: isDragging }"
+        role="button"
+        tabindex="0"
+        @dragover.prevent="isDragging = true"
+        @dragleave="isDragging = false"
+        @drop="onDrop"
+        @click="fileInput?.click()"
+        @keydown.enter="fileInput?.click()"
+      >
+        <span class="pu-drop-ico">⬆</span>
+        <p class="pu-drop-text">Drop your set here or <span class="pu-browse">browse</span></p>
+        <p class="pu-drop-formats">MP3, WAV, FLAC, OGG or M4A</p>
+      </div>
+      <p class="pu-warn">⚠ Upload and confirm before air time — the show starts automatically</p>
+    </template>
+
+    <!-- Uploaded: preview + confirm -->
+    <template v-else>
+      <div class="pu-filerow">
+        <span class="pu-file-ico">🎵</span>
+        <div class="pu-file-info">
+          <p class="pu-filename">{{ flow.prerecordedFilename.value || 'Uploaded set' }}</p>
+        </div>
+        <span class="pu-chip" :class="{ confirmed: isConfirmed }">
+          {{ isConfirmed ? 'Confirmed' : 'Uploaded' }}
+        </span>
+      </div>
+
+      <AudioPlayer
+        v-if="flow.prerecordedUrl.value"
+        :key="flow.prerecordedUrl.value"
+        :src="flow.prerecordedUrl.value"
+      />
+
+      <div class="pu-actions">
+        <p v-if="!isConfirmed" class="pu-hint">
+          Listen in, then confirm to lock this file for air time
+        </p>
+        <p v-else class="pu-hint done">✓ Confirmed — streams automatically at air time</p>
+        <BaseButton variant="ghost" size="sm" @click="fileInput?.click()">Re-upload</BaseButton>
+        <BaseButton variant="danger" size="sm" @click="showDeleteModal = true">Delete</BaseButton>
+        <BaseButton
+          v-if="!isConfirmed"
+          variant="primary"
+          size="sm"
+          :loading="confirming"
+          @click="confirm"
+        >
+          ✓ Confirm
+        </BaseButton>
+      </div>
+    </template>
+
+    <p v-if="localError" class="pu-error">{{ localError }}</p>
+
+    <input
+      ref="fileInput"
+      type="file"
+      :accept="ACCEPTED.join(',')"
+      class="pu-input"
+      @change="onFileSelect"
+    />
+
+    <BaseModal :open="showDeleteModal" title="Delete upload" @close="showDeleteModal = false">
+      <p>Delete the uploaded set?</p>
+      <p class="text-muted">The show will have nothing to play at air time until you upload again.</p>
+      <template #footer>
+        <BaseButton variant="ghost" @click="showDeleteModal = false">Cancel</BaseButton>
+        <BaseButton variant="danger" :loading="deleting" @click="deleteUpload">Delete</BaseButton>
+      </template>
+    </BaseModal>
+  </div>
+</template>
+
+<style scoped>
+.prep-upload {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  font-family: var(--font-ui);
+}
+
+.pu-dropzone {
+  border: 1px dashed var(--color-border-light);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xl) var(--spacing-md);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.pu-dropzone:hover,
+.pu-dropzone.dragging {
+  border-color: var(--color-primary);
+}
+
+.pu-drop-ico {
+  font-size: 1.5rem;
+  color: var(--color-text-muted);
+}
+
+.pu-drop-text {
+  margin: var(--spacing-sm) 0 2px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.pu-browse {
+  color: var(--color-primary);
+}
+
+.pu-drop-formats {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.pu-warn {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-warning);
+}
+
+.pu-progress,
+.pu-filerow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.pu-progress-body,
+.pu-file-info {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pu-file-ico {
+  flex: 0 0 auto;
+}
+
+.pu-filename {
+  margin: 0 0 var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pu-meta {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.pu-bar {
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-alt);
+  overflow: hidden;
+}
+
+.pu-bar-fill {
+  height: 100%;
+  background: var(--color-primary);
+  transition: width var(--transition-fast);
+}
+
+.pu-percent {
+  flex: 0 0 auto;
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+
+.pu-chip {
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.pu-chip.confirmed {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.pu-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.pu-hint {
+  margin: 0;
+  flex: 1 1 auto;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.pu-hint.done {
+  color: var(--color-success);
+}
+
+.pu-error {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-error);
+}
+
+.pu-input {
+  display: none;
+}
+</style>

--- a/frontend/src/admin/components/show-detail/ShowHeader.vue
+++ b/frontend/src/admin/components/show-detail/ShowHeader.vue
@@ -17,16 +17,25 @@ const props = defineProps<{
   phase: ShowPhase;
   editMode: boolean;
   canEdit: boolean;
+  /** Whether the date/host meta segments open the schedule & host editor. */
+  canEditSchedule: boolean;
   uploadingCover: boolean;
   saving: boolean;
   /** Title form value while editing. */
   title: string;
+  /** Description form value while editing. */
+  description: string;
+  /** Hide the description block (UNHEARD keeps it in its info card). */
+  hideDescription?: boolean;
 }>();
 
 const emit = defineEmits<{
   'update:title': [value: string];
+  'update:description': [value: string];
   'cover-selected': [file: File];
   'start-edit': [];
+  /** Open the schedule & host editor (clicked date/time or host in the meta line). */
+  'edit-schedule': [];
   save: [];
   cancel: [];
 }>();
@@ -118,8 +127,47 @@ function onCoverChange(event: Event) {
         </span>
       </div>
       <p class="sh-meta">
-        Show #{{ show.id }}<template v-if="airLabel"> · {{ airLabel }}</template>
-        <template v-if="show.host_username"> · Hosted by {{ show.host_username }}</template>
+        Show #{{ show.id }}
+        <template v-if="airLabel">
+          ·
+          <button
+            v-if="canEditSchedule"
+            type="button"
+            class="sh-meta-edit"
+            title="Edit date & time"
+            @click="emit('edit-schedule')"
+          >
+            {{ airLabel }} <span class="sh-pencil">✎</span>
+          </button>
+          <template v-else>{{ airLabel }}</template>
+        </template>
+        ·
+        <button
+          v-if="canEditSchedule"
+          type="button"
+          class="sh-meta-edit"
+          title="Edit host"
+          @click="emit('edit-schedule')"
+        >
+          {{ show.host_username ? `Hosted by ${show.host_username}` : 'No host assigned' }}
+          <span class="sh-pencil">✎</span>
+        </button>
+        <template v-else-if="show.host_username">Hosted by {{ show.host_username }}</template>
+      </p>
+
+      <textarea
+        v-if="editMode && !hideDescription"
+        :value="props.description"
+        class="sh-desc-input"
+        rows="3"
+        placeholder="Brief description... (listeners see this on the show page)"
+        @input="emit('update:description', ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+      <p v-else-if="show.description && !hideDescription" class="sh-desc">
+        {{ show.description }}
+      </p>
+      <p v-else-if="canEdit && !hideDescription" class="sh-desc empty">
+        No description yet — listeners see this on the show page.
       </p>
     </div>
 
@@ -290,6 +338,59 @@ function onCoverChange(event: Event) {
   font-family: var(--font-ui);
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+}
+
+.sh-meta-edit {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-bottom: 1px dashed var(--color-border-light);
+}
+
+.sh-meta-edit:hover {
+  color: var(--color-text);
+  border-bottom-color: var(--color-text-muted);
+}
+
+.sh-pencil {
+  font-size: 0.75em;
+  opacity: 0.7;
+}
+
+.sh-desc {
+  margin: var(--spacing-sm) 0 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--color-text);
+  white-space: pre-line;
+}
+
+.sh-desc.empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.sh-desc-input {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+  padding: 8px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.sh-desc-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
 }
 
 .sh-actions {

--- a/frontend/src/admin/components/show-detail/ShowHeader.vue
+++ b/frontend/src/admin/components/show-detail/ShowHeader.vue
@@ -1,0 +1,306 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { ShowDetail } from '../../api';
+import { BaseButton, FormInput } from '@shared/components';
+import type { ShowPhase } from '../../composables/useShowPhase';
+
+/**
+ * Identity header of the redesigned show dashboard: cover thumbnail (with
+ * replace), show title as the page h1, type + phase badges, and a single meta
+ * line (show # · air date/time · host). Replaces the old "Episode overview"
+ * page title + separate identity card.
+ *
+ * Pure presentation: edit state and all side effects stay on ShowDetailPage.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  phase: ShowPhase;
+  editMode: boolean;
+  canEdit: boolean;
+  uploadingCover: boolean;
+  saving: boolean;
+  /** Title form value while editing. */
+  title: string;
+}>();
+
+const emit = defineEmits<{
+  'update:title': [value: string];
+  'cover-selected': [file: File];
+  'start-edit': [];
+  save: [];
+  cancel: [];
+}>();
+
+const coverInput = ref<HTMLInputElement | null>(null);
+
+const showTypeLabel = computed(() => (props.show.show_type || 'unheard').toUpperCase());
+
+const phaseBadge = computed(() => {
+  switch (props.phase) {
+    case 'broadcast':
+      return { label: 'On air', cls: 'onair' };
+    case 'wrapup':
+      return { label: 'Finished', cls: 'finished' };
+    default:
+      return { label: 'Upcoming', cls: 'upcoming' };
+  }
+});
+
+/** "Sun, Jul 12, 2026 at 16:40–18:40" (end segment optional). */
+const airLabel = computed(() => {
+  const s = props.show;
+  if (!s.date) return null;
+  const d = new Date(s.date + 'T' + (s.start_time || '00:00') + ':00');
+  const day = d.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const verb = props.phase === 'wrapup' ? 'Aired' : '';
+  let time = '';
+  if (s.start_time) {
+    time = ` at ${s.start_time}`;
+    if (s.end_time) time += `–${s.end_time}`;
+  }
+  return `${verb ? verb + ' ' : ''}${day}${time}`;
+});
+
+function onCoverChange(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) {
+    emit('cover-selected', file);
+  }
+  input.value = '';
+}
+</script>
+
+<template>
+  <div class="show-header">
+    <div class="sh-cover">
+      <img v-if="show.cover_url" :src="show.cover_url" alt="Cover" class="sh-cover-img" />
+      <div v-else class="sh-cover-placeholder">🎙</div>
+      <button
+        v-if="canEdit"
+        type="button"
+        class="sh-cover-replace"
+        :disabled="uploadingCover"
+        @click="coverInput?.click()"
+      >
+        ⬆ {{ show.cover_url ? 'Replace' : 'Upload' }}
+      </button>
+      <input
+        ref="coverInput"
+        type="file"
+        accept="image/*"
+        class="sh-cover-input"
+        @change="onCoverChange"
+      />
+    </div>
+
+    <div class="sh-body">
+      <div class="sh-title-row">
+        <FormInput
+          v-if="editMode"
+          class="sh-title-input"
+          :model-value="props.title"
+          required
+          @update:model-value="emit('update:title', $event)"
+        />
+        <h1 v-else class="sh-title">{{ show.title }}</h1>
+        <span class="sh-badge" :class="`type-${show.show_type || 'unheard'}`">
+          {{ showTypeLabel }}
+        </span>
+        <span class="sh-badge phase" :class="phaseBadge.cls">
+          <span v-if="phase === 'broadcast'" class="sh-dot"></span>
+          {{ phaseBadge.label }}
+        </span>
+      </div>
+      <p class="sh-meta">
+        Show #{{ show.id }}<template v-if="airLabel"> · {{ airLabel }}</template>
+        <template v-if="show.host_username"> · Hosted by {{ show.host_username }}</template>
+      </p>
+    </div>
+
+    <div class="sh-actions">
+      <BaseButton v-if="canEdit && !editMode" variant="ghost" size="sm" @click="emit('start-edit')">
+        ✎ Edit
+      </BaseButton>
+      <template v-if="editMode">
+        <BaseButton variant="ghost" size="sm" @click="emit('cancel')">Cancel</BaseButton>
+        <BaseButton variant="primary" size="sm" :loading="saving" @click="emit('save')">
+          Save
+        </BaseButton>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.show-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
+  padding-bottom: var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--spacing-lg);
+}
+
+.sh-cover {
+  position: relative;
+  flex: 0 0 auto;
+  width: 72px;
+  height: 72px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-surface-alt);
+}
+
+.sh-cover-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sh-cover-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+}
+
+.sh-cover-replace {
+  position: absolute;
+  inset: auto 0 0 0;
+  border: none;
+  padding: 3px 0;
+  font-size: 0.65rem;
+  font-family: var(--font-ui);
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.sh-cover:hover .sh-cover-replace,
+.sh-cover-replace:focus-visible {
+  opacity: 1;
+}
+
+.sh-cover-replace:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.sh-cover-input {
+  display: none;
+}
+
+.sh-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sh-title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.sh-title {
+  margin: 0;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+
+.sh-title-input {
+  min-width: 220px;
+}
+
+.sh-badge {
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.sh-badge.type-external {
+  background: rgba(59, 130, 246, 0.12);
+  color: #3b82f6;
+}
+
+.sh-badge.type-brunchtime {
+  background: rgba(245, 158, 11, 0.14);
+  color: #f59e0b;
+}
+
+.sh-badge.phase {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.sh-badge.phase.upcoming {
+  background: rgba(59, 130, 246, 0.12);
+  color: #3b82f6;
+}
+
+.sh-badge.phase.onair {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.sh-badge.phase.finished {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.sh-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-error);
+  animation: sh-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes sh-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.sh-meta {
+  margin: var(--spacing-xs) 0 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.sh-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+@media (max-width: 640px) {
+  .show-header {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/frontend/src/admin/components/show-detail/StatusStrip.vue
+++ b/frontend/src/admin/components/show-detail/StatusStrip.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ShowDetail, SoundCloudStatus } from '../../api';
+import type { ShowPhase } from '../../composables/useShowPhase';
+
+/**
+ * The status strip of the redesigned show dashboard: three compact metric
+ * cards under the header.
+ *
+ *   1. Clock    — countdown to air / time on air / finished duration
+ *   2. Mode     — streaming-mode toggle + preparation readiness (prep/broadcast)
+ *                 or publishing progress (wrap-up)
+ *   3. Announcements — slot overview (composer wiring lands with the
+ *                 scheduled-announcements backend)
+ *
+ * Pure presentation; all side effects live on ShowDetailPage.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  phase: ShowPhase;
+  mode: 'live' | 'upload';
+  canManage: boolean;
+  countdown: string;
+  elapsed: string;
+  /** Actual duration of the finished show, or null to fall back to schedule. */
+  duration: string | null;
+  recordingState: 'ready' | 'processing' | 'failed' | null;
+  scStatus: SoundCloudStatus | null;
+  /** Number of composed announcement slots (of 4). */
+  announcementsReady: number;
+  /** Render the streaming-mode card (false for UNHEARD, which has no host flow). */
+  modeCard?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'select-live': [];
+  'select-upload': [];
+}>();
+
+const clock = computed(() => {
+  switch (props.phase) {
+    case 'broadcast':
+      return { label: 'On air since', value: props.elapsed, hint: null };
+    case 'wrapup': {
+      if (props.duration) {
+        return {
+          label: 'Duration',
+          value: props.duration,
+          hint: scheduledLabel.value ? `Scheduled ${scheduledLabel.value}` : null,
+        };
+      }
+      // No recording length yet — fall back to the scheduled duration rather
+      // than rendering a bare dash.
+      return {
+        label: 'Duration',
+        value: scheduledLabel.value ?? '—',
+        hint: scheduledLabel.value ? 'Scheduled — recording still processing' : null,
+      };
+    }
+    default:
+      return { label: 'On air in', value: props.countdown, hint: null };
+  }
+});
+
+/** "2h" / "1h 30m" from the scheduled start/end times. */
+const scheduledLabel = computed(() => {
+  const s = props.show;
+  if (!s.start_time || !s.end_time) return null;
+  const [sh, sm] = s.start_time.split(':').map(Number);
+  const [eh, em] = s.end_time.split(':').map(Number);
+  let mins = eh * 60 + em - (sh * 60 + sm);
+  if (mins <= 0) mins += 24 * 60; // overnight show
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+});
+
+// ── Card 2: preparation readiness (prep/broadcast) ─────────────────────────
+const hasFile = computed(() => !!props.show.prerecorded_key);
+const confirmed = computed(() => !!props.show.prerecorded_confirmed_at);
+
+const prepStatus = computed<{ label: string; done: boolean }>(() => {
+  if (props.mode === 'live') {
+    return { label: 'Ready to stream at air time', done: true };
+  }
+  if (!hasFile.value) return { label: 'No file uploaded yet', done: false };
+  return confirmed.value
+    ? { label: 'File uploaded & confirmed', done: true }
+    : { label: 'Uploaded — not confirmed', done: false };
+});
+
+// ── Card 2: publishing progress (wrap-up) ──────────────────────────────────
+const publishing = computed<{ label: string; cls: string; hint: string | null }>(() => {
+  if (props.recordingState === 'failed') {
+    return { label: 'Recording failed', cls: 'error', hint: null };
+  }
+  if (props.recordingState === 'processing') {
+    return { label: 'Converting audio…', cls: 'busy', hint: 'Download unlocks when done' };
+  }
+  if (props.show.soundcloud_url) {
+    return props.show.soundcloud_public
+      ? { label: 'Published on SoundCloud', cls: 'done', hint: null }
+      : { label: '🔒 Private on SoundCloud', cls: 'warn', hint: '1 step left — publish below' };
+  }
+  if (props.recordingState === 'ready') {
+    return { label: 'Audio ready', cls: 'done', hint: 'Not on SoundCloud yet' };
+  }
+  return { label: 'No recording', cls: 'muted', hint: null };
+});
+</script>
+
+<template>
+  <div class="status-strip">
+    <div class="ss-card">
+      <p class="ss-label">{{ clock.label }}</p>
+      <p class="ss-clock">{{ clock.value }}</p>
+      <p v-if="clock.hint" class="ss-hint">{{ clock.hint }}</p>
+    </div>
+
+    <div v-if="phase === 'wrapup' || modeCard !== false" class="ss-card">
+      <template v-if="phase !== 'wrapup'">
+        <p class="ss-label">Streaming mode</p>
+        <div v-if="canManage" class="ss-modetoggle" role="group" aria-label="Streaming mode">
+          <button
+            type="button"
+            :class="['ss-modebtn', { active: mode === 'upload' }]"
+            @click="emit('select-upload')"
+          >
+            ☁️ Pre-recorded
+          </button>
+          <button
+            type="button"
+            :class="['ss-modebtn', { active: mode === 'live' }]"
+            @click="emit('select-live')"
+          >
+            📡 Live
+          </button>
+        </div>
+        <p v-else class="ss-value">{{ mode === 'live' ? '📡 Live' : '☁️ Pre-recorded' }}</p>
+        <p class="ss-hint" :class="{ done: prepStatus.done, warn: !prepStatus.done }">
+          {{ prepStatus.label }}
+        </p>
+      </template>
+      <template v-else>
+        <p class="ss-label">Publishing</p>
+        <p class="ss-value" :class="publishing.cls">{{ publishing.label }}</p>
+        <p v-if="publishing.hint" class="ss-hint">{{ publishing.hint }}</p>
+      </template>
+    </div>
+
+    <div class="ss-card">
+      <p class="ss-label">Announcements</p>
+      <p class="ss-value">{{ announcementsReady }} of 4 {{ phase === 'wrapup' ? 'sent' : 'scheduled' }}</p>
+      <p class="ss-hint">Instagram · Telegram</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.status-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.ss-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  min-width: 0;
+}
+
+.ss-label {
+  margin: 0 0 var(--spacing-xs);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.ss-clock {
+  margin: 0;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.ss-value {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ss-value.done {
+  color: var(--color-success);
+}
+
+.ss-value.warn {
+  color: var(--color-warning);
+}
+
+.ss-value.error {
+  color: var(--color-error);
+}
+
+.ss-value.busy {
+  color: #3b82f6;
+}
+
+.ss-value.muted {
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+
+.ss-hint {
+  margin: var(--spacing-xs) 0 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.ss-hint.done {
+  color: var(--color-success);
+}
+
+.ss-hint.warn {
+  color: var(--color-warning);
+}
+
+.ss-modetoggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.ss-modebtn {
+  padding: 5px 12px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.ss-modebtn:hover {
+  background: var(--color-surface-hover);
+}
+
+.ss-modebtn.active {
+  background: var(--color-surface-hover);
+  color: var(--color-primary);
+}
+</style>

--- a/frontend/src/admin/components/show-detail/TelegramComposerModal.vue
+++ b/frontend/src/admin/components/show-detail/TelegramComposerModal.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
   open: boolean;
   show: ShowDetail;
   sending: boolean;
+  /** Only admins may trigger the bot (matches the backend gate). */
+  canSend: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -57,7 +59,13 @@ const timeLabel = computed(() => props.show.start_time || '');
     </p>
     <template #footer>
       <BaseButton variant="ghost" @click="emit('close')">Cancel</BaseButton>
-      <BaseButton variant="primary" :loading="sending" @click="emit('send')">
+      <BaseButton
+        variant="primary"
+        :loading="sending"
+        :disabled="!canSend"
+        :title="canSend ? undefined : 'Only admins can send the Telegram preview'"
+        @click="emit('send')"
+      >
         Send preview to channel
       </BaseButton>
     </template>

--- a/frontend/src/admin/components/show-detail/TelegramComposerModal.vue
+++ b/frontend/src/admin/components/show-detail/TelegramComposerModal.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { ShowDetail } from '../../api';
+import { BaseButton, BaseModal } from '@shared/components';
+
+/**
+ * Telegram announcement composer: live chat-bubble preview of what the bot
+ * will post (cover + caption), with "Send preview" wired to the existing
+ * backend preview endpoint. Caption editing and scheduling land with the
+ * scheduled-announcements backend; until then the caption mirrors what the
+ * backend composes from the show data.
+ */
+const props = defineProps<{
+  open: boolean;
+  show: ShowDetail;
+  sending: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  send: [];
+}>();
+
+/** Frontend approximation of the backend-composed message. */
+const caption = computed(() => {
+  const s = props.show;
+  const when = s.date
+    ? new Date(s.date + 'T' + (s.start_time || '00:00') + ':00').toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'short',
+        day: 'numeric',
+      })
+    : '';
+  const time = s.start_time ? ` · ${s.start_time}` : '';
+  const host = s.host_username ? ` with ${s.host_username}` : '';
+  return `${s.title}${host}\n${when}${time}\nTune in live on moafunk.de`;
+});
+
+const timeLabel = computed(() => props.show.start_time || '');
+</script>
+
+<template>
+  <BaseModal :open="open" title="📱 Telegram · announcement" @close="emit('close')">
+    <div class="tg-preview-wrap">
+      <div class="tg-bubble">
+        <img v-if="show.cover_url" :src="show.cover_url" alt="Show cover" class="tg-img" />
+        <div class="tg-body">
+          <p class="tg-channel">Moafunk</p>
+          <p class="tg-text">{{ caption }}</p>
+          <p class="tg-time">{{ timeLabel }}</p>
+        </div>
+      </div>
+    </div>
+    <p class="tg-note">
+      The bot composes the final message from the show data. Caption editing &amp; scheduling
+      arrive in a later update.
+    </p>
+    <template #footer>
+      <BaseButton variant="ghost" @click="emit('close')">Cancel</BaseButton>
+      <BaseButton variant="primary" :loading="sending" @click="emit('send')">
+        Send preview to channel
+      </BaseButton>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+.tg-preview-wrap {
+  display: flex;
+  justify-content: center;
+  padding: var(--spacing-md);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  font-family: var(--font-ui);
+}
+
+.tg-bubble {
+  max-width: 280px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px 12px 12px 2px;
+  overflow: hidden;
+}
+
+.tg-img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.tg-body {
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.tg-channel {
+  margin: 0 0 2px;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: #3b82f6;
+}
+
+.tg-text {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+  color: var(--color-text);
+  white-space: pre-line;
+}
+
+.tg-time {
+  margin: var(--spacing-xs) 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+}
+
+.tg-note {
+  margin: var(--spacing-md) 0 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/admin/components/show-detail/WrapupPipeline.vue
+++ b/frontend/src/admin/components/show-detail/WrapupPipeline.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { LatestRecording, ShowDetail, SoundCloudStatus } from '../../api';
+import { BaseButton } from '@shared/components';
+import AudioPlayer from '../AudioPlayer.vue';
+import { fmtClock } from '../../composables/useShowClocks';
+
+/**
+ * Post-production pipeline for finished shows: a step list from
+ * "stream ended" through audio conversion (→ download) to SoundCloud
+ * upload (→ publish). Each step shows its own state, so a missing duration
+ * or pending conversion reads as "processing" rather than broken.
+ *
+ * Pure presentation: all side effects live on ShowDetailPage.
+ */
+const props = defineProps<{
+  show: ShowDetail;
+  latestRecording: LatestRecording | null;
+  recordingState: 'ready' | 'processing' | 'failed' | null;
+  canManage: boolean;
+  canPublish: boolean;
+  canGoLiveAgain: boolean;
+  scStatus: SoundCloudStatus | null;
+  uploadingToSoundCloud: boolean;
+  togglingSoundCloudPrivacy: boolean;
+}>();
+
+const emit = defineEmits<{
+  publish: [];
+  'upload-soundcloud': [];
+  'connect-soundcloud': [];
+  'live-panel': [];
+}>();
+
+const durationLabel = computed(() =>
+  props.latestRecording?.duration_ms ? fmtClock(props.latestRecording.duration_ms) : null
+);
+
+type StepState = 'done' | 'busy' | 'failed' | 'pending';
+
+const conversionStep = computed<{ state: StepState; hint: string }>(() => {
+  switch (props.recordingState) {
+    case 'ready':
+      return {
+        state: 'done',
+        hint: durationLabel.value ? `Recorded ${durationLabel.value}` : 'Ready to download',
+      };
+    case 'processing':
+      return { state: 'busy', hint: 'Converting — download unlocks when done' };
+    case 'failed':
+      return {
+        state: 'failed',
+        hint: props.latestRecording?.error_message || 'Recording failed.',
+      };
+    default:
+      return { state: 'pending', hint: 'No live recording for this show' };
+  }
+});
+
+const soundcloudStep = computed<{ state: StepState; hint: string }>(() => {
+  if (props.show.soundcloud_url) {
+    return props.show.soundcloud_public
+      ? { state: 'done', hint: 'Published — visible to listeners' }
+      : { state: 'busy', hint: 'Private — not visible to listeners yet' };
+  }
+  if (!props.scStatus?.configured) return { state: 'pending', hint: 'Not configured' };
+  if (!props.scStatus.authorized) return { state: 'pending', hint: 'Connect SoundCloud first' };
+  return { state: 'pending', hint: 'Not uploaded yet' };
+});
+
+const STEP_ICONS: Record<StepState, string> = {
+  done: '✓',
+  busy: '◌',
+  failed: '✕',
+  pending: '·',
+};
+</script>
+
+<template>
+  <div class="card wrapup-card">
+    <div class="wp-head">
+      <h2 class="wp-title">Post-production</h2>
+      <BaseButton
+        v-if="canManage && canGoLiveAgain"
+        variant="ghost"
+        size="sm"
+        title="Still inside the show window — resume streaming"
+        @click="emit('live-panel')"
+      >
+        ↻ Go live again
+      </BaseButton>
+    </div>
+
+    <!-- Step 1: recording / conversion → download -->
+    <div class="wp-step">
+      <span class="wp-step-ico" :class="conversionStep.state">
+        {{ STEP_ICONS[conversionStep.state] }}
+      </span>
+      <div class="wp-step-body">
+        <p class="wp-step-label">Audio file</p>
+        <p class="wp-step-hint" :class="conversionStep.state">{{ conversionStep.hint }}</p>
+      </div>
+      <a
+        v-if="recordingState === 'ready' && latestRecording?.download_url"
+        :href="latestRecording.download_url"
+        class="wp-dl"
+        download
+      >
+        ⬇ Download
+      </a>
+    </div>
+
+    <AudioPlayer
+      v-if="recordingState === 'ready' && latestRecording?.download_url"
+      :key="latestRecording.download_url"
+      :src="latestRecording.download_url"
+    />
+
+    <!-- Step 2: SoundCloud upload → publish -->
+    <div v-if="canPublish && scStatus" class="wp-step">
+      <span class="wp-step-ico" :class="soundcloudStep.state">
+        {{ STEP_ICONS[soundcloudStep.state] }}
+      </span>
+      <div class="wp-step-body">
+        <p class="wp-step-label">
+          SoundCloud
+          <a
+            v-if="show.soundcloud_url"
+            :href="show.soundcloud_url"
+            target="_blank"
+            rel="noopener"
+            class="wp-link"
+            >open ↗</a
+          >
+        </p>
+        <p class="wp-step-hint" :class="soundcloudStep.state">{{ soundcloudStep.hint }}</p>
+      </div>
+
+      <template v-if="!scStatus.configured"></template>
+      <BaseButton
+        v-else-if="!scStatus.authorized"
+        size="sm"
+        variant="primary"
+        @click="emit('connect-soundcloud')"
+      >
+        🔗 Connect
+      </BaseButton>
+      <BaseButton
+        v-else-if="show.soundcloud_url && !show.soundcloud_public"
+        size="sm"
+        variant="success"
+        :loading="togglingSoundCloudPrivacy"
+        @click="emit('publish')"
+      >
+        🚀 Publish
+      </BaseButton>
+      <BaseButton
+        v-else-if="!show.soundcloud_url"
+        size="sm"
+        variant="ghost"
+        :loading="uploadingToSoundCloud"
+        @click="emit('upload-soundcloud')"
+      >
+        ☁️ Upload to SoundCloud
+      </BaseButton>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.wrapup-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  min-height: 100%;
+  font-family: var(--font-ui);
+}
+
+.wp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.wp-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.wp-step {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.wp-step:last-child {
+  border-bottom: none;
+}
+
+.wp-step-ico {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.wp-step-ico.done {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.wp-step-ico.busy {
+  background: rgba(59, 130, 246, 0.12);
+  color: #3b82f6;
+  animation: wp-spin 1.6s linear infinite;
+}
+
+.wp-step-ico.failed {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+@keyframes wp-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.wp-step-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.wp-step-label {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.wp-step-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.wp-step-hint.failed {
+  color: var(--color-error);
+}
+
+.wp-step-hint.done {
+  color: var(--color-success);
+}
+
+.wp-link {
+  margin-left: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  color: var(--color-link);
+}
+
+.wp-link:hover {
+  color: var(--color-link-hover);
+}
+
+.wp-dl {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  background-color: #8b5cf6;
+  color: #fff;
+  white-space: nowrap;
+}
+
+.wp-dl:hover {
+  opacity: 0.85;
+}
+</style>

--- a/frontend/src/admin/composables/useShowClocks.ts
+++ b/frontend/src/admin/composables/useShowClocks.ts
@@ -1,0 +1,76 @@
+import { computed, onScopeDispose, ref, type ComputedRef, type Ref } from 'vue';
+import type { LatestRecording } from '../api';
+
+/**
+ * Live clock values for the show dashboard status strip: countdown to air,
+ * elapsed since air, and the finished-show duration.
+ *
+ * Extracted from the former LiveCard so the redesigned dashboard can render
+ * them in a metric card. Owns a 1 s ticker; must be called inside an active
+ * effect scope.
+ */
+export interface UseShowClocks {
+  /** "04d 12h 33m 38s" until air (days dropped once under a day), or '—'. */
+  countdown: ComputedRef<string>;
+  /** Same format, time since air, or '—'. */
+  elapsed: ComputedRef<string>;
+  /** "HH:MM:SS" duration of the finished show, or null if unknown. */
+  duration: ComputedRef<string | null>;
+}
+
+/** "04d 12h 33m 38s" — days segment dropped once under a day. */
+export function fmtDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const d = Math.floor(total / 86400);
+  const h = Math.floor((total % 86400) / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return d > 0 ? `${d}d ${pad(h)}h ${pad(m)}m ${pad(s)}s` : `${pad(h)}h ${pad(m)}m ${pad(s)}s`;
+}
+
+/** "HH:MM:SS" clock — used for the finished-show duration. */
+export function fmtClock(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+export function useShowClocks(
+  airTarget: Ref<Date | null>,
+  latestRecording: Ref<LatestRecording | null>
+): UseShowClocks {
+  const now = ref(Date.now());
+  const timer = setInterval(() => {
+    now.value = Date.now();
+  }, 1000);
+  onScopeDispose(() => clearInterval(timer));
+
+  const countdown = computed(() =>
+    airTarget.value ? fmtDuration(airTarget.value.getTime() - now.value) : '—'
+  );
+
+  const elapsed = computed(() =>
+    airTarget.value ? fmtDuration(now.value - airTarget.value.getTime()) : '—'
+  );
+
+  /**
+   * Duration of the finished show. Prefers the recording's stored length; for
+   * legacy rows that predate duration persistence, a failed short capture
+   * still carries its length in the reason string ("… is only 3s …").
+   * Returns null when unknown so the caller can fall back to the scheduled
+   * duration instead of rendering a bare dash.
+   */
+  const duration = computed<string | null>(() => {
+    const rec = latestRecording.value?.duration_ms;
+    if (rec) return fmtClock(rec);
+    const shortMatch = latestRecording.value?.error_message?.match(/only (\d+)s/);
+    if (shortMatch) return fmtClock(Number(shortMatch[1]) * 1000);
+    return null;
+  });
+
+  return { countdown, elapsed, duration };
+}

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onActivated, onUnmounted } from 'vue';
+import { ref, computed, watch, onMounted, onActivated, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import {
   showsApi,
@@ -9,23 +9,25 @@ import {
   type SoundCloudStatus,
   type GuestCredentials,
 } from '../api';
-import { BaseButton, BaseModal, FormInput } from '@shared/components';
+import { BaseButton, BaseModal } from '@shared/components';
 import AudioPlayer from '../components/AudioPlayer.vue';
-import {
-  IdentityPanel,
-  LiveCard,
-  ScheduleHostPanel,
-  SocialMediaCard,
-} from '../components/show-cockpit/panels';
-import { GridShell } from './show-cockpit';
+import LiveSetupTest from '../components/LiveSetupTest.vue';
+import { ScheduleHostPanel } from '../components/show-cockpit/panels';
+import ShowHeader from '../components/show-detail/ShowHeader.vue';
+import StatusStrip from '../components/show-detail/StatusStrip.vue';
+import PrepUploadInline from '../components/show-detail/PrepUploadInline.vue';
+import WrapupPipeline from '../components/show-detail/WrapupPipeline.vue';
+import AnnouncementsCard from '../components/show-detail/AnnouncementsCard.vue';
+import TelegramComposerModal from '../components/show-detail/TelegramComposerModal.vue';
 import { useShowPhase } from '../composables/useShowPhase';
+import { useShowClocks } from '../composables/useShowClocks';
 import { useFlash } from '../composables/useFlash';
 import { useDataInvalidation } from '../composables/useDataInvalidation';
 import { useDateTimeRange } from '../composables/useDateTimeRange';
 import { useHostFlow } from '../composables/useHostFlow';
 import { useAuthStore } from '../stores/auth';
 import { resolveMediaMode } from '../showMediaMode';
-import { berlinToUtcDate } from '../showTime';
+import { berlinToUtcDate, isShowEnded } from '../showTime';
 import { VueDatePicker } from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 
@@ -132,15 +134,62 @@ const mediaMode = ref<'live' | 'upload'>('upload');
 /** The assigned host may manage media (matches the backend require_user_show check). */
 const canManageMedia = computed(() => !!show.value && show.value.host_user_id === auth.user?.id);
 
-// ── Dashboard: soft lifecycle phase drives the Live card's state machine ────
-// docs/stream-rework/show-cockpit-plan.md — the show host dashboard is a fixed
-// 2×2 grid (metadata · live · schedule+host · social).
+// ── Dashboard: soft lifecycle phase drives the layout's state machine ───────
+// docs/stream-rework/show-cockpit-plan.md — header → status strip → phase
+// panel (preparation / launchpad / post-production) + announcements.
 const { phase } = useShowPhase(show);
 
 const airTarget = computed(() => {
   if (!show.value?.date || !show.value?.start_time) return null;
   return berlinToUtcDate(show.value.date, show.value.start_time);
 });
+
+/** Still inside the show's air window → offer to resume streaming. */
+const canGoLiveAgain = computed(() => (show.value ? !isShowEnded(show.value) : false));
+
+// ── Inline preparation (absorbs /stream/upload · /stream/confirm · /stream/live)
+// The dashboard renders the prep panels directly; useHostFlow stays the source
+// of truth, so the fullscreen flow keeps working from the same state.
+const showTelegramModal = ref(false);
+
+/**
+ * Make sure the host-flow singleton has this show selected (and the current
+ * media mode set) so the inline prep panels can upload/confirm/test against it.
+ */
+async function ensureFlowSelection() {
+  if (!show.value || !canManageMedia.value) return;
+  const id = show.value.id;
+  let mine = hostFlow.shows.value.find((s) => s.id === id);
+  if (!mine) {
+    await hostFlow.fetchMyShow();
+    mine = hostFlow.shows.value.find((s) => s.id === id);
+  }
+  if (!mine) return;
+  if (hostFlow.show.value?.id !== id) {
+    hostFlow.selectShow(mine);
+  }
+  hostFlow.selectMode(mediaMode.value === 'live' ? 'live' : 'prerecorded');
+}
+
+watch(mediaMode, () => {
+  void ensureFlowSelection();
+});
+
+/** Inline prep changed something (upload/confirm/delete) — resync the show. */
+function onPrepChanged() {
+  void loadShow();
+}
+
+/** The inline live test passed — continue to the fullscreen live panel. */
+function goLivePanel() {
+  hostFlow.goToStep('on-air');
+  router.push('/stream/on-air');
+}
+
+async function sendTelegramFromModal() {
+  await sendTelegramPreview();
+  showTelegramModal.value = false;
+}
 
 /** Format a date string + time string into a readable datetime */
 function fmtDateTime(date: string, time: string): string {
@@ -205,6 +254,9 @@ const RECORDING_STATE_LABELS: Record<'ready' | 'processing' | 'failed', string> 
   processing: 'Processing…',
   failed: 'Failed',
 };
+
+// ── Status-strip clocks (countdown / elapsed / finished duration) ───────────
+const { countdown, elapsed, duration } = useShowClocks(airTarget, latestRecording);
 
 function formatDurationMs(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000);
@@ -314,6 +366,9 @@ async function loadShow() {
     // A present prerecorded file implies upload mode; otherwise honour the
     // delivery mode the show was created with (defaults to 'upload').
     mediaMode.value = resolveMediaMode(show.value);
+    // Prime the host-flow singleton so the inline prep panels work directly
+    // on this show (fire-and-forget; only relevant for the assigned host).
+    void ensureFlowSelection();
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to load show';
   } finally {
@@ -426,9 +481,6 @@ async function enterFlow(mode: 'prerecorded' | 'live') {
     flash.error(e instanceof Error ? e.message : 'Failed to open the streaming flow');
   }
 }
-
-/** Launch the user story for the currently selected media type. */
-const launchFlow = () => enterFlow(mediaMode.value === 'live' ? 'live' : 'prerecorded');
 
 // Description editing
 function startEditDescription() {
@@ -945,102 +997,190 @@ onUnmounted(() => {
     <div v-else-if="error" class="flash-message error">{{ error }}</div>
 
     <template v-else-if="show">
-      <!-- Header (UNHEARD) -->
-      <div v-if="isUnheard" class="page-header">
-        <router-link to="/shows" class="back-link">← Back to Shows</router-link>
-        <h1 class="page-title">{{ show.title }}</h1>
-      </div>
+      <!-- ===================== Unified show dashboard =====================
+           New layout (all show types): back link → identity header → status
+           strip → phase panel + announcements → details. -->
+      <router-link :to="isUnheard || isAdmin ? '/shows' : '/stream'" class="back-link">
+        ← Back
+      </router-link>
 
-      <!-- Header (external/brunchtime dashboard) -->
-      <div v-else class="page-header dash-header">
-        <router-link :to="isAdmin ? '/shows' : '/stream'" class="back-link">← Back</router-link>
-        <div class="dash-header-row">
-          <div>
-            <p class="dash-eyebrow">SHOW DASHBOARD</p>
-            <h1 class="page-title">Episode overview</h1>
-          </div>
-          <div class="dash-header-actions">
-            <BaseButton
-              v-if="canEdit && !editMode"
-              variant="ghost"
-              size="sm"
-              @click="startDashboardEdit"
-            >
-              ✎ Edit
-            </BaseButton>
-            <template v-if="editMode">
-              <BaseButton variant="ghost" size="sm" @click="cancelDashboardEdit">Cancel</BaseButton>
-              <BaseButton variant="primary" size="sm" :loading="saving" @click="saveDashboardEdits">
-                Save
-              </BaseButton>
+      <ShowHeader
+        v-model:title="titleForm"
+        :show="show"
+        :phase="phase"
+        :edit-mode="editMode"
+        :can-edit="!isUnheard && canEdit"
+        :uploading-cover="uploadingCover"
+        :saving="saving"
+        @cover-selected="uploadCoverFile"
+        @start-edit="startDashboardEdit"
+        @save="saveDashboardEdits"
+        @cancel="cancelDashboardEdit"
+      />
+
+      <StatusStrip
+        :show="show"
+        :phase="phase"
+        :mode="mediaMode"
+        :can-manage="!isUnheard && canManageMedia"
+        :countdown="countdown"
+        :elapsed="elapsed"
+        :duration="duration"
+        :recording-state="recordingState"
+        :sc-status="scStatus"
+        :announcements-ready="0"
+        :mode-card="!isUnheard"
+        @select-live="mediaMode = 'live'"
+        @select-upload="mediaMode = 'upload'"
+      />
+
+      <!-- ── Phase panel + announcements (external / brunchtime) ─────────── -->
+      <div v-if="!isUnheard" class="dash-main">
+        <div class="dash-phase">
+          <!-- PREP: inline preparation for the selected streaming mode -->
+          <div v-if="phase === 'prep'" class="card phase-card">
+            <h2 class="phase-title">
+              Preparation · {{ mediaMode === 'live' ? 'live' : 'pre-recorded' }}
+            </h2>
+            <template v-if="canManageMedia">
+              <PrepUploadInline
+                v-if="mediaMode === 'upload'"
+                :show-id="show.id"
+                @changed="onPrepChanged"
+              />
+              <LiveSetupTest v-else @passed="goLivePanel" />
             </template>
+            <p v-else class="phase-muted">
+              Only the assigned host can prepare the stream.
+              {{ show.host_username ? `Assigned host: ${show.host_username}.` : 'No host assigned yet.' }}
+            </p>
           </div>
-        </div>
-      </div>
 
-      <!-- ===================== External / brunchtime dashboard ===================== -->
-      <!-- Fixed 2×2 grid of cards (docs/stream-rework/show-cockpit-plan.md).
-           GridShell only arranges the named slots; all state/handlers stay here. -->
-      <GridShell v-if="!isUnheard">
-        <template #identity>
-          <IdentityPanel
-            v-model:title="titleForm"
-            v-model:description="descriptionForm"
-            :show="show"
-            :edit-mode="editMode"
-            :can-edit="canEdit"
-            :uploading-cover="uploadingCover"
-            @cover-selected="uploadCoverFile"
-          />
-        </template>
+          <!-- BROADCAST: launchpad — live controls stay in the fullscreen panel -->
+          <div v-else-if="phase === 'broadcast'" class="card phase-card launchpad">
+            <h2 class="phase-title">On air</h2>
+            <p class="launchpad-status">
+              <span class="launchpad-dot"></span>
+              On air · <span class="launchpad-elapsed">{{ elapsed }}</span>
+            </p>
+            <p class="phase-muted">
+              {{
+                mediaMode === 'live'
+                  ? 'Level meters, self-monitor and stop controls live in the panel.'
+                  : 'The backend plays your pre-recorded set automatically.'
+              }}
+            </p>
+            <BaseButton
+              v-if="canManageMedia"
+              variant="primary"
+              class="launchpad-action"
+              @click="enterFlow('live')"
+            >
+              🎛 Open live panel
+            </BaseButton>
+          </div>
 
-        <template #live>
-          <LiveCard
+          <!-- WRAP-UP: post-production pipeline -->
+          <WrapupPipeline
+            v-else
             :show="show"
-            :phase="phase"
-            :mode="mediaMode"
-            :air-target="airTarget"
             :latest-recording="latestRecording"
             :recording-state="recordingState"
             :can-manage="canManageMedia"
             :can-publish="canUseSoundcloud"
+            :can-go-live-again="canGoLiveAgain"
             :sc-status="scStatus"
             :uploading-to-sound-cloud="uploadingToSoundCloud"
             :toggling-sound-cloud-privacy="togglingSoundCloudPrivacy"
-            @select-live="mediaMode = 'live'"
-            @select-upload="mediaMode = 'upload'"
-            @prep="launchFlow"
-            @live-panel="enterFlow('live')"
             @publish="toggleSoundCloudPrivacy"
             @upload-soundcloud="uploadToSoundCloud"
             @connect-soundcloud="connectSoundCloud"
+            @live-panel="enterFlow('live')"
           />
-        </template>
+        </div>
 
-        <template #schedule>
-          <ScheduleHostPanel
-            v-model:edit-start="editStart"
-            v-model:edit-duration="editDuration"
-            v-model:selected-host-id="selectedHostId"
-            v-model:host-edit-mode="hostEditMode"
-            v-model:new-guest-username="newGuestUsername"
-            :show="show"
-            :edit-mode="editMode"
-            :can-edit-host="canEditHost"
-            :assigning-host="assigningHost"
-            :guest-creds="guestCreds"
-            :edit-time-valid="editTimeValid"
-            :edit-time-error="editTimeError"
-            @assign-host="assignHost"
-            @create-guest="createGuestHost"
-            @unassign-host="unassignHost"
-          />
-        </template>
+        <AnnouncementsCard
+          :show="show"
+          :phase="phase"
+          :can-post="isAdmin"
+          :sending-telegram-preview="sendingTelegramPreview"
+          @compose-instagram="openInstagramPreview"
+          @compose-telegram="showTelegramModal = true"
+        />
+      </div>
 
-        <template #social>
-          <SocialMediaCard />
-        </template>
-      </GridShell>
+      <!-- ── Details: description + schedule & host (external / brunchtime) ─ -->
+      <div v-if="!isUnheard" class="dash-second">
+        <div class="card desc-card">
+          <h2 class="phase-title">Description</h2>
+          <textarea
+            v-if="editMode"
+            v-model="descriptionForm"
+            class="text-field"
+            rows="4"
+            placeholder="Brief description..."
+          ></textarea>
+          <p v-else-if="show.description" class="desc-view">{{ show.description }}</p>
+          <p v-else class="empty-state">No description yet — listeners see this on the show page.</p>
+
+          <template v-if="isAdmin">
+            <div class="section-divider"></div>
+            <h3 class="phase-title">AI show bio</h3>
+            <template v-if="!editingAiBio">
+              <div v-if="show.ai_bio" class="desc-view">{{ show.ai_bio }}</div>
+              <p v-else class="empty-state">AI bio will be generated from the show description.</p>
+              <div class="button-row">
+                <BaseButton v-if="show.ai_bio" variant="ghost" size="sm" @click="startEditAiBio">
+                  Edit
+                </BaseButton>
+                <BaseButton
+                  variant="ghost"
+                  size="sm"
+                  :loading="regeneratingBio"
+                  :disabled="!show.description"
+                  @click="regenerateShowBio"
+                >
+                  ↻ Regenerate
+                </BaseButton>
+              </div>
+            </template>
+            <div v-else class="edit-panel">
+              <textarea
+                v-model="aiBioForm"
+                class="text-field"
+                rows="8"
+                placeholder="AI-generated show bio..."
+              ></textarea>
+              <div class="edit-actions">
+                <BaseButton variant="ghost" size="sm" @click="editingAiBio = false">
+                  Cancel
+                </BaseButton>
+                <BaseButton variant="primary" size="sm" :loading="saving" @click="saveAiBio">
+                  Save
+                </BaseButton>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <ScheduleHostPanel
+          v-model:edit-start="editStart"
+          v-model:edit-duration="editDuration"
+          v-model:selected-host-id="selectedHostId"
+          v-model:host-edit-mode="hostEditMode"
+          v-model:new-guest-username="newGuestUsername"
+          :show="show"
+          :edit-mode="editMode"
+          :can-edit-host="canEditHost"
+          :assigning-host="assigningHost"
+          :guest-creds="guestCreds"
+          :edit-time-valid="editTimeValid"
+          :edit-time-error="editTimeError"
+          @assign-host="assignHost"
+          @create-guest="createGuestHost"
+          @unassign-host="unassignHost"
+        />
+      </div>
 
       <div v-if="isUnheard" class="top-grid">
         <div class="main-column">
@@ -1217,23 +1357,22 @@ onUnmounted(() => {
           <h2 class="section-title">Cover</h2>
           <div v-if="show.cover_url" class="show-cover-preview">
             <img :src="show.cover_url" alt="Show Cover" class="show-cover-img" />
-            <div v-if="isAdmin" class="cover-actions">
-              <BaseButton variant="primary" size="sm" @click="openInstagramPreview">
-                <span v-if="show.instagram_posted_at">📸 Posted to Instagram ✓</span>
-                <span v-else>📸 Instagram Preview</span>
-              </BaseButton>
-              <BaseButton
-                variant="secondary"
-                size="sm"
-                :loading="sendingTelegramPreview"
-                @click="sendTelegramPreview"
-              >
-                📱 Preview on Telegram
-              </BaseButton>
-            </div>
           </div>
           <p v-else class="empty-state">Cover appears after artists are assigned and processed.</p>
         </div>
+      </div>
+
+      <!-- Announcements (UNHEARD) — the Instagram/Telegram actions moved here
+           from the old cover card so all show types share the same card. -->
+      <div v-if="isUnheard" class="unheard-announcements">
+        <AnnouncementsCard
+          :show="show"
+          :phase="phase"
+          :can-post="isAdmin"
+          :sending-telegram-preview="sendingTelegramPreview"
+          @compose-instagram="openInstagramPreview"
+          @compose-telegram="showTelegramModal = true"
+        />
       </div>
 
       <!-- Download / Upload Row (UNHEARD only, admin only) -->
@@ -1649,6 +1788,16 @@ onUnmounted(() => {
       </template>
     </BaseModal>
 
+    <!-- Telegram Composer Modal (all show types) -->
+    <TelegramComposerModal
+      v-if="show"
+      :open="showTelegramModal"
+      :show="show"
+      :sending="sendingTelegramPreview"
+      @close="showTelegramModal = false"
+      @send="sendTelegramFromModal"
+    />
+
     <!-- Instagram Re-post Confirmation Modal (all show types) -->
     <BaseModal
       :open="showInstagramConfirmModal"
@@ -1687,6 +1836,121 @@ onUnmounted(() => {
 
 .card {
   margin-bottom: var(--spacing-lg);
+}
+
+/* ── Redesigned dashboard layout (all show types) ───────────────────────── */
+.dash-main {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: var(--spacing-lg);
+  align-items: stretch;
+  margin-bottom: var(--spacing-lg);
+}
+
+.dash-phase {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.dash-phase > .card,
+.dash-main > :deep(.card) {
+  flex: 1 1 auto;
+  margin-bottom: 0;
+  min-height: 100%;
+}
+
+.dash-second {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-lg);
+  align-items: stretch;
+  margin-bottom: var(--spacing-lg);
+}
+
+.dash-second > .card,
+.dash-second > :deep(.card) {
+  margin-bottom: 0;
+}
+
+.phase-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.phase-title {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.phase-muted {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.launchpad-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-error);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.launchpad-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-error);
+  animation: launchpad-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes launchpad-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.launchpad-elapsed {
+  font-variant-numeric: tabular-nums;
+}
+
+.launchpad-action {
+  margin-top: auto;
+  width: 100%;
+}
+
+.desc-view {
+  margin: 0;
+  font-family: var(--font-ui);
+  line-height: var(--line-height-relaxed, 1.6);
+  color: var(--color-text);
+  white-space: pre-line;
+}
+
+.unheard-announcements {
+  margin-bottom: var(--spacing-lg);
+}
+
+@media (max-width: 900px) {
+  .dash-main,
+  .dash-second {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── External/brunchtime dashboard ──────────────────────────────────────── */

--- a/frontend/src/admin/pages/ShowDetailPage.vue
+++ b/frontend/src/admin/pages/ShowDetailPage.vue
@@ -151,6 +151,39 @@ const canGoLiveAgain = computed(() => (show.value ? !isShowEnded(show.value) : f
 // The dashboard renders the prep panels directly; useHostFlow stays the source
 // of truth, so the fullscreen flow keeps working from the same state.
 const showTelegramModal = ref(false);
+const showScheduleModal = ref(false);
+
+/** Open the schedule & host editor (from the header meta line). */
+function openScheduleModal() {
+  if (!show.value) return;
+  setEditRange(show.value.date, show.value.start_time, show.value.end_time);
+  guestCreds.value = null;
+  showScheduleModal.value = true;
+}
+
+/** Save date/time edits made in the schedule modal, then close it. */
+async function saveScheduleFromModal() {
+  if (!show.value) return;
+  if (!editTimeValid.value) {
+    flash.error(editTimeError.value || 'Invalid date/time');
+    return;
+  }
+  saving.value = true;
+  try {
+    await showsApi.update(show.value.id, {
+      date: editDate.value,
+      start_time: editStartTime.value || undefined,
+      end_time: editEndTime.value || undefined,
+    });
+    flash.success('Date & time updated');
+    showScheduleModal.value = false;
+    await loadShow();
+  } catch (e) {
+    flash.error(e instanceof Error ? e.message : 'Failed to update date & time');
+  } finally {
+    saving.value = false;
+  }
+}
 
 /**
  * Make sure the host-flow singleton has this show selected (and the current
@@ -1006,14 +1039,18 @@ onUnmounted(() => {
 
       <ShowHeader
         v-model:title="titleForm"
+        v-model:description="descriptionForm"
         :show="show"
         :phase="phase"
         :edit-mode="editMode"
         :can-edit="!isUnheard && canEdit"
+        :can-edit-schedule="!isUnheard && (canEdit || canEditHost)"
+        :hide-description="isUnheard"
         :uploading-cover="uploadingCover"
         :saving="saving"
         @cover-selected="uploadCoverFile"
         @start-edit="startDashboardEdit"
+        @edit-schedule="openScheduleModal"
         @save="saveDashboardEdits"
         @cancel="cancelDashboardEdit"
       />
@@ -1102,83 +1139,8 @@ onUnmounted(() => {
         <AnnouncementsCard
           :show="show"
           :phase="phase"
-          :can-post="isAdmin"
-          :sending-telegram-preview="sendingTelegramPreview"
           @compose-instagram="openInstagramPreview"
           @compose-telegram="showTelegramModal = true"
-        />
-      </div>
-
-      <!-- ── Details: description + schedule & host (external / brunchtime) ─ -->
-      <div v-if="!isUnheard" class="dash-second">
-        <div class="card desc-card">
-          <h2 class="phase-title">Description</h2>
-          <textarea
-            v-if="editMode"
-            v-model="descriptionForm"
-            class="text-field"
-            rows="4"
-            placeholder="Brief description..."
-          ></textarea>
-          <p v-else-if="show.description" class="desc-view">{{ show.description }}</p>
-          <p v-else class="empty-state">No description yet — listeners see this on the show page.</p>
-
-          <template v-if="isAdmin">
-            <div class="section-divider"></div>
-            <h3 class="phase-title">AI show bio</h3>
-            <template v-if="!editingAiBio">
-              <div v-if="show.ai_bio" class="desc-view">{{ show.ai_bio }}</div>
-              <p v-else class="empty-state">AI bio will be generated from the show description.</p>
-              <div class="button-row">
-                <BaseButton v-if="show.ai_bio" variant="ghost" size="sm" @click="startEditAiBio">
-                  Edit
-                </BaseButton>
-                <BaseButton
-                  variant="ghost"
-                  size="sm"
-                  :loading="regeneratingBio"
-                  :disabled="!show.description"
-                  @click="regenerateShowBio"
-                >
-                  ↻ Regenerate
-                </BaseButton>
-              </div>
-            </template>
-            <div v-else class="edit-panel">
-              <textarea
-                v-model="aiBioForm"
-                class="text-field"
-                rows="8"
-                placeholder="AI-generated show bio..."
-              ></textarea>
-              <div class="edit-actions">
-                <BaseButton variant="ghost" size="sm" @click="editingAiBio = false">
-                  Cancel
-                </BaseButton>
-                <BaseButton variant="primary" size="sm" :loading="saving" @click="saveAiBio">
-                  Save
-                </BaseButton>
-              </div>
-            </div>
-          </template>
-        </div>
-
-        <ScheduleHostPanel
-          v-model:edit-start="editStart"
-          v-model:edit-duration="editDuration"
-          v-model:selected-host-id="selectedHostId"
-          v-model:host-edit-mode="hostEditMode"
-          v-model:new-guest-username="newGuestUsername"
-          :show="show"
-          :edit-mode="editMode"
-          :can-edit-host="canEditHost"
-          :assigning-host="assigningHost"
-          :guest-creds="guestCreds"
-          :edit-time-valid="editTimeValid"
-          :edit-time-error="editTimeError"
-          @assign-host="assignHost"
-          @create-guest="createGuestHost"
-          @unassign-host="unassignHost"
         />
       </div>
 
@@ -1368,8 +1330,6 @@ onUnmounted(() => {
         <AnnouncementsCard
           :show="show"
           :phase="phase"
-          :can-post="isAdmin"
-          :sending-telegram-preview="sendingTelegramPreview"
           @compose-instagram="openInstagramPreview"
           @compose-telegram="showTelegramModal = true"
         />
@@ -1780,10 +1740,50 @@ onUnmounted(() => {
         <BaseButton
           variant="primary"
           :loading="postingToInstagram"
-          :disabled="!show?.ai_bio || !show?.cover_url"
+          :disabled="!show?.ai_bio || !show?.cover_url || !isAdmin"
+          :title="isAdmin ? undefined : 'Only admins can post to Instagram'"
           @click="postToInstagram()"
         >
           📤 Publish
+        </BaseButton>
+      </template>
+    </BaseModal>
+
+    <!-- Schedule & Host Modal (external/brunchtime) — opened from the header
+         meta line; wraps the existing panel with its own Save for the dates. -->
+    <BaseModal
+      :open="showScheduleModal"
+      title="Schedule & host"
+      @close="showScheduleModal = false"
+    >
+      <ScheduleHostPanel
+        v-if="show"
+        v-model:edit-start="editStart"
+        v-model:edit-duration="editDuration"
+        v-model:selected-host-id="selectedHostId"
+        v-model:host-edit-mode="hostEditMode"
+        v-model:new-guest-username="newGuestUsername"
+        class="schedule-modal-panel"
+        :show="show"
+        :edit-mode="canEdit"
+        :can-edit-host="canEditHost"
+        :assigning-host="assigningHost"
+        :guest-creds="guestCreds"
+        :edit-time-valid="editTimeValid"
+        :edit-time-error="editTimeError"
+        @assign-host="assignHost"
+        @create-guest="createGuestHost"
+        @unassign-host="unassignHost"
+      />
+      <template #footer>
+        <BaseButton variant="ghost" @click="showScheduleModal = false">Close</BaseButton>
+        <BaseButton
+          v-if="canEdit"
+          variant="primary"
+          :loading="saving"
+          @click="saveScheduleFromModal"
+        >
+          Save date &amp; time
         </BaseButton>
       </template>
     </BaseModal>
@@ -1794,6 +1794,7 @@ onUnmounted(() => {
       :open="showTelegramModal"
       :show="show"
       :sending="sendingTelegramPreview"
+      :can-send="isAdmin"
       @close="showTelegramModal = false"
       @send="sendTelegramFromModal"
     />
@@ -1944,6 +1945,14 @@ onUnmounted(() => {
 
 .unheard-announcements {
   margin-bottom: var(--spacing-lg);
+}
+
+/* The schedule & host panel rendered inside the modal: strip the card chrome. */
+.schedule-modal-panel {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin-bottom: 0;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/admin/pages/flow/FlowLive.vue
+++ b/frontend/src/admin/pages/flow/FlowLive.vue
@@ -1,200 +1,16 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
-import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
-import DbMeter from '@admin/components/DbMeter.vue';
-import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
-import { config } from '@/config';
+import { useHostFlow } from '@admin/composables';
+import LiveSetupTest from '@admin/components/LiveSetupTest.vue';
 
+/**
+ * Fullscreen live-preparation step (/stream/live). The actual device setup +
+ * rehearsal logic lives in the shared LiveSetupTest component, which the show
+ * dashboard also renders inline; this page only wraps it with the step chrome
+ * and handles navigation.
+ */
 const router = useRouter();
 const flow = useHostFlow();
-
-// The private Icecast `/test` mount the rehearsal plays back from. Same MP3 the
-// public `/live.mp3` would serve, but non-public. Empty (e.g. local dev) → the
-// real test can't run; the dev-skip below covers that case.
-const previewUrl = config.stream.icecastTestUrl;
-
-// ─── Device selection ────────────────────────────────────────────────────────
-const audioCapture = useAudioCapture();
-const selectedDevice = ref('');
-
-let deviceRefreshInterval: ReturnType<typeof setInterval> | null = null;
-
-function onDeviceChange() {
-  audioCapture.listDevices();
-}
-
-onMounted(async () => {
-  // First refresh prompts for permission so device labels are populated.
-  await audioCapture.refreshDevices();
-  // The capture singleton persists across navigations (so audio survives into
-  // the Stream step). If we re-enter setup while a device is still being
-  // captured, mirror it in the dropdown — otherwise the UI shows "no input
-  // selected" while actually recording that stale device on Start Test.
-  const activeId = audioCapture.selectedDeviceId.value;
-  if (audioCapture.isCapturing.value && activeId && activeId !== 'screen') {
-    selectedDevice.value = activeId;
-  }
-  // Keep the list fresh: react to hot-plug events, plus a slow timer fallback.
-  navigator.mediaDevices.addEventListener('devicechange', onDeviceChange);
-  deviceRefreshInterval = setInterval(() => audioCapture.listDevices(), 3000);
-});
-
-async function handleDeviceSelect() {
-  if (!selectedDevice.value) return;
-  await audioCapture.captureDevice(selectedDevice.value);
-  // A change of input invalidates any previous successful test.
-  resetTest();
-}
-
-async function handleScreenShare() {
-  const ok = await audioCapture.captureScreenAudio();
-  if (ok) {
-    selectedDevice.value = '';
-    resetTest();
-  }
-}
-
-const capturedLabel = computed(() => {
-  if (audioCapture.selectedDeviceId.value === 'screen') return 'Screen Audio';
-  return (
-    audioCapture.devices.value.find((d) => d.deviceId === audioCapture.selectedDeviceId.value)
-      ?.label || 'Audio input'
-  );
-});
-
-// ─── Test broadcast (real producer → /test harbour → Icecast /test.mp3) ───────
-// This is the *same* pipeline as going live (browser → WS → backend ffmpeg →
-// Liquidsoap harbor → Icecast), just pushed to the private `/test` mount. The
-// host plays it back below to confirm it sounds exactly like `/live.mp3` would —
-// without anything reaching the public. No recording, no Telegram (backend skips
-// both for `?test=true`).
-type TestPhase = 'ready' | 'connecting' | 'live' | 'error';
-const testPhase = ref<TestPhase>('ready');
-const testError = ref<string | null>(null);
-const sentChunks = ref(0);
-// Guards onUnmounted so passing the test (which already stops the rehearsal)
-// doesn't race with cleanup.
-const testActive = computed(() => testPhase.value === 'connecting' || testPhase.value === 'live');
-
-const streamSocket = useStreamSocket({
-  onLive: () => {
-    testPhase.value = 'live';
-  },
-  onError: (msg) => {
-    testPhase.value = 'error';
-    testError.value = msg;
-    stopTestRecording();
-  },
-  onDisconnected: () => {
-    // The rehearsal ended (server-side or dropped) before the host accepted it.
-    if (testPhase.value === 'live' || testPhase.value === 'connecting') {
-      testPhase.value = 'ready';
-      stopTestRecording();
-    }
-  },
-});
-
-// ─── Test recorder (dedicated MediaRecorder on the capture stream) ──────────
-// Independent of the singleton capture's main onData wiring, so it never
-// disturbs the real go-live pipeline in the next step.
-let testRecorder: MediaRecorder | null = null;
-
-function startTestRecording(): boolean {
-  const stream = audioCapture.processedStream.value || audioCapture.mediaStream.value;
-  if (!stream) {
-    testPhase.value = 'error';
-    testError.value = 'No audio stream available. Select an audio device first.';
-    return false;
-  }
-
-  const tracks = stream.getAudioTracks();
-  if (tracks.length === 0 || tracks.every((t) => t.readyState !== 'live')) {
-    testPhase.value = 'error';
-    testError.value = 'Audio device is no longer active. Re-select your device.';
-    return false;
-  }
-
-  const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-    ? 'audio/webm;codecs=opus'
-    : 'audio/webm';
-
-  testRecorder = new MediaRecorder(stream, { mimeType, audioBitsPerSecond: 192000 });
-
-  testRecorder.ondataavailable = async (event) => {
-    if (event.data.size > 0) {
-      const buffer = await event.data.arrayBuffer();
-      streamSocket.send(buffer);
-      sentChunks.value++;
-    }
-  };
-
-  testRecorder.onerror = () => {
-    testError.value = 'Audio recorder error';
-    testPhase.value = 'error';
-  };
-
-  testRecorder.start(250);
-  return true;
-}
-
-function stopTestRecording() {
-  if (testRecorder && testRecorder.state !== 'inactive') {
-    testRecorder.stop();
-  }
-  testRecorder = null;
-}
-
-// ─── Test flow ────────────────────────────────────────────────────────────────
-async function runTest() {
-  if (!previewUrl) {
-    testPhase.value = 'error';
-    testError.value = 'Test stream is not configured on this server.';
-    return;
-  }
-
-  testError.value = null;
-  testPhase.value = 'connecting';
-  sentChunks.value = 0;
-
-  try {
-    // Connect in TEST mode → backend pushes to `/test`, not `/live`.
-    await streamSocket.connect(false, undefined, true);
-    // Stream live audio through the real pipeline. `onLive` flips to 'live'.
-    if (!startTestRecording()) {
-      streamSocket.stopStream();
-    }
-  } catch {
-    testPhase.value = 'error';
-    testError.value = 'Failed to connect to the test stream.';
-    stopTestRecording();
-  }
-}
-
-/** Stop the rehearsal broadcast (keeps the audio capture for the next step). */
-function stopTestBroadcast() {
-  stopTestRecording();
-  streamSocket.stopStream();
-}
-
-/** Reset test state (e.g. after switching inputs). */
-function resetTest() {
-  stopTestBroadcast();
-  testPhase.value = 'ready';
-  testError.value = null;
-  sentChunks.value = 0;
-  flow.setLiveTestPassed(false);
-}
-
-function retryTest() {
-  resetTest();
-}
-
-function markTestPassed() {
-  stopTestBroadcast();
-  flow.setLiveTestPassed(true);
-  goToStream();
-}
 
 function goToStream() {
   flow.goToStep('on-air');
@@ -205,24 +21,6 @@ function goBackToMode() {
   flow.revertToMode();
   router.push(flow.showId.value ? `/shows/${flow.showId.value}` : '/stream/select');
 }
-
-const isDev = import.meta.env.DEV;
-
-onUnmounted(() => {
-  navigator.mediaDevices.removeEventListener('devicechange', onDeviceChange);
-  if (deviceRefreshInterval) {
-    clearInterval(deviceRefreshInterval);
-    deviceRefreshInterval = null;
-  }
-  // Stop a still-running rehearsal so we never leave a producer pushing to
-  // `/test` after navigating away. Passing the test already stopped it (this is
-  // then a no-op); a fresh go-live in FlowOnAir reconnects to `/live`.
-  if (testActive.value) {
-    stopTestBroadcast();
-  }
-  // NOTE: do NOT call audioCapture.stopCapture() here —
-  // the singleton capture persists into the Stream step (FlowOnAir).
-});
 </script>
 
 <template>
@@ -232,106 +30,12 @@ onUnmounted(() => {
       Pick your audio input, check the level on the meter, then run a quick test.
     </p>
 
-    <!-- ─── Device selection ─── -->
-    <div class="device-section">
-      <h3>Audio Input</h3>
-
-      <div class="device-row">
-        <select v-model="selectedDevice" class="device-select" @change="handleDeviceSelect">
-          <option value="">-- Select audio input --</option>
-          <option
-            v-for="device in audioCapture.devices.value"
-            :key="device.deviceId"
-            :value="device.deviceId"
-          >
-            {{ device.label }}
-          </option>
-        </select>
-        <button class="btn-icon" title="Refresh devices" @click="audioCapture.listDevices()">
-          🔄
-        </button>
-      </div>
-
-      <button class="btn-link screen-share" @click="handleScreenShare">
-        🖥️ Share screen audio instead
-      </button>
-
-      <!-- Capture status + dB meter -->
-      <div v-if="audioCapture.isCapturing.value" class="capture-block">
-        <div class="capture-status">
-          <span class="status-dot active"></span>
-          Capturing — <strong>{{ capturedLabel }}</strong>
-        </div>
-        <DbMeter :media-stream="audioCapture.mediaStream.value" label="Input Level" />
-      </div>
-
-      <p v-if="audioCapture.error.value" class="error-text">{{ audioCapture.error.value }}</p>
+    <div class="setup-card">
+      <LiveSetupTest @passed="goToStream" />
     </div>
-
-    <!-- ─── Test ─── -->
-    <div class="test-panel">
-      <h3>Test Your Stream</h3>
-      <p class="panel-hint">
-        This sends your audio through the real broadcast path to a <strong>private</strong> test
-        mount — exactly what listeners would hear on the live stream, but not public. Press play
-        below to check it before going live.
-      </p>
-
-      <!-- Ready -->
-      <div v-if="testPhase === 'ready'" class="test-state">
-        <button
-          class="btn-primary btn-lg"
-          :disabled="!audioCapture.isCapturing.value || !previewUrl"
-          @click="runTest"
-        >
-          🎤 Start Test
-        </button>
-        <p v-if="!audioCapture.isCapturing.value" class="text-muted">
-          Select an audio input first.
-        </p>
-        <p v-else-if="!previewUrl" class="text-muted">
-          Test stream isn’t configured on this server.
-        </p>
-      </div>
-
-      <!-- Connecting -->
-      <div v-else-if="testPhase === 'connecting'" class="test-state">
-        <p class="text-muted">Connecting to the test stream…</p>
-      </div>
-
-      <!-- Live (test broadcast running) -->
-      <div v-else-if="testPhase === 'live'" class="test-state">
-        <div class="test-recording-indicator">
-          <span class="recording-dot"></span>
-          Test broadcast live
-          <span class="chunk-counter">({{ sentChunks }} chunks sent)</span>
-        </div>
-
-        <!-- Play back the private /test mount. Same component as the on-air
-             preview; runs a few seconds behind, so use headphones. -->
-        <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
-
-        <p>Does it sound clear on the test stream?</p>
-        <div class="test-result-actions">
-          <button class="btn-success" @click="markTestPassed">✓ Yes, go live</button>
-          <button class="btn-secondary" @click="retryTest">⏹ Stop test</button>
-        </div>
-      </div>
-
-      <!-- Error -->
-      <div v-else-if="testPhase === 'error'" class="test-state">
-        <p class="error-text">{{ testError || 'An error occurred during the test.' }}</p>
-        <button class="btn-secondary" @click="retryTest">Try Again</button>
-      </div>
-    </div>
-
-    <!-- Dev-only: skip test entirely -->
-    <button v-if="isDev && !flow.liveTestPassed.value" class="btn-dev-skip" @click="markTestPassed">
-      🛠 Skip Test (dev)
-    </button>
 
     <div class="step-actions">
-      <button class="btn-secondary" @click="goBackToMode">← Back</button>
+      <button class="btn-secondary" type="button" @click="goBackToMode">← Back</button>
     </div>
   </div>
 </template>
@@ -354,216 +58,18 @@ onUnmounted(() => {
   margin: 0 0 var(--spacing-xl);
 }
 
+.setup-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+}
+
 .step-actions {
   display: flex;
   justify-content: space-between;
   margin-top: var(--spacing-2xl);
   gap: var(--spacing-md);
-}
-
-/* ─── Device section ─── */
-.device-section {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  margin-bottom: var(--spacing-lg);
-}
-
-.device-section h3 {
-  margin: 0 0 var(--spacing-md);
-  font-size: var(--font-size-md);
-}
-
-.device-row {
-  display: flex;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-sm);
-}
-
-.device-select {
-  flex: 1;
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text);
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-}
-
-.btn-icon {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--spacing-sm);
-  cursor: pointer;
-  font-size: var(--font-size-md);
-}
-
-.screen-share {
-  margin-bottom: var(--spacing-md);
-}
-
-.capture-block {
-  margin-top: var(--spacing-md);
-}
-
-.capture-status {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  font-size: var(--font-size-sm);
-  color: var(--color-text);
-  margin-bottom: var(--spacing-md);
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-text-muted);
-}
-
-.status-dot.active {
-  background: #22c55e;
-  box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
-}
-
-/* ─── Test panel ─── */
-.test-panel {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-xl);
-  margin-bottom: var(--spacing-lg);
-}
-
-.test-panel h3 {
-  margin: 0 0 var(--spacing-xs);
-  font-size: var(--font-size-md);
-}
-
-.panel-hint {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  margin: 0 0 var(--spacing-lg);
-}
-
-.test-state {
-  text-align: center;
-}
-
-.test-state > p {
-  color: var(--color-text-muted);
-  margin: 0 0 var(--spacing-md);
-}
-
-.test-recording-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: #ef4444;
-  margin-bottom: var(--spacing-md);
-}
-
-.recording-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #ef4444;
-  animation: pulse-red 1s ease-in-out infinite;
-}
-
-@keyframes pulse-red {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
-
-.progress-bar {
-  height: 8px;
-  background: var(--color-surface-alt);
-  border-radius: var(--radius-full);
-  overflow: hidden;
-  margin-bottom: var(--spacing-sm);
-}
-
-.progress-fill {
-  height: 100%;
-  background: var(--color-primary);
-  transition: width 100ms linear;
-  border-radius: var(--radius-full);
-}
-
-.test-playing-indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-primary);
-  margin-bottom: var(--spacing-md);
-}
-
-.playing-icon {
-  animation: bounce 0.6s ease-in-out infinite alternate;
-}
-
-@keyframes bounce {
-  from {
-    transform: scale(1);
-  }
-  to {
-    transform: scale(1.15);
-  }
-}
-
-.playback-section {
-  margin-bottom: var(--spacing-lg);
-}
-
-.test-result-actions {
-  display: flex;
-  gap: var(--spacing-md);
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-/* ─── Buttons ─── */
-.btn-primary {
-  background: var(--color-primary);
-  color: var(--color-primary-text, #fff);
-  border: none;
-  padding: var(--spacing-sm) var(--spacing-xl);
-  border-radius: var(--radius-md);
-  font-family: var(--font-family);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.btn-primary:hover:not(:disabled) {
-  opacity: 0.9;
-}
-
-.btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.btn-lg {
-  padding: var(--spacing-md) var(--spacing-2xl);
-  font-size: var(--font-size-lg);
 }
 
 .btn-secondary {
@@ -578,74 +84,8 @@ onUnmounted(() => {
   transition: all var(--transition-fast);
 }
 
-.btn-secondary:hover:not(:disabled) {
+.btn-secondary:hover {
   color: var(--color-text);
   border-color: var(--color-border-light);
-}
-
-.btn-success {
-  background: #22c55e;
-  color: #fff;
-  border: none;
-  padding: var(--spacing-sm) var(--spacing-xl);
-  border-radius: var(--radius-md);
-  font-family: var(--font-family);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-bold);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.btn-success:hover {
-  background: #16a34a;
-}
-
-.btn-link {
-  background: none;
-  border: none;
-  color: var(--color-primary);
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  text-decoration: underline;
-  padding: var(--spacing-xs) 0;
-}
-
-.btn-link:hover {
-  opacity: 0.8;
-}
-
-.error-text {
-  color: #ef4444;
-  font-size: var(--font-size-sm);
-}
-
-.text-muted {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-
-.chunk-counter {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  font-weight: normal;
-}
-
-.btn-dev-skip {
-  margin-top: var(--spacing-md);
-  background: var(--color-warning, #f59e0b);
-  color: #000;
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  padding: var(--spacing-sm) var(--spacing-xl);
-  border: 2px dashed #000;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.btn-dev-skip:hover {
-  background: var(--color-warning-hover, #d97706);
 }
 </style>

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -1114,15 +1114,15 @@ onUnmounted(() => {
   }
 }
 
+/* Metric-card styling, matching the show dashboard's status strip. */
 .future-panel {
-  background: var(--color-surface-alt);
+  background: var(--color-surface);
   border: 1px dashed var(--color-border);
   border-radius: var(--radius-lg);
-  padding: var(--spacing-lg) var(--spacing-md);
-  text-align: center;
+  padding: var(--spacing-md) var(--spacing-lg);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--spacing-xs);
   opacity: 0.6;
 }
@@ -1135,7 +1135,7 @@ onUnmounted(() => {
 }
 
 .metric-value {
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-bold);
   font-variant-numeric: tabular-nums;
   color: var(--color-text);
@@ -1147,13 +1147,16 @@ onUnmounted(() => {
 }
 
 .future-icon {
-  font-size: 1.5rem;
+  font-size: 1.1rem;
 }
 
 .future-label {
-  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
-  color: var(--color-text);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
 }
 
 .future-badge {

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -542,93 +542,91 @@ onUnmounted(() => {
     <!-- STREAMING PHASE (stream is active)                                 -->
     <!-- ═══════════════════════════════════════════════════════════════════ -->
     <template v-else-if="streamActive">
-      <!-- Header with status -->
-      <div class="streaming-header">
-        <div class="stream-status">
+      <!-- One on-air card: status header → end-time banner → body → actions -->
+      <div class="panel-card">
+        <div class="onair-header">
           <span class="status-dot live"></span>
           <span class="status-label">LIVE</span>
-        </div>
-        <div class="elapsed-timer">{{ elapsedText }}</div>
-      </div>
-
-      <!-- End time countdown banner -->
-      <div v-if="remainingText !== null" :class="['end-time-banner', { warning: endTimeWarning }]">
-        <span class="end-time-label">{{ endTimeWarning ? '⚠ Ending in' : 'Time remaining' }}</span>
-        <span class="end-time-value">{{ remainingText }}</span>
-      </div>
-
-      <!-- Recording indicator -->
-      <div v-if="isRecording" class="recording-banner">
-        <span class="rec-dot"></span>
-        <span class="rec-label">REC</span>
-        <span v-if="recordingElapsed" class="rec-elapsed">{{ recordingElapsed }}</span>
-        <button class="btn-stop-rec" @click="stopRecording">Stop Recording</button>
-      </div>
-
-      <!-- Show info -->
-      <div class="show-card-compact">
-        <span class="show-title">{{ show?.title }}</span>
-        <span class="show-meta">
-          {{ formattedDate }}
-          <template v-if="show?.start_time"> · {{ show.start_time }}</template>
-          <template v-if="show?.end_time"> – {{ show.end_time }}</template>
-        </span>
-      </div>
-
-      <!-- Live mode controls -->
-      <template v-if="isLiveMode">
-        <div v-if="audioCapture" class="audio-level-section">
-          <DbMeter :media-stream="audioCapture.mediaStream.value" label="Audio Level" />
-        </div>
-
-        <!-- Broadcaster preview: hear the relay feed (#175). Hidden unless a
-             /test mount is configured. -->
-        <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
-
-        <div class="stop-section">
-          <button class="btn-stop" :disabled="stopping" @click="handleStop">
-            {{ stopping ? 'Stopping...' : '⏹ Stop Streaming' }}
+          <span v-if="isRecording" class="rec-chip">
+            <span class="rec-dot"></span>
+            REC
+            <template v-if="recordingElapsed">{{ recordingElapsed }}</template>
+          </span>
+          <button v-if="isRecording" class="btn-stop-rec" @click="stopRecording">
+            Stop recording
           </button>
-        </div>
-      </template>
-
-      <!-- Upload mode: passive monitoring -->
-      <template v-else>
-        <div class="upload-streaming-status">
-          <div class="upload-status-dot">
-            <span :class="['status-dot', uploadStreamActive ? 'live' : 'offline']"></span>
-          </div>
-          <p class="upload-status-text">
-            {{
-              uploadStreamActive
-                ? 'Your pre-recorded set is playing'
-                : 'Waiting for stream to start...'
-            }}
-          </p>
-          <p class="upload-status-hint">
-            The backend is handling playback automatically. You can close this page safely.
-          </p>
+          <span class="onair-spacer"></span>
+          <span class="elapsed-timer">{{ elapsedText }}</span>
         </div>
 
-        <div class="stop-section">
-          <button class="btn-stop" :disabled="stopping" @click="handleStopUpload">
-            {{ stopping ? 'Stopping...' : '⏹ Stop Show' }}
-          </button>
-        </div>
-      </template>
-
-      <!-- Stop stream & change settings -->
-      <div class="change-settings-section">
-        <button
-          class="btn-change-settings"
-          :disabled="stopping || changingSettings"
-          @click="handleStopAndChangeSettings"
+        <div
+          v-if="remainingText !== null"
+          :class="['end-time-banner', { warning: endTimeWarning }]"
         >
-          {{ changingSettings ? 'Stopping...' : '⚠ Stop Stream & Change Settings' }}
-        </button>
-        <p class="change-settings-hint">
-          This will stop the current stream and let you reconfigure your show.
-        </p>
+          <span class="end-time-label">{{ endTimeWarning ? '⚠ Ending in' : 'Time remaining' }}</span>
+          <span class="end-time-value">{{ remainingText }}</span>
+        </div>
+
+        <div class="onair-body">
+          <p class="onair-show">
+            {{ show?.title }}
+            <span class="onair-meta">
+              {{ formattedDate }}
+              <template v-if="show?.start_time"> · {{ show.start_time }}</template>
+              <template v-if="show?.end_time"> – {{ show.end_time }}</template>
+            </span>
+          </p>
+
+          <!-- Live mode: level meter + self-monitor -->
+          <template v-if="isLiveMode">
+            <div v-if="audioCapture" class="audio-level-section">
+              <DbMeter :media-stream="audioCapture.mediaStream.value" label="Audio Level" />
+            </div>
+
+            <!-- Broadcaster preview: hear the relay feed (#175). Hidden unless a
+                 /test mount is configured. -->
+            <StreamPreviewPlayer v-if="previewUrl" :src="previewUrl" />
+          </template>
+
+          <!-- Upload mode: passive monitoring -->
+          <div v-else class="upload-streaming-status">
+            <span :class="['status-dot', uploadStreamActive ? 'live' : 'offline']"></span>
+            <div class="upload-status-body">
+              <p class="upload-status-text">
+                {{
+                  uploadStreamActive
+                    ? 'Your pre-recorded set is playing'
+                    : 'Waiting for stream to start...'
+                }}
+              </p>
+              <p class="upload-status-hint">
+                The backend is handling playback automatically. You can close this page safely.
+              </p>
+            </div>
+          </div>
+
+          <div class="onair-actions">
+            <button
+              class="btn-change-settings"
+              :disabled="stopping || changingSettings"
+              :title="'Stop the current stream and reconfigure your show'"
+              @click="handleStopAndChangeSettings"
+            >
+              {{ changingSettings ? 'Stopping...' : '⚠ Stop & change settings' }}
+            </button>
+            <button
+              v-if="isLiveMode"
+              class="btn-stop"
+              :disabled="stopping"
+              @click="handleStop"
+            >
+              {{ stopping ? 'Stopping...' : '⏹ Stop streaming' }}
+            </button>
+            <button v-else class="btn-stop" :disabled="stopping" @click="handleStopUpload">
+              {{ stopping ? 'Stopping...' : '⏹ Stop show' }}
+            </button>
+          </div>
+        </div>
       </div>
 
       <!-- Live telemetry (#177) + remaining placeholder -->
@@ -657,90 +655,76 @@ onUnmounted(() => {
     <!-- WAITING PHASE (before stream starts)                               -->
     <!-- ═══════════════════════════════════════════════════════════════════ -->
     <template v-else>
-      <h1 class="waiting-title">Waiting Room</h1>
+      <!-- Waiting room: one centered card — meta line → countdown → status row -->
+      <div class="panel-card waiting-card">
+        <p class="waiting-meta">
+          {{ show?.title }} · {{ formattedDate
+          }}<template v-if="show?.start_time"> · {{ show.start_time }}</template
+          ><template v-if="show?.end_time">–{{ show.end_time }}</template>
+          · {{ isLiveMode ? '🎙 Live' : '📁 Pre-recorded' }} · Berlin time
+        </p>
 
-      <!-- Show info card -->
-      <div class="show-card">
-        <div class="show-card-row">
-          <span class="show-card-label">Show</span>
-          <span class="show-card-value">{{ show?.title }}</span>
-        </div>
-        <div class="show-card-row">
-          <span class="show-card-label">Start</span>
-          <span class="show-card-value">{{ formattedStart }} (Berlin)</span>
-        </div>
-        <div class="show-card-row">
-          <span class="show-card-label">End</span>
-          <span class="show-card-value">{{ formattedEnd }} (Berlin)</span>
-        </div>
-        <div class="show-card-row">
-          <span class="show-card-label">Mode</span>
-          <span class="show-card-value">{{ isLiveMode ? '🎙️ Live' : '📁 Pre-recorded' }}</span>
-        </div>
-      </div>
-
-      <!-- Countdown -->
-      <div :class="['countdown-section', alertState]">
         <p class="countdown-label">
           {{ remaining > 0 ? 'Show starts in' : 'Show time!' }}
         </p>
-        <div class="countdown-display">{{ countdownText }}</div>
+        <div :class="['countdown-box', alertState]">
+          <span class="countdown-display">{{ countdownText }}</span>
+        </div>
         <p v-if="alertState === 'warning'" class="countdown-alert warning-text">
-          Less than 1 minute!
+          Less than 1 minute — goes live automatically
         </p>
         <p v-if="alertState === 'critical' && remaining > 0" class="countdown-alert critical-text">
           Starting soon!
         </p>
-      </div>
 
-      <!-- Recording option (live mode) -->
-      <div v-if="isLiveMode" class="record-option">
-        <label class="record-checkbox-label" @click="toggleRecordStream">
-          <span :class="['checkbox-icon', { checked: flow.recordStream.value }]">
-            {{ flow.recordStream.value ? '☑' : '☐' }}
-          </span>
-          <span>Record this show</span>
-        </label>
-        <p class="record-hint">Audio will be saved for later download &amp; editing</p>
-      </div>
-
-      <!-- Mode-specific status -->
-      <div class="mode-status">
-        <template v-if="isLiveMode">
-          <div class="audio-status">
-            <span :class="['status-dot', audioDeviceOk ? 'ok' : 'lost']"></span>
-            <span v-if="audioDeviceOk">Audio device active</span>
-            <span v-else class="status-lost-text">Audio device disconnected — return to setup</span>
-          </div>
-          <!-- dB meter stays live throughout the countdown -->
-          <div v-if="audioCapture && audioDeviceOk" class="waiting-meter">
-            <DbMeter :media-stream="audioCapture.mediaStream.value" label="Input Level" />
-          </div>
-        </template>
-        <template v-else>
-          <div class="upload-status">
+        <!-- Recording toggle + device / upload readiness -->
+        <div class="waiting-status-row">
+          <template v-if="isLiveMode">
+            <label class="record-checkbox-label" @click="toggleRecordStream">
+              <span :class="['checkbox-icon', { checked: flow.recordStream.value }]">
+                {{ flow.recordStream.value ? '☑' : '☐' }}
+              </span>
+              <span>Record this show</span>
+            </label>
+            <span class="audio-status">
+              <span :class="['status-dot', audioDeviceOk ? 'ok' : 'lost']"></span>
+              <span v-if="audioDeviceOk">Audio device active</span>
+              <span v-else class="status-lost-text">
+                Audio device disconnected — return to setup
+              </span>
+            </span>
+          </template>
+          <span v-else class="upload-status">
             <span class="upload-ready-icon">✓</span>
             <span>Your pre-recorded set is ready to go</span>
-          </div>
-        </template>
-      </div>
-
-      <!-- Auto-start status -->
-      <div class="go-live-section">
-        <p v-if="goLiveLoading" class="go-live-status">Connecting...</p>
-        <p v-if="goLiveError" class="go-live-error">
-          {{ goLiveError }}
-          <button class="btn-retry" @click="autoStarted = false">Retry</button>
+          </span>
+        </div>
+        <p v-if="isLiveMode" class="record-hint">
+          Audio will be saved for later download &amp; editing
         </p>
 
-        <!-- Dev-only: start stream without waiting for countdown -->
-        <button
-          v-if="isDev && !goLiveLoading && remaining > 0"
-          class="btn-dev-start"
-          @click="handleGoLive"
-        >
-          🛠 Start Stream Now (dev)
-        </button>
+        <!-- dB meter stays live throughout the countdown -->
+        <div v-if="isLiveMode && audioCapture && audioDeviceOk" class="waiting-meter">
+          <DbMeter :media-stream="audioCapture.mediaStream.value" label="Input Level" />
+        </div>
+
+        <!-- Auto-start status -->
+        <div class="go-live-section">
+          <p v-if="goLiveLoading" class="go-live-status">Connecting...</p>
+          <p v-if="goLiveError" class="go-live-error">
+            {{ goLiveError }}
+            <button class="btn-retry" @click="autoStarted = false">Retry</button>
+          </p>
+
+          <!-- Dev-only: start stream without waiting for countdown -->
+          <button
+            v-if="isDev && !goLiveLoading && remaining > 0"
+            class="btn-dev-start"
+            @click="handleGoLive"
+          >
+            🛠 Start stream now (dev)
+          </button>
+        </div>
       </div>
     </template>
   </div>
@@ -1411,5 +1395,156 @@ onUnmounted(() => {
 
 .btn-primary:hover {
   opacity: 0.9;
+}
+
+/* ── Redesigned live panel (matches the show dashboard's design language) ── */
+.panel-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  margin-bottom: var(--spacing-lg);
+}
+
+.onair-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.onair-spacer {
+  flex: 1 1 auto;
+}
+
+.rec-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The banner sits flush inside the card, under the header. */
+.panel-card .end-time-banner {
+  border-radius: 0;
+  margin: 0;
+  border-left: none;
+  border-right: none;
+}
+
+.onair-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+}
+
+.onair-show {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+
+.onair-meta {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  color: var(--color-text-muted);
+}
+
+.onair-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+/* New horizontal layout for the pre-recorded monitoring row. */
+.panel-card .upload-streaming-status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+}
+
+.upload-status-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.panel-card .upload-status-text {
+  margin: 0;
+}
+
+.panel-card .upload-status-hint {
+  margin: 0;
+}
+
+/* ── Waiting room card ── */
+.waiting-card {
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.waiting-meta {
+  margin: 0 0 var(--spacing-lg);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.countdown-box {
+  display: inline-block;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--spacing-md) var(--spacing-2xl);
+  margin-bottom: var(--spacing-sm);
+  transition: border-color 0.3s ease;
+}
+
+.countdown-box.warning {
+  border-color: #eab308;
+  animation: pulse-yellow 1.5s ease-in-out infinite;
+}
+
+.countdown-box.critical {
+  border-color: #ef4444;
+  animation: pulse-red 1s ease-in-out infinite;
+}
+
+.waiting-status-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xl);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-lg);
+}
+
+.waiting-card .record-checkbox-label {
+  margin: 0;
+}
+
+.waiting-card .record-hint {
+  margin: var(--spacing-xs) 0 0;
+}
+
+.waiting-card .waiting-meter {
+  margin-top: var(--spacing-lg);
+  text-align: left;
 }
 </style>

--- a/frontend/src/shared/styles/tokens.css
+++ b/frontend/src/shared/styles/tokens.css
@@ -30,6 +30,16 @@
 
   /* Typography */
   --font-family: 'Courier New', Courier, monospace;
+  /* Sans stack for dense UI surfaces (dashboard body text); mono stays the
+     brand accent for clocks, numbers, and headings. */
+  --font-ui:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    sans-serif;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;


### PR DESCRIPTION
## Summary

Full redesign of the show dashboard and an interim restyle of the live panel, from the 2026-07-06 design session:

- **`refactor(stream)`**: extract `LiveSetupTest` from `FlowLive` — device setup + `/test` rehearsal now a shared component, rendered inline on the dashboard
- **`feat(admin_dashboard)`**: redesigned show dashboard for all show types — header → status strip → phase panel (prep / launchpad / post-production) + announcements
- **`style(stream)`**: metric-card telemetry panels on the live panel
- **`feat(admin_dashboard)`**: inline meta editing, clickable announcement slots
- **`feat(stream)`**: redesigned live panel (waiting room + on-air card) — interim state; successor is spec'd in `docs/stream-rework/live-panel-2.0.md`
- **`docs(stream)`**: Live Panel 2.0 design handoff + interactive prototype, phaabe DNS handoff notes
- CLAUDE.md label-taxonomy/milestones update, package-lock refresh

## Follow-up

Live Panel 2.0 (milestone + 6 issues) builds on this — spec: `docs/stream-rework/live-panel-2.0.md`.