### PR TITLE
feat(stream): connection & upload quality card (browser-side)

### DIFF
--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+// Connection & upload quality card (Live Panel 2.0, #275). All browser-side:
+// throughput sparkline (measured egress vs "needed for target" dashed line),
+// metric tiles, and the good/tight/slow verdict pill from useUploadHealth.
+// RTT arrives with the backend ack telemetry (#277); the quality selector
+// with the bitrate issue (#276).
+import { ref, computed, watch, onMounted, toRef } from 'vue';
+import { useUploadHealth, HISTORY_SECONDS, type UploadVerdict } from '@admin/composables';
+
+const props = defineProps<{
+  /** Poll the socket while true (i.e. while live / rehearsing). */
+  active: boolean;
+  /** Encoder target in bits/s (fixed 192k until #276). */
+  targetBitsPerSecond: number;
+}>();
+
+const health = useUploadHealth(toRef(props, 'active'), toRef(props, 'targetBitsPerSecond'));
+const { uploadKbps, bufferSeconds, lateCount, history, neededKbps, verdict, verdictText } = health;
+
+const VERDICT_CLASS: Record<UploadVerdict, string> = {
+  good: 'verdict-good',
+  tight: 'verdict-tight',
+  slow: 'verdict-slow',
+};
+const verdictClass = computed(() => VERDICT_CLASS[verdict.value]);
+
+// ─── Sparkline ───────────────────────────────────────────────────────────────
+const canvas = ref<HTMLCanvasElement | null>(null);
+
+function draw() {
+  const el = canvas.value;
+  const ctx = el?.getContext('2d');
+  if (!el || !ctx) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const w = el.clientWidth;
+  const h = el.clientHeight;
+  if (el.width !== w * dpr || el.height !== h * dpr) {
+    el.width = w * dpr;
+    el.height = h * dpr;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+
+  const needed = neededKbps.value;
+  const max = Math.max(needed * 1.5, ...history.value.map((v) => v * 1.1), 1);
+  const y = (v: number) => h - (Math.min(v, max) / max) * h;
+
+  // Gridlines
+  ctx.strokeStyle = 'rgba(128, 128, 128, 0.25)';
+  ctx.lineWidth = 1;
+  for (const f of [0.25, 0.5, 0.75]) {
+    ctx.beginPath();
+    ctx.moveTo(0, h * f);
+    ctx.lineTo(w, h * f);
+    ctx.stroke();
+  }
+
+  // "Needed for target" dashed line
+  const ny = y(needed);
+  ctx.strokeStyle = '#d85a30';
+  ctx.setLineDash([5, 4]);
+  ctx.beginPath();
+  ctx.moveTo(0, ny);
+  ctx.lineTo(w, ny);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.fillStyle = '#888';
+  ctx.font = '10px monospace';
+  ctx.fillText(`${Math.round(needed)} kbps`, 6, Math.max(10, ny - 4));
+
+  // Measured egress line
+  const data = history.value;
+  if (data.length >= 2) {
+    ctx.strokeStyle = '#1d9e75';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    data.forEach((v, i) => {
+      const x = (i / (HISTORY_SECONDS - 1)) * w;
+      if (i === 0) ctx.moveTo(x, y(v));
+      else ctx.lineTo(x, y(v));
+    });
+    ctx.stroke();
+  }
+}
+
+watch(history, draw, { deep: false });
+onMounted(draw);
+</script>
+
+<template>
+  <div class="panel-card conn-card">
+    <div class="conn-head">
+      <span class="conn-title">📶 Connection &amp; upload</span>
+      <span :class="['conn-verdict', verdictClass]">{{ verdictText }}</span>
+    </div>
+
+    <div class="conn-body">
+      <div class="conn-chart">
+        <canvas ref="canvas" class="conn-canvas"></canvas>
+        <div class="conn-chart-legend">
+          <span class="conn-axis">-{{ HISTORY_SECONDS }} s</span>
+          <span class="conn-legend">
+            <span class="legend-swatch legend-upload"></span>upload ·
+            <span class="legend-swatch legend-needed"></span>needed
+          </span>
+          <span class="conn-axis">now</span>
+        </div>
+      </div>
+
+      <div class="conn-tiles">
+        <div class="conn-tile">
+          <p class="conn-tile-label">Upload</p>
+          <p class="conn-tile-value">{{ uploadKbps }}k</p>
+        </div>
+        <div class="conn-tile">
+          <p class="conn-tile-label">Buffer</p>
+          <p class="conn-tile-value">{{ bufferSeconds.toFixed(1) }} s</p>
+        </div>
+        <div class="conn-tile">
+          <p class="conn-tile-label">RTT</p>
+          <p class="conn-tile-value conn-tile-muted" title="Arrives with the stream WS telemetry">
+            —
+          </p>
+        </div>
+        <div class="conn-tile">
+          <p class="conn-tile-label">Late</p>
+          <p class="conn-tile-value">{{ lateCount }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.conn-card {
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+
+.conn-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-sm);
+}
+
+.conn-title {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+}
+
+.conn-verdict {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.verdict-good {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.verdict-tight {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.verdict-slow {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.conn-body {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: var(--spacing-md);
+  align-items: stretch;
+}
+
+@media (max-width: 600px) {
+  .conn-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.conn-canvas {
+  display: block;
+  width: 100%;
+  height: 96px;
+}
+
+.conn-chart-legend {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 2px;
+}
+
+.conn-axis {
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+
+.conn-legend {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 2px;
+  vertical-align: middle;
+  margin: 0 4px 2px 0;
+}
+
+.legend-upload {
+  background: #1d9e75;
+}
+
+.legend-needed {
+  border-top: 2px dashed #d85a30;
+  height: 0;
+  margin-left: 4px;
+}
+
+.conn-tiles {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  align-content: start;
+}
+
+.conn-tile {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  padding: 6px 10px;
+}
+
+.conn-tile-label {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+}
+
+.conn-tile-value {
+  margin: 1px 0 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+
+.conn-tile-muted {
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -4,7 +4,7 @@
 // metric tiles, and the good/tight/slow verdict pill from useUploadHealth.
 // RTT arrives with the backend ack telemetry (#277); the quality selector
 // with the bitrate issue (#276).
-import { ref, computed, watch, onMounted, toRef } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted, toRef } from 'vue';
 import { useUploadHealth, HISTORY_SECONDS, type UploadVerdict } from '@admin/composables';
 
 const props = defineProps<{
@@ -69,14 +69,14 @@ function draw() {
   ctx.font = '10px monospace';
   ctx.fillText(`${Math.round(needed)} kbps`, 6, Math.max(10, ny - 4));
 
-  // Measured egress line
+  // Measured egress line, right-anchored so the newest sample sits at "now"
   const data = history.value;
   if (data.length >= 2) {
     ctx.strokeStyle = '#1d9e75';
     ctx.lineWidth = 2;
     ctx.beginPath();
     data.forEach((v, i) => {
-      const x = (i / (HISTORY_SECONDS - 1)) * w;
+      const x = w - ((data.length - 1 - i) / (HISTORY_SECONDS - 1)) * w;
       if (i === 0) ctx.moveTo(x, y(v));
       else ctx.lineTo(x, y(v));
     });
@@ -85,7 +85,14 @@ function draw() {
 }
 
 watch(history, draw, { deep: false });
-onMounted(draw);
+
+let resizeObserver: ResizeObserver | null = null;
+onMounted(() => {
+  draw();
+  resizeObserver = new ResizeObserver(draw);
+  if (canvas.value) resizeObserver.observe(canvas.value);
+});
+onUnmounted(() => resizeObserver?.disconnect());
 </script>
 
 <template>

--- a/frontend/src/admin/components/LiveSetupTest.vue
+++ b/frontend/src/admin/components/LiveSetupTest.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { useHostFlow, useAudioCapture, useStreamSocket } from '@admin/composables';
+import {
+  useHostFlow,
+  useAudioCapture,
+  useStreamSocket,
+  useUploadHealth,
+  STREAM_AUDIO_BITS_PER_SECOND,
+} from '@admin/composables';
 import DbMeter from '@admin/components/DbMeter.vue';
 import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
 import { config } from '@/config';
@@ -121,7 +127,10 @@ function startTestRecording(): boolean {
     ? 'audio/webm;codecs=opus'
     : 'audio/webm';
 
-  testRecorder = new MediaRecorder(stream, { mimeType, audioBitsPerSecond: 192000 });
+  testRecorder = new MediaRecorder(stream, {
+    mimeType,
+    audioBitsPerSecond: STREAM_AUDIO_BITS_PER_SECOND,
+  });
 
   testRecorder.ondataavailable = async (event) => {
     if (event.data.size > 0) {
@@ -195,6 +204,15 @@ function markTestPassed() {
   flow.setLiveTestPassed(true);
   emit('passed');
 }
+
+// ─── Rehearsal connection verdict (#275) ─────────────────────────────────────
+// The same browser-side upload telemetry as the on-air connection card runs
+// against the test broadcast, so the host knows "connection good enough"
+// BEFORE air time.
+const testHealth = useUploadHealth(
+  computed(() => testPhase.value === 'live'),
+  ref(STREAM_AUDIO_BITS_PER_SECOND)
+);
 
 const isDev = import.meta.env.DEV;
 
@@ -280,6 +298,14 @@ onUnmounted(() => {
           <span class="ls-dot rec"></span>
           Test broadcast live
           <span class="ls-muted">· {{ sentChunks }} chunks sent</span>
+        </p>
+
+        <!-- Same upload telemetry as the on-air connection card (#275). -->
+        <p class="ls-conn">
+          <span :class="['ls-conn-pill', `ls-conn-${testHealth.verdict.value}`]">
+            {{ testHealth.verdictText.value }}
+          </span>
+          <span class="ls-muted">· {{ testHealth.uploadKbps.value }} kbps up</span>
         </p>
 
         <!-- Runs a few seconds behind — use headphones. -->
@@ -452,6 +478,37 @@ onUnmounted(() => {
   margin: 0;
   font-size: var(--font-size-sm);
   font-weight: 600;
+  color: var(--color-error);
+}
+
+.ls-conn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.ls-conn-pill {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.ls-conn-good {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.ls-conn-tight {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+}
+
+.ls-conn-slow {
+  background: var(--color-error-bg);
   color: var(--color-error);
 }
 

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -1,13 +1,29 @@
 export { useFlash, type FlashMessage } from './useFlash';
 export {
   useStreamSocket,
+  getStreamSocketStats,
   type StreamConnectionState,
+  type StreamSocketStats,
   type UseStreamSocketOptions,
 } from './useStreamSocket';
-export { useAudioCapture, type AudioDevice, type UseAudioCaptureOptions } from './useAudioCapture';
+export {
+  useAudioCapture,
+  STREAM_AUDIO_BITS_PER_SECOND,
+  type AudioDevice,
+  type UseAudioCaptureOptions,
+} from './useAudioCapture';
 export { useAudioMeter } from './useAudioMeter';
 export { useDbMeter, dbToLevel, DB_FLOOR, DB_CEIL } from './useDbMeter';
 export { useSpectrum, groupBands, SPECTRUM_BANDS } from './useSpectrum';
+export {
+  useUploadHealth,
+  computeTick,
+  verdictFor,
+  HISTORY_SECONDS,
+  CONTAINER_OVERHEAD,
+  type UploadVerdict,
+  type UploadTick,
+} from './useUploadHealth';
 export {
   useRecordingSession,
   type TrackType,

--- a/frontend/src/admin/composables/useAudioCapture.ts
+++ b/frontend/src/admin/composables/useAudioCapture.ts
@@ -11,6 +11,13 @@ export interface UseAudioCaptureOptions {
 }
 
 /**
+ * Encoder target for live/test broadcasts. Fixed at MediaRecorder construction
+ * for now — the selectable/auto bitrate (#276) will turn this into state.
+ * Also feeds the connection card's "needed for target" math (#275).
+ */
+export const STREAM_AUDIO_BITS_PER_SECOND = 192_000;
+
+/**
  * Pick AudioContext options that match the capture device's real sample rate.
  *
  * Pro interfaces (e.g. Allen & Heath Xone:23C) run at 96/44.1 kHz and ignore the
@@ -291,7 +298,7 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
 
       mediaRecorder = new MediaRecorder(streamToRecord, {
         mimeType,
-        audioBitsPerSecond: 192000,
+        audioBitsPerSecond: STREAM_AUDIO_BITS_PER_SECOND,
       });
 
       mediaRecorder.ondataavailable = async (event) => {

--- a/frontend/src/admin/composables/useStreamSocket.ts
+++ b/frontend/src/admin/composables/useStreamSocket.ts
@@ -17,6 +17,10 @@ const reconnectAttempts = ref(0);
 
 let socket: WebSocket | null = null;
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+// Total binary payload bytes handed to socket.send() since (re)connect.
+// Together with bufferedAmount this is the browser-side upload-health signal
+// (#275): egress = Δqueued − Δbuffered, buffer-seconds = buffered / byte-rate.
+let bytesQueued = 0;
 // Remembered across reconnects so the backend keeps auto-recording the same show.
 let currentShowId: number | null = null;
 // Remembered across reconnects so a rehearsal stays on the private `/test` mount.
@@ -38,6 +42,31 @@ if (typeof window !== 'undefined') {
       socket.close(1000, 'Page unload');
     }
   });
+}
+
+export interface StreamSocketStats {
+  /** Whether a socket exists and is OPEN. */
+  connected: boolean;
+  /** Bytes accepted by send() but not yet handed to the OS/network. */
+  bufferedAmount: number;
+  /** Total binary payload bytes queued since the socket (re)connected. */
+  bytesQueued: number;
+}
+
+/**
+ * Read-only upload counters for the singleton stream socket (#275).
+ *
+ * A standalone export (NOT part of useStreamSocket()) so telemetry consumers
+ * can poll it without calling the composable — calling useStreamSocket()
+ * replaces the singleton's event callbacks, which would break the component
+ * that owns the connection.
+ */
+export function getStreamSocketStats(): StreamSocketStats {
+  return {
+    connected: socket !== null && socket.readyState === WebSocket.OPEN,
+    bufferedAmount: socket?.bufferedAmount ?? 0,
+    bytesQueued,
+  };
 }
 
 export function useStreamSocket(options: UseStreamSocketOptions = {}) {
@@ -75,6 +104,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
 
       socket = new WebSocket(wsUrl);
       socket.binaryType = 'arraybuffer';
+      bytesQueued = 0;
 
       socket.onopen = () => {
         console.log('[StreamSocket] Connected');
@@ -136,6 +166,9 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
       return false;
     }
     socket.send(data);
+    if (data instanceof ArrayBuffer) {
+      bytesQueued += data.byteLength;
+    }
     return true;
   }
 

--- a/frontend/src/admin/composables/useUploadHealth.ts
+++ b/frontend/src/admin/composables/useUploadHealth.ts
@@ -1,0 +1,155 @@
+import { ref, computed, onUnmounted, watch, type Ref } from 'vue';
+import { getStreamSocketStats, type StreamSocketStats } from './useStreamSocket';
+
+/** Seconds of throughput history kept for the sparkline. */
+export const HISTORY_SECONDS = 60;
+/** Container/framing overhead on top of the raw encoder bitrate. */
+export const CONTAINER_OVERHEAD = 1.15;
+/** Send-buffer seconds above which a tick counts as "late". */
+const LATE_BUFFER_S = 1.5;
+/** Buffer thresholds for the verdict pill. */
+const BUFFER_GOOD_S = 0.5;
+
+export type UploadVerdict = 'good' | 'tight' | 'slow';
+
+export interface UploadTick {
+  /** Payload kbit/s handed to the socket this tick (encoder output rate). */
+  encodedKbps: number;
+  /** Payload kbit/s actually drained to the network this tick. */
+  egressKbps: number;
+  /** Send-buffer depth in seconds at the target byte rate. */
+  bufferSeconds: number;
+}
+
+/**
+ * Compute one telemetry tick from two socket-stat snapshots. Pure — unit
+ * tested. `elapsedMs` guards against timer jitter; a `bytesQueued` that went
+ * backwards means the socket reconnected, which yields a zero tick.
+ */
+export function computeTick(
+  prev: Pick<StreamSocketStats, 'bufferedAmount' | 'bytesQueued'>,
+  cur: Pick<StreamSocketStats, 'bufferedAmount' | 'bytesQueued'>,
+  targetBitsPerSecond: number,
+  elapsedMs: number
+): UploadTick {
+  if (elapsedMs <= 0 || cur.bytesQueued < prev.bytesQueued) {
+    return { encodedKbps: 0, egressKbps: 0, bufferSeconds: 0 };
+  }
+
+  const queuedBytes = cur.bytesQueued - prev.bytesQueued;
+  const drainedBytes = Math.max(0, queuedBytes - (cur.bufferedAmount - prev.bufferedAmount));
+  const secs = elapsedMs / 1000;
+
+  const targetBytesPerSecond = (targetBitsPerSecond * CONTAINER_OVERHEAD) / 8;
+
+  return {
+    encodedKbps: (queuedBytes * 8) / secs / 1000,
+    egressKbps: (drainedBytes * 8) / secs / 1000,
+    bufferSeconds: targetBytesPerSecond > 0 ? cur.bufferedAmount / targetBytesPerSecond : 0,
+  };
+}
+
+/**
+ * Verdict from the send-buffer depth. The browser can't measure headroom
+ * beyond the produced bitrate (egress is capped at what the encoder emits),
+ * so buffer drain IS the congestion signal: an empty buffer means the network
+ * keeps up with the target; a growing one means it doesn't.
+ */
+export function verdictFor(bufferSeconds: number): UploadVerdict {
+  if (bufferSeconds < BUFFER_GOOD_S) return 'good';
+  if (bufferSeconds < LATE_BUFFER_S) return 'tight';
+  return 'slow';
+}
+
+/**
+ * Browser-side upload health for the stream WebSocket (#275).
+ *
+ * Polls the singleton socket's counters once a second while `active` is true:
+ * encoded rate (bytes handed to send()), real egress (bufferedAmount drain),
+ * send-buffer seconds, late-tick counter, sparkline history, and a
+ * good/tight/slow verdict. Zero backend involvement.
+ */
+export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<number>) {
+  const uploadKbps = ref(0);
+  const encodedKbps = ref(0);
+  const bufferSeconds = ref(0);
+  const lateCount = ref(0);
+  /** Last HISTORY_SECONDS egress samples (kbps), oldest first. */
+  const history = ref<number[]>([]);
+
+  const neededKbps = computed(() => (targetBitsPerSecond.value * CONTAINER_OVERHEAD) / 1000);
+  const verdict = computed<UploadVerdict>(() => verdictFor(bufferSeconds.value));
+  const verdictText = computed(() => {
+    switch (verdict.value) {
+      case 'good':
+        return 'Good — keeping up with the target';
+      case 'tight':
+        return `Tight — ${bufferSeconds.value.toFixed(1)} s buffered`;
+      case 'slow':
+        return 'Too slow — lower the quality';
+    }
+  });
+
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let prev: StreamSocketStats | null = null;
+  let prevTs = 0;
+
+  function tick() {
+    const cur = getStreamSocketStats();
+    const now = performance.now();
+
+    if (prev && prev.connected && cur.connected) {
+      const t = computeTick(prev, cur, targetBitsPerSecond.value, now - prevTs);
+      encodedKbps.value = Math.round(t.encodedKbps);
+      uploadKbps.value = Math.round(t.egressKbps);
+      bufferSeconds.value = t.bufferSeconds;
+      if (t.bufferSeconds > LATE_BUFFER_S) lateCount.value++;
+      history.value = [...history.value.slice(-(HISTORY_SECONDS - 1)), t.egressKbps];
+    }
+
+    prev = cur;
+    prevTs = now;
+  }
+
+  function reset() {
+    uploadKbps.value = 0;
+    encodedKbps.value = 0;
+    bufferSeconds.value = 0;
+    lateCount.value = 0;
+    history.value = [];
+    prev = null;
+    prevTs = 0;
+  }
+
+  function stop() {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  }
+
+  watch(
+    active,
+    (on) => {
+      stop();
+      if (on) {
+        reset();
+        interval = setInterval(tick, 1000);
+      }
+    },
+    { immediate: true }
+  );
+
+  onUnmounted(stop);
+
+  return {
+    uploadKbps,
+    encodedKbps,
+    bufferSeconds,
+    lateCount,
+    history,
+    neededKbps,
+    verdict,
+    verdictText,
+  };
+}

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -8,8 +8,10 @@ import {
   useSpectrum,
   useDbMeter,
   DB_FLOOR,
+  STREAM_AUDIO_BITS_PER_SECOND,
 } from '@admin/composables';
 import { streamApi, recordingApi, hostFlowApi, type StreamMetrics } from '@admin/api';
+import ConnectionCard from '@admin/components/ConnectionCard.vue';
 import DbMeter from '@admin/components/DbMeter.vue';
 import SpectrumBars from '@admin/components/SpectrumBars.vue';
 import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
@@ -765,17 +767,12 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- 3 · Connection & upload (live mode) — metrics land with the
-           connection-card issue. -->
-      <div v-if="isLiveMode" class="panel-card slot-card slot-placeholder">
-        <div class="slot-head">
-          <span class="slot-title">📶 Connection &amp; upload</span>
-          <span class="slot-badge">Coming soon</span>
-        </div>
-        <p class="slot-hint">
-          Throughput vs. target, send buffer, RTT and the upload-quality selector will live here.
-        </p>
-      </div>
+      <!-- 3 · Connection & upload (live mode, browser-side telemetry #275) -->
+      <ConnectionCard
+        v-if="isLiveMode"
+        :active="streamActive"
+        :target-bits-per-second="STREAM_AUDIO_BITS_PER_SECOND"
+      />
 
       <!-- 4 · Live chat — Telegram bridge lands with the chat issue. -->
       <div class="panel-card slot-card slot-placeholder">

--- a/frontend/tests/useUploadHealth.test.ts
+++ b/frontend/tests/useUploadHealth.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { computeTick, verdictFor, CONTAINER_OVERHEAD } from '../src/admin/composables/useUploadHealth';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createApp, defineComponent, nextTick, ref, type Ref } from 'vue';
+
+const { statsMock } = vi.hoisted(() => ({ statsMock: vi.fn() }));
+vi.mock('../src/admin/composables/useStreamSocket', () => ({
+  getStreamSocketStats: statsMock,
+}));
+
+import {
+  computeTick,
+  verdictFor,
+  useUploadHealth,
+  CONTAINER_OVERHEAD,
+  HISTORY_SECONDS,
+} from '../src/admin/composables/useUploadHealth';
 
 const TARGET = 192_000; // bits/s
 const TARGET_BYTES_PER_S = (TARGET * CONTAINER_OVERHEAD) / 8;
@@ -50,6 +63,80 @@ describe('computeTick', () => {
   it('yields a zero tick for non-positive elapsed time', () => {
     const t = computeTick(stats(0), stats(27_600), TARGET, 0);
     expect(t).toEqual({ encodedKbps: 0, egressKbps: 0, bufferSeconds: 0 });
+  });
+});
+
+describe('useUploadHealth (stateful)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    statsMock.mockReset();
+  });
+
+  /** Mount the composable inside a throwaway component for lifecycle hooks. */
+  function mountHealth(active: Ref<boolean>) {
+    let health!: ReturnType<typeof useUploadHealth>;
+    const app = createApp(
+      defineComponent({
+        setup() {
+          health = useUploadHealth(active, ref(TARGET));
+          return () => null;
+        },
+      })
+    );
+    app.mount(document.createElement('div'));
+    return { health, unmount: () => app.unmount() };
+  }
+
+  it('caps history at HISTORY_SECONDS and counts each slow tick as late', () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'performance'] });
+    // Steady 27,600 bytes/s queued, 60,000 bytes stuck in the buffer
+    // (≈ 2.2 s at the target rate → every tick is "late").
+    let queued = 0;
+    statsMock.mockImplementation(() => ({
+      connected: true,
+      bufferedAmount: 60_000,
+      bytesQueued: (queued += 27_600),
+    }));
+
+    const { health, unmount } = mountHealth(ref(true));
+    const ticks = HISTORY_SECONDS + 10;
+    vi.advanceTimersByTime(ticks * 1000);
+
+    expect(health.history.value.length).toBe(HISTORY_SECONDS);
+    // First tick only seeds prev; every following tick is late.
+    expect(health.lateCount.value).toBe(ticks - 1);
+    expect(health.verdict.value).toBe('slow');
+    unmount();
+  });
+
+  it('skips ticks while disconnected and stops polling on unmount', async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'performance'] });
+    statsMock.mockImplementation(() => ({
+      connected: false,
+      bufferedAmount: 0,
+      bytesQueued: 0,
+    }));
+
+    const active = ref(true);
+    const { health, unmount } = mountHealth(active);
+    vi.advanceTimersByTime(5000);
+    expect(health.history.value).toEqual([]);
+    expect(health.uploadKbps.value).toBe(0);
+
+    // Deactivating clears the interval — no further polls.
+    active.value = false;
+    await nextTick();
+    const polls = statsMock.mock.calls.length;
+    vi.advanceTimersByTime(5000);
+    expect(statsMock.mock.calls.length).toBe(polls);
+
+    // Reactivate, then unmount must also stop the timer.
+    active.value = true;
+    await nextTick();
+    unmount();
+    const pollsAfterUnmount = statsMock.mock.calls.length;
+    vi.advanceTimersByTime(5000);
+    expect(statsMock.mock.calls.length).toBe(pollsAfterUnmount);
   });
 });
 

--- a/frontend/tests/useUploadHealth.test.ts
+++ b/frontend/tests/useUploadHealth.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { computeTick, verdictFor, CONTAINER_OVERHEAD } from '../src/admin/composables/useUploadHealth';
+
+const TARGET = 192_000; // bits/s
+const TARGET_BYTES_PER_S = (TARGET * CONTAINER_OVERHEAD) / 8;
+
+function stats(bytesQueued: number, bufferedAmount = 0) {
+  return { bytesQueued, bufferedAmount };
+}
+
+describe('computeTick', () => {
+  it('reports encoded == egress when the buffer stays empty', () => {
+    // 27,600 bytes/s ≈ 192 kbps × 1.15 overhead
+    const t = computeTick(stats(0), stats(27_600), TARGET, 1000);
+    expect(t.encodedKbps).toBeCloseTo(220.8, 1);
+    expect(t.egressKbps).toBeCloseTo(220.8, 1);
+    expect(t.bufferSeconds).toBe(0);
+  });
+
+  it('subtracts buffer growth from egress under congestion', () => {
+    // Queued 27,600 bytes but 20,000 of them are stuck in the buffer.
+    const t = computeTick(stats(0, 0), stats(27_600, 20_000), TARGET, 1000);
+    expect(t.encodedKbps).toBeCloseTo(220.8, 1);
+    expect(t.egressKbps).toBeCloseTo(((27_600 - 20_000) * 8) / 1000, 1);
+    expect(t.bufferSeconds).toBeCloseTo(20_000 / TARGET_BYTES_PER_S, 3);
+  });
+
+  it('adds buffer drain to egress during recovery', () => {
+    // Buffer shrank by 10,000 while 27,600 new bytes were queued.
+    const t = computeTick(stats(0, 10_000), stats(27_600, 0), TARGET, 1000);
+    expect(t.egressKbps).toBeCloseTo(((27_600 + 10_000) * 8) / 1000, 1);
+  });
+
+  it('never reports negative egress', () => {
+    // Buffer grew by more than was queued (shouldn't happen, but clamp).
+    const t = computeTick(stats(0, 0), stats(100, 5_000), TARGET, 1000);
+    expect(t.egressKbps).toBe(0);
+  });
+
+  it('scales rates by the elapsed time', () => {
+    const t = computeTick(stats(0), stats(27_600), TARGET, 2000);
+    expect(t.encodedKbps).toBeCloseTo(110.4, 1);
+  });
+
+  it('yields a zero tick when the counter reset (socket reconnect)', () => {
+    const t = computeTick(stats(1_000_000), stats(5_000), TARGET, 1000);
+    expect(t).toEqual({ encodedKbps: 0, egressKbps: 0, bufferSeconds: 0 });
+  });
+
+  it('yields a zero tick for non-positive elapsed time', () => {
+    const t = computeTick(stats(0), stats(27_600), TARGET, 0);
+    expect(t).toEqual({ encodedKbps: 0, egressKbps: 0, bufferSeconds: 0 });
+  });
+});
+
+describe('verdictFor', () => {
+  it('is good while the buffer drains immediately', () => {
+    expect(verdictFor(0)).toBe('good');
+    expect(verdictFor(0.4)).toBe('good');
+  });
+
+  it('is tight when the buffer holds noticeable backlog', () => {
+    expect(verdictFor(0.5)).toBe('tight');
+    expect(verdictFor(1.4)).toBe('tight');
+  });
+
+  it('is slow when the backlog exceeds the late threshold', () => {
+    expect(verdictFor(1.5)).toBe('slow');
+    expect(verdictFor(9)).toBe('slow');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Live Panel 2.0 connection & upload card (#275) per `docs/stream-rework/live-panel-2.0.md` — entirely browser-side, **zero backend changes**, exactly as the spec's implementation map prescribes (`ws.bufferedAmount` drain as "the best congestion signal").

### Telemetry (`useUploadHealth`)
- `useStreamSocket` now counts queued payload bytes in `send()`; a standalone `getStreamSocketStats()` export lets telemetry poll the singleton **without** calling `useStreamSocket()` (which would clobber the owning component's event callbacks)
- 1 s tick computes: encoded rate (bytes handed to the socket), **real egress** (queued − Δ`bufferedAmount`), send-buffer depth in seconds, late-tick counter, 60 s history
- **Verdict** (`Good / Tight / Too slow` pill): keyed off send-buffer drain. Design note: the browser cannot observe headroom beyond the produced bitrate — egress is capped at what the encoder emits — so the prototype's "4.1× headroom" number isn't honestly measurable client-side; an empty buffer *is* the "network keeps up" signal. Buffer < 0.5 s → good, < 1.5 s → tight, above → too slow.
- Pure `computeTick` / `verdictFor` helpers with 10 new Vitest cases (congestion, recovery, reconnect counter reset, clamping)

### ConnectionCard (on-air panel)
- Throughput sparkline: measured egress (teal) vs dashed "needed for target" line (192 kbps × 1.15 container overhead), HiDPI-aware canvas
- Metric tiles: Upload · Buffer · RTT (— until the WS ack telemetry #277) · Late
- Replaces the shell's "coming soon" placeholder; the quality selector footer arrives with #276

### Rehearsal verdict (LiveSetupTest)
- The same telemetry runs against the `/test` broadcast: verdict pill + upload rate shown while the test is live — "connection good enough" **before** air time, as the design locked in

### Shared constant
- `STREAM_AUDIO_BITS_PER_SECOND` (192k) replaces both hard-coded `audioBitsPerSecond` values; #276 turns it into state

## Test plan
- `npx vitest run` — 100/100 green
- `npm run lint`, `npm run build` — clean
- Manual: rehearsal on the dashboard shows the pill while the test broadcast runs; on-air card ticks once live

Closes #275