### PR TITLE
feat(stream): input & stream spectrum analyzers with faders

### DIFF
--- a/frontend/src/admin/components/LiveSetupTest.vue
+++ b/frontend/src/admin/components/LiveSetupTest.vue
@@ -268,9 +268,7 @@ onUnmounted(() => {
           🎤 Start test
         </button>
         <p v-if="!audioCapture.isCapturing.value" class="ls-muted">Select an audio input first.</p>
-        <p v-else-if="!previewUrl" class="ls-muted">
-          Test stream isn't configured on this server.
-        </p>
+        <p v-else-if="!previewUrl" class="ls-muted">Test stream isn't configured on this server.</p>
       </div>
 
       <div v-else-if="testPhase === 'connecting'" class="ls-test-state">
@@ -436,6 +434,15 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
+}
+
+/* The preview player is chrome-less since the analyzer rework (#274) — give
+   it back an inset card inside the test panel. */
+.ls-test-state :deep(.preview-player) {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
 }
 
 .ls-onair {

--- a/frontend/src/admin/components/SpectrumBars.vue
+++ b/frontend/src/admin/components/SpectrumBars.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+// Dumb bar-spectrum renderer for the Live Panel 2.0 analyzer cards (#274).
+// Feed it normalized bands from useSpectrum(); colors match the prototype
+// (teal input, purple stream).
+defineProps<{
+  /** Normalized band magnitudes, 0..1 (from useSpectrum). */
+  bands: number[];
+  /** Color variant: 'input' (teal, default) or 'stream' (purple). */
+  variant?: 'input' | 'stream';
+}>();
+</script>
+
+<template>
+  <div :class="['spectrum', variant ?? 'input']" role="img" aria-label="Spectrum analyzer">
+    <div
+      v-for="(v, i) in bands"
+      :key="i"
+      class="spectrum-bar"
+      :style="{ height: `${Math.max(6, Math.round(v * 100))}%` }"
+    ></div>
+  </div>
+</template>
+
+<style scoped>
+.spectrum {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 56px;
+}
+
+.spectrum-bar {
+  flex: 1 1 0;
+  min-height: 2px;
+  border-radius: 1px;
+  background: var(--spectrum-color);
+  transition: height 60ms linear;
+}
+
+.spectrum.input {
+  --spectrum-color: #1d9e75;
+}
+
+.spectrum.stream {
+  --spectrum-color: #7f77dd;
+}
+</style>

--- a/frontend/src/admin/components/StreamPreviewPlayer.vue
+++ b/frontend/src/admin/components/StreamPreviewPlayer.vue
@@ -89,11 +89,14 @@ async function startPlayback(withCors: boolean): Promise<void> {
       analyser.value = node;
     } catch (e) {
       console.warn('[StreamPreview] Web-Audio graph failed, plain playback only:', e);
+      corsBlocked.value = true;
     }
   }
 
   await el.play();
   playing.value = true;
+  // Clear any error a raced CORS attempt set before this (fallback) play won.
+  playError.value = null;
 }
 
 async function toggle() {
@@ -101,6 +104,7 @@ async function toggle() {
   if (playing.value) {
     teardownElement();
     playing.value = false;
+    playError.value = null;
     return;
   }
   starting.value = true;
@@ -158,8 +162,8 @@ onUnmounted(() => {
 
     <p v-if="playError" class="preview-error">{{ playError }}</p>
     <p v-else-if="corsBlocked" class="preview-warn">
-      Spectrum unavailable — the mount doesn't send CORS headers
-      (<code>Access-Control-Allow-Origin</code>). Audio preview still works.
+      Spectrum unavailable — usually a missing <code>Access-Control-Allow-Origin</code> header on
+      the mount. Audio preview still works.
     </p>
     <p class="preview-hint">
       Use <strong>headphones</strong> — the relay feed runs a few seconds behind live, so speakers

--- a/frontend/src/admin/components/StreamPreviewPlayer.vue
+++ b/frontend/src/admin/components/StreamPreviewPlayer.vue
@@ -1,12 +1,133 @@
 <script setup lang="ts">
-// Broadcaster self-monitoring preview (#175). Plays the Icecast `/test` mount so
-// the host can confirm their audio is actually reaching the relay before/while
-// going live. Plain <audio controls> — playback is opt-in (no autoplay) so it
+// Broadcaster self-monitoring preview (#175) + stream spectrum analyzer (#274).
+// Plays the Icecast `/test` mount through a Web-Audio graph so the host can
+// hear AND see what listeners receive. Playback is opt-in (no autoplay) so it
 // never starts feedback on its own.
-defineProps<{
+//
+// CORS: reading spectrum data from a cross-origin stream requires
+// `Access-Control-Allow-Origin` on the mount. We try CORS mode first
+// (crossorigin=anonymous + MediaElementSource → analyser → destination). If the
+// mount lacks the header the CORS load errors out, and we rebuild a plain
+// element without the graph — audible preview, flat spectrum, visible hint.
+// (A MediaElementSource is permanent for its element, so the fallback needs a
+// fresh element — that's why the <audio> is created programmatically.)
+import { ref, shallowRef, onUnmounted, watch } from 'vue';
+import { useSpectrum } from '@admin/composables';
+import SpectrumBars from '@admin/components/SpectrumBars.vue';
+
+const props = defineProps<{
   /** The Icecast `/test` mount URL (MP3). Component is only mounted when set. */
   src: string;
 }>();
+
+const playing = ref(false);
+const starting = ref(false);
+/** Monitor volume in % — element volume only; listeners are unaffected. */
+const monitorVolume = ref(70);
+/** True when CORS mode failed and we fell back to plain (no-spectrum) playback. */
+const corsBlocked = ref(false);
+const playError = ref<string | null>(null);
+
+const analyser = shallowRef<AnalyserNode | null>(null);
+const { bands } = useSpectrum(analyser);
+
+let el: HTMLAudioElement | null = null;
+let audioContext: AudioContext | null = null;
+let sourceNode: MediaElementAudioSourceNode | null = null;
+
+function teardownElement() {
+  if (el) {
+    el.onerror = null;
+    el.pause();
+    el.removeAttribute('src');
+    el.load();
+    el = null;
+  }
+  if (sourceNode) {
+    sourceNode.disconnect();
+    sourceNode = null;
+  }
+  if (analyser.value) {
+    analyser.value.disconnect();
+    analyser.value = null;
+  }
+}
+
+async function startPlayback(withCors: boolean): Promise<void> {
+  teardownElement();
+  playError.value = null;
+
+  el = new Audio();
+  el.preload = 'none';
+  if (withCors) el.crossOrigin = 'anonymous';
+  el.volume = monitorVolume.value / 100;
+  // Cache-bust so a stop→start rejoins the live edge instead of a stale buffer.
+  el.src = props.src + (props.src.includes('?') ? '&' : '?') + '_=' + Date.now();
+
+  el.onerror = () => {
+    if (withCors) {
+      // Most likely a missing Access-Control-Allow-Origin on the mount.
+      console.warn('[StreamPreview] CORS load failed — falling back to plain playback');
+      corsBlocked.value = true;
+      startPlayback(false).catch(() => {});
+    } else {
+      playError.value = 'Could not play the relay stream.';
+      playing.value = false;
+    }
+  };
+
+  if (withCors) {
+    try {
+      audioContext = audioContext ?? new AudioContext();
+      if (audioContext.state === 'suspended') await audioContext.resume();
+      sourceNode = audioContext.createMediaElementSource(el);
+      const node = audioContext.createAnalyser();
+      node.fftSize = 2048;
+      node.smoothingTimeConstant = 0.75;
+      sourceNode.connect(node);
+      node.connect(audioContext.destination);
+      analyser.value = node;
+    } catch (e) {
+      console.warn('[StreamPreview] Web-Audio graph failed, plain playback only:', e);
+    }
+  }
+
+  await el.play();
+  playing.value = true;
+}
+
+async function toggle() {
+  if (starting.value) return;
+  if (playing.value) {
+    teardownElement();
+    playing.value = false;
+    return;
+  }
+  starting.value = true;
+  try {
+    await startPlayback(!corsBlocked.value);
+  } catch (e) {
+    // A CORS failure usually surfaces via onerror (handled above); anything
+    // else lands here.
+    if (!playing.value && !corsBlocked.value) {
+      playError.value = e instanceof Error ? e.message : 'Could not play the relay stream.';
+    }
+  } finally {
+    starting.value = false;
+  }
+}
+
+watch(monitorVolume, (v) => {
+  if (el) el.volume = v / 100;
+});
+
+onUnmounted(() => {
+  teardownElement();
+  if (audioContext) {
+    audioContext.close();
+    audioContext = null;
+  }
+});
 </script>
 
 <template>
@@ -14,31 +135,50 @@ defineProps<{
     <div class="preview-header">
       <span class="preview-icon">🎧</span>
       <span class="preview-title">Listen to your stream</span>
+      <button class="preview-toggle" :disabled="starting" @click="toggle">
+        {{ playing ? '⏹ Stop' : starting ? '…' : '▶ Play' }}
+      </button>
     </div>
-    <audio class="preview-audio" controls preload="none" :src="src">
-      Your browser can’t play this stream.
-    </audio>
+
+    <SpectrumBars :bands="bands" variant="stream" />
+
+    <div class="preview-fader">
+      <label class="preview-fader-label" for="monitor-volume">Monitor</label>
+      <input
+        id="monitor-volume"
+        v-model.number="monitorVolume"
+        class="preview-fader-range"
+        type="range"
+        min="0"
+        max="100"
+        step="1"
+      />
+      <span class="preview-fader-value">{{ monitorVolume }}%</span>
+    </div>
+
+    <p v-if="playError" class="preview-error">{{ playError }}</p>
+    <p v-else-if="corsBlocked" class="preview-warn">
+      Spectrum unavailable — the mount doesn't send CORS headers
+      (<code>Access-Control-Allow-Origin</code>). Audio preview still works.
+    </p>
     <p class="preview-hint">
-      Use <strong>headphones</strong> — this is the relay feed and runs a few seconds behind live,
-      so playing it on speakers will echo. It confirms your audio is reaching the server.
+      Use <strong>headphones</strong> — the relay feed runs a few seconds behind live, so speakers
+      will echo. It confirms your audio is reaching the server.
     </p>
   </section>
 </template>
 
 <style scoped>
 .preview-player {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-md) var(--spacing-lg);
-  margin-bottom: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
 }
 
 .preview-header {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-sm);
 }
 
 .preview-icon {
@@ -46,17 +186,73 @@ defineProps<{
 }
 
 .preview-title {
+  flex: 1 1 auto;
   font-weight: var(--font-weight-bold);
   color: var(--color-text);
 }
 
-.preview-audio {
-  width: 100%;
+.preview-toggle {
+  background: none;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  padding: 4px 12px;
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.preview-toggle:hover:not(:disabled) {
+  background: var(--color-surface-alt);
+}
+
+.preview-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.preview-fader {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.preview-fader-label {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.preview-fader-range {
+  flex: 1 1 auto;
+  accent-color: var(--color-primary);
+}
+
+.preview-fader-value {
+  min-width: 42px;
+  text-align: right;
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+
+.preview-error {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+}
+
+.preview-warn {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-warning);
 }
 
 .preview-hint {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
-  margin: var(--spacing-sm) 0 0;
+  margin: 0;
 }
 </style>

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -7,6 +7,7 @@ export {
 export { useAudioCapture, type AudioDevice, type UseAudioCaptureOptions } from './useAudioCapture';
 export { useAudioMeter } from './useAudioMeter';
 export { useDbMeter, dbToLevel, DB_FLOOR, DB_CEIL } from './useDbMeter';
+export { useSpectrum, groupBands, SPECTRUM_BANDS } from './useSpectrum';
 export {
   useRecordingSession,
   type TrackType,

--- a/frontend/src/admin/composables/useAudioCapture.ts
+++ b/frontend/src/admin/composables/useAudioCapture.ts
@@ -40,6 +40,9 @@ const inputVolume = ref(1);
 const mediaStream = shallowRef<MediaStream | null>(null);
 // The processed stream (with gain applied) for MediaRecorder
 const processedStream = shallowRef<MediaStream | null>(null);
+// Post-gain analyser for the input spectrum display (#274) — taps the same
+// signal that is recorded/streamed, so the gain fader shapes what you see.
+const analyserNode = shallowRef<AnalyserNode | null>(null);
 
 // Private singleton vars
 let mediaRecorder: MediaRecorder | null = null;
@@ -183,9 +186,15 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
     // Apply current volume
     gainNode.gain.value = inputVolume.value;
 
-    // Connect: source -> gain -> destination
+    // Connect: source -> gain -> destination (+ analyser tap, post-gain)
     sourceNode.connect(gainNode);
     gainNode.connect(destinationNode);
+
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 2048;
+    analyser.smoothingTimeConstant = 0.7;
+    gainNode.connect(analyser);
+    analyserNode.value = analyser;
 
     // Use the processed stream for recording
     processedStream.value = destinationNode.stream;
@@ -200,6 +209,10 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
     if (gainNode) {
       gainNode.disconnect();
       gainNode = null;
+    }
+    if (analyserNode.value) {
+      analyserNode.value.disconnect();
+      analyserNode.value = null;
     }
     if (destinationNode) {
       destinationNode = null;
@@ -367,6 +380,7 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
     error,
     mediaStream,
     processedStream,
+    analyserNode,
     inputVolume,
     setInputVolume,
     setOnData,

--- a/frontend/src/admin/composables/useSpectrum.ts
+++ b/frontend/src/admin/composables/useSpectrum.ts
@@ -1,0 +1,98 @@
+import { ref, onUnmounted, watch, type Ref } from 'vue';
+
+/** Number of bars in the analyzer display (matches the Live Panel 2.0 prototype). */
+export const SPECTRUM_BANDS = 28;
+/** Band range in Hz — log-spaced from low bass to the top of typical MP3/Opus content. */
+const F_MIN = 40;
+const F_MAX = 16000;
+/** Minimum ms between reactive band updates (rAF is throttled to this). */
+const UPDATE_INTERVAL_MS = 40;
+
+/**
+ * Group an FFT magnitude array (0..255 per bin, from `getByteFrequencyData`)
+ * into `bandCount` log-spaced bands between `fMin` and `fMax`, normalized to
+ * 0..1 (per-band peak). Pure — unit-tested separately from the rAF loop.
+ */
+export function groupBands(
+  freqData: Uint8Array,
+  sampleRate: number,
+  fftSize: number,
+  bandCount = SPECTRUM_BANDS,
+  fMin = F_MIN,
+  fMax = F_MAX
+): number[] {
+  const binHz = sampleRate / fftSize;
+  const logMin = Math.log10(fMin);
+  const logMax = Math.log10(fMax);
+  const bands = new Array<number>(bandCount).fill(0);
+
+  for (let b = 0; b < bandCount; b++) {
+    const lo = Math.pow(10, logMin + ((logMax - logMin) * b) / bandCount);
+    const hi = Math.pow(10, logMin + ((logMax - logMin) * (b + 1)) / bandCount);
+    const startBin = Math.min(freqData.length - 1, Math.max(0, Math.floor(lo / binHz)));
+    const endBin = Math.min(freqData.length - 1, Math.max(startBin, Math.ceil(hi / binHz)));
+
+    let peak = 0;
+    for (let i = startBin; i <= endBin; i++) {
+      if (freqData[i] > peak) peak = freqData[i];
+    }
+    bands[b] = peak / 255;
+  }
+
+  return bands;
+}
+
+/**
+ * Drive a bar-spectrum display from a Web-Audio `AnalyserNode`.
+ *
+ * Follows `useDbMeter`'s lifecycle contract: auto start/stops when the
+ * analyser ref changes and cleans up on unmount. The caller owns the analyser
+ * (and its AudioContext) — this composable only reads from it.
+ */
+export function useSpectrum(analyser: Ref<AnalyserNode | null>, bandCount = SPECTRUM_BANDS) {
+  /** Normalized band magnitudes (0..1), `bandCount` entries. */
+  const bands = ref<number[]>(new Array<number>(bandCount).fill(0));
+
+  let animationId: number | null = null;
+  let freqData: Uint8Array<ArrayBuffer> | null = null;
+  let lastUpdateTs = 0;
+
+  function update(ts: number) {
+    const node = analyser.value;
+    if (!node) return;
+
+    if (ts - lastUpdateTs >= UPDATE_INTERVAL_MS) {
+      lastUpdateTs = ts;
+      if (!freqData || freqData.length !== node.frequencyBinCount) {
+        freqData = new Uint8Array(node.frequencyBinCount);
+      }
+      node.getByteFrequencyData(freqData);
+      bands.value = groupBands(freqData, node.context.sampleRate, node.fftSize, bandCount);
+    }
+
+    animationId = requestAnimationFrame(update);
+  }
+
+  function stop() {
+    if (animationId !== null) {
+      cancelAnimationFrame(animationId);
+      animationId = null;
+    }
+    bands.value = new Array<number>(bandCount).fill(0);
+    freqData = null;
+    lastUpdateTs = 0;
+  }
+
+  watch(
+    analyser,
+    (node) => {
+      stop();
+      if (node) animationId = requestAnimationFrame(update);
+    },
+    { immediate: true }
+  );
+
+  onUnmounted(stop);
+
+  return { bands };
+}

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
-import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
+import {
+  useHostFlow,
+  useAudioCapture,
+  useStreamSocket,
+  useSpectrum,
+  useDbMeter,
+  DB_FLOOR,
+} from '@admin/composables';
 import { streamApi, recordingApi, hostFlowApi, type StreamMetrics } from '@admin/api';
 import DbMeter from '@admin/components/DbMeter.vue';
+import SpectrumBars from '@admin/components/SpectrumBars.vue';
 import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
 import { config } from '@/config';
 
@@ -161,6 +169,23 @@ function playBeep() {
 // ─── Audio device status (live mode, waiting + streaming phases) ────────────
 const audioCapture = isLiveMode.value ? useAudioCapture() : null;
 const audioDeviceOk = computed(() => audioCapture?.isCapturing.value ?? false);
+
+// ─── Input spectrum + gain fader (Live Panel 2.0 analyzers, #274) ───────────
+// Spectrum + peak both tap the post-gain signal, so the fader shapes exactly
+// what is recorded/streamed.
+const { bands: inputBands } = useSpectrum(computed(() => audioCapture?.analyserNode.value ?? null));
+const { peakDb: inputPeakDb } = useDbMeter(
+  computed(() => audioCapture?.processedStream.value ?? null)
+);
+const inputPeakText = computed(() =>
+  inputPeakDb.value <= DB_FLOOR + 0.5 ? '−∞ dB' : `${inputPeakDb.value.toFixed(1)} dB`
+);
+const inputGainPct = computed(() => Math.round((audioCapture?.inputVolume.value ?? 1) * 100));
+
+function onInputGain(event: Event) {
+  const pct = Number((event.target as HTMLInputElement).value);
+  audioCapture?.setInputVolume(pct / 100);
+}
 
 // ─── Stream socket ──────────────────────────────────────────────────────────
 const streamSocket = useStreamSocket({
@@ -687,12 +712,23 @@ onUnmounted(() => {
         <div class="panel-card slot-card">
           <div class="slot-head">
             <span class="slot-title">🎙 Input — your source</span>
+            <span class="slot-readout">{{ inputPeakText }}</span>
           </div>
-          <DbMeter
-            v-if="audioCapture"
-            :media-stream="audioCapture.mediaStream.value"
-            label="Level"
-          />
+          <SpectrumBars :bands="inputBands" variant="input" />
+          <div class="fader-row">
+            <label class="fader-label" for="input-gain">Input gain</label>
+            <input
+              id="input-gain"
+              class="fader-range"
+              type="range"
+              min="0"
+              max="150"
+              step="1"
+              :value="inputGainPct"
+              @input="onInputGain"
+            />
+            <span class="fader-value">{{ inputGainPct }}%</span>
+          </div>
         </div>
         <div class="panel-card slot-card">
           <div class="slot-head">
@@ -1148,18 +1184,45 @@ onUnmounted(() => {
   color: var(--color-text-muted);
 }
 
+.slot-readout {
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+/* Fader row under an analyzer (input gain / monitor volume). */
+.fader-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.fader-label {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.fader-range {
+  flex: 1 1 auto;
+  accent-color: var(--color-primary);
+}
+
+.fader-value {
+  min-width: 42px;
+  text-align: right;
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+
 /* Slot waiting on a later Live Panel 2.0 issue. */
 .slot-placeholder {
   border-style: dashed;
   opacity: 0.7;
-}
-
-/* Flatten the preview player's own card chrome inside the slot card. */
-.slot-card :deep(.preview-player) {
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
 }
 
 /* dB meter shown during the waiting countdown */

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -172,10 +172,13 @@ const audioDeviceOk = computed(() => audioCapture?.isCapturing.value ?? false);
 
 // ─── Input spectrum + gain fader (Live Panel 2.0 analyzers, #274) ───────────
 // Spectrum + peak both tap the post-gain signal, so the fader shapes exactly
-// what is recorded/streamed.
-const { bands: inputBands } = useSpectrum(computed(() => audioCapture?.analyserNode.value ?? null));
+// what is recorded/streamed. Gated on the streaming phase — the waiting room
+// has its own DbMeter, and each meter costs an AudioContext + rAF loop.
+const { bands: inputBands } = useSpectrum(
+  computed(() => (streamActive.value ? (audioCapture?.analyserNode.value ?? null) : null))
+);
 const { peakDb: inputPeakDb } = useDbMeter(
-  computed(() => audioCapture?.processedStream.value ?? null)
+  computed(() => (streamActive.value ? (audioCapture?.processedStream.value ?? null) : null))
 );
 const inputPeakText = computed(() =>
   inputPeakDb.value <= DB_FLOOR + 0.5 ? '−∞ dB' : `${inputPeakDb.value.toFixed(1)} dB`

--- a/frontend/tests/useSpectrum.test.ts
+++ b/frontend/tests/useSpectrum.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { groupBands, SPECTRUM_BANDS } from '../src/admin/composables/useSpectrum';
+
+const SAMPLE_RATE = 48000;
+const FFT_SIZE = 2048;
+const BIN_COUNT = FFT_SIZE / 2; // frequencyBinCount
+
+function freqDataFilledWith(value: number): Uint8Array {
+  return new Uint8Array(BIN_COUNT).fill(value);
+}
+
+describe('groupBands', () => {
+  it('returns the requested number of bands (default SPECTRUM_BANDS)', () => {
+    const bands = groupBands(freqDataFilledWith(0), SAMPLE_RATE, FFT_SIZE);
+    expect(bands).toHaveLength(SPECTRUM_BANDS);
+  });
+
+  it('maps silence to all-zero bands', () => {
+    const bands = groupBands(freqDataFilledWith(0), SAMPLE_RATE, FFT_SIZE);
+    expect(bands.every((v) => v === 0)).toBe(true);
+  });
+
+  it('maps full-scale input to all-one bands', () => {
+    const bands = groupBands(freqDataFilledWith(255), SAMPLE_RATE, FFT_SIZE);
+    expect(bands.every((v) => v === 1)).toBe(true);
+  });
+
+  it('normalizes magnitudes to 0..1', () => {
+    const bands = groupBands(freqDataFilledWith(128), SAMPLE_RATE, FFT_SIZE);
+    for (const v of bands) {
+      expect(v).toBeGreaterThan(0.49);
+      expect(v).toBeLessThan(0.51);
+    }
+  });
+
+  it('places a low-frequency tone in the bottom bands only', () => {
+    // 100 Hz tone → bin ≈ 100 / (48000/2048) ≈ bin 4
+    const data = freqDataFilledWith(0);
+    const binHz = SAMPLE_RATE / FFT_SIZE;
+    data[Math.round(100 / binHz)] = 255;
+
+    const bands = groupBands(data, SAMPLE_RATE, FFT_SIZE);
+    const hot = bands.map((v, i) => (v > 0 ? i : -1)).filter((i) => i >= 0);
+
+    expect(hot.length).toBeGreaterThan(0);
+    // All hot bands are in the lower third of the display.
+    expect(Math.max(...hot)).toBeLessThan(SPECTRUM_BANDS / 3);
+  });
+
+  it('places a high-frequency tone in the top bands only', () => {
+    // 12 kHz tone → upper end of the 40 Hz..16 kHz log scale
+    const data = freqDataFilledWith(0);
+    const binHz = SAMPLE_RATE / FFT_SIZE;
+    data[Math.round(12000 / binHz)] = 255;
+
+    const bands = groupBands(data, SAMPLE_RATE, FFT_SIZE);
+    const hot = bands.map((v, i) => (v > 0 ? i : -1)).filter((i) => i >= 0);
+
+    expect(hot.length).toBeGreaterThan(0);
+    expect(Math.min(...hot)).toBeGreaterThan((SPECTRUM_BANDS * 2) / 3);
+  });
+
+  it('supports a custom band count', () => {
+    const bands = groupBands(freqDataFilledWith(255), SAMPLE_RATE, FFT_SIZE, 12);
+    expect(bands).toHaveLength(12);
+    expect(bands.every((v) => v === 1)).toBe(true);
+  });
+
+  it('never reads past the end of the FFT data at 44.1 kHz', () => {
+    // At 44.1 kHz the 16 kHz upper edge maps close to the last bin — must clamp.
+    const bands = groupBands(freqDataFilledWith(255), 44100, FFT_SIZE);
+    expect(bands).toHaveLength(SPECTRUM_BANDS);
+    expect(bands.every((v) => v === 1)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Live Panel 2.0 analyzers (#274) per `docs/stream-rework/live-panel-2.0.md` — the two analyzer card slots from the shell (#273/PR #280) now carry real spectra and faders.

### Input — your source (teal)
- New `useSpectrum` composable: `AnalyserNode` → 28 log-spaced bands (40 Hz–16 kHz), throttled rAF loop; pure `groupBands()` covered by 8 new Vitest cases
- `useAudioCapture` gains a **post-gain analyser tap** — the spectrum shows exactly what is recorded/streamed, so the gain fader shapes the display like in the prototype
- **Input gain fader (0–150 %)** wired to the existing `GainNode`/`setInputVolume`, live **peak-dB readout** in the card header (`useDbMeter` on `processedStream`)

### Stream — what listeners hear (purple, "~6 s behind")
- `StreamPreviewPlayer` rebuilt as the stream analyzer: CORS-mode playback (`crossorigin=anonymous` + `MediaElementSource → analyser → destination`), custom play/stop, **monitor-volume fader** (element volume only — listeners unaffected, default 70 %)
- **Graceful CORS fallback**: if the mount doesn't send `Access-Control-Allow-Origin`, the CORS load errors → the player rebuilds a plain element (audible preview, flat spectrum) and shows a hint. A `MediaElementSource` is permanent per element, hence the programmatic `<audio>`
- The `/test` rehearsal panel (`LiveSetupTest`) inherits the spectrum player; its inset-card look is restored locally

## ⚠ CORS on the Icecast mounts — needs verification

`docs/stream-rework/prod/icecast.xml` has no `http-headers` block, but Icecast-KH may send `Access-Control-Allow-Origin: *` by default — and **adding a duplicate header would break CORS entirely**. I couldn't verify from this machine (the known connectivity quirk). Before/after merging, check from a box that can reach the relay:

```bash
curl -sI https://radio.live.moafunk.de/test.mp3 | grep -i access-control
```

If nothing comes back, add to `icecast.xml` (global or per-mount):
```xml
<http-headers>
  <header name="Access-Control-Allow-Origin" value="*" />
</http-headers>
```
The frontend degrades gracefully either way (audible preview + hint, no spectrum).

## Test plan
- `npx vitest run` — 90/90 green (8 new for `groupBands`: normalization, log placement low/high, custom band count, 44.1 kHz clamping)
- `npm run build`, `npm run lint` — clean
- Manual: input spectrum reacts to gain fader; stream card plays with spectrum on a CORS-enabled mount, falls back with hint otherwise

Closes #274