### PR TITLE
feat(stream): selectable + auto upload bitrate

### DIFF
--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -172,6 +172,7 @@ onUnmounted(() => resizeObserver?.disconnect());
         <button
           type="button"
           :class="['conn-step', { 'conn-step-active': qualityMode === 'auto' }]"
+          :aria-pressed="qualityMode === 'auto'"
           @click="selectQuality('auto')"
         >
           Auto
@@ -181,6 +182,7 @@ onUnmounted(() => resizeObserver?.disconnect());
           :key="step"
           type="button"
           :class="['conn-step', { 'conn-step-active': qualityMode === step }]"
+          :aria-pressed="qualityMode === step"
           @click="selectQuality(step)"
         >
           {{ step }}

--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -5,17 +5,46 @@
 // RTT arrives with the backend ack telemetry (#277); the quality selector
 // with the bitrate issue (#276).
 import { ref, computed, watch, onMounted, onUnmounted, toRef } from 'vue';
-import { useUploadHealth, HISTORY_SECONDS, type UploadVerdict } from '@admin/composables';
+import {
+  useUploadHealth,
+  useAutoBitrate,
+  HISTORY_SECONDS,
+  QUALITY_STEPS_KBPS,
+  type UploadVerdict,
+  type UploadQualityMode,
+} from '@admin/composables';
 
 const props = defineProps<{
   /** Poll the socket while true (i.e. while live / rehearsing). */
   active: boolean;
-  /** Encoder target in bits/s (fixed 192k until #276). */
+  /** Currently applied encoder target in bits/s. */
   targetBitsPerSecond: number;
+}>();
+
+const emit = defineEmits<{
+  /** Ask the owner to switch the encoder to this target (bits/s). */
+  (e: 'select-bitrate', bitsPerSecond: number): void;
 }>();
 
 const health = useUploadHealth(toRef(props, 'active'), toRef(props, 'targetBitsPerSecond'));
 const { uploadKbps, bufferSeconds, lateCount, history, neededKbps, verdict, verdictText } = health;
+
+// ─── Upload quality selector (#276) ─────────────────────────────────────────
+const qualityMode = ref<UploadQualityMode>('auto');
+const currentKbps = computed(() => Math.round(props.targetBitsPerSecond / 1000));
+
+useAutoBitrate({
+  mode: qualityMode,
+  currentKbps,
+  bufferSeconds,
+  ticks: health.ticks,
+  onChange: (kbps) => emit('select-bitrate', kbps * 1000),
+});
+
+function selectQuality(step: UploadQualityMode) {
+  qualityMode.value = step;
+  if (step !== 'auto') emit('select-bitrate', step * 1000);
+}
 
 const VERDICT_CLASS: Record<UploadVerdict, string> = {
   good: 'verdict-good',
@@ -135,6 +164,34 @@ onUnmounted(() => resizeObserver?.disconnect());
           <p class="conn-tile-value">{{ lateCount }}</p>
         </div>
       </div>
+    </div>
+
+    <div class="conn-quality">
+      <span class="conn-quality-label">Upload quality</span>
+      <div class="conn-quality-steps" role="group" aria-label="Upload quality">
+        <button
+          type="button"
+          :class="['conn-step', { 'conn-step-active': qualityMode === 'auto' }]"
+          @click="selectQuality('auto')"
+        >
+          Auto
+        </button>
+        <button
+          v-for="step in QUALITY_STEPS_KBPS"
+          :key="step"
+          type="button"
+          :class="['conn-step', { 'conn-step-active': qualityMode === step }]"
+          @click="selectQuality(step)"
+        >
+          {{ step }}
+        </button>
+        <span class="conn-step-unit">kbps</span>
+      </div>
+      <p class="conn-quality-note">
+        <template v-if="qualityMode === 'auto'">Auto · currently {{ currentKbps }} kbps · </template
+        >Auto steps down when the buffer grows · switch = &lt;1 s encoder restart, covered by the
+        relay
+      </p>
     </div>
   </div>
 </template>
@@ -268,6 +325,65 @@ onUnmounted(() => resizeObserver?.disconnect());
 }
 
 .conn-tile-muted {
+  color: var(--color-text-muted);
+}
+
+.conn-quality {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-sm);
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid var(--color-border);
+}
+
+.conn-quality-label {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.conn-quality-steps {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.conn-step {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  padding: 3px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.conn-step:hover {
+  color: var(--color-text);
+}
+
+.conn-step-active {
+  background: var(--color-surface-alt);
+  border-color: var(--color-text-muted);
+  color: var(--color-text);
+}
+
+.conn-step-unit {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-left: 2px;
+}
+
+.conn-quality-note {
+  flex-basis: 100%;
+  margin: 2px 0 0;
+  font-family: var(--font-ui);
+  font-size: 0.625rem;
   color: var(--color-text-muted);
 }
 </style>

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -33,6 +33,7 @@ export {
   STEP_DOWN_BUFFER_S,
   STEP_DOWN_TICKS,
   STEP_UP_TICKS,
+  STEP_SETTLE_TICKS,
   type UploadQualityMode,
   type AutoBitrateState,
 } from './useAutoBitrate';

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -25,6 +25,18 @@ export {
   type UploadTick,
 } from './useUploadHealth';
 export {
+  useAutoBitrate,
+  decideBitrate,
+  initialAutoState,
+  QUALITY_STEPS_KBPS,
+  AUTO_CEILING_KBPS,
+  STEP_DOWN_BUFFER_S,
+  STEP_DOWN_TICKS,
+  STEP_UP_TICKS,
+  type UploadQualityMode,
+  type AutoBitrateState,
+} from './useAutoBitrate';
+export {
   useRecordingSession,
   type TrackType,
   type TrackState,

--- a/frontend/src/admin/composables/useAudioCapture.ts
+++ b/frontend/src/admin/composables/useAudioCapture.ts
@@ -11,9 +11,9 @@ export interface UseAudioCaptureOptions {
 }
 
 /**
- * Encoder target for live/test broadcasts. Fixed at MediaRecorder construction
- * for now — the selectable/auto bitrate (#276) will turn this into state.
- * Also feeds the connection card's "needed for target" math (#275).
+ * Default encoder target for live/test broadcasts. The live target is the
+ * `streamBitsPerSecond` ref (selectable/auto, #276); this constant seeds it
+ * and stays the fixed rate for the prep rehearsal.
  */
 export const STREAM_AUDIO_BITS_PER_SECOND = 192_000;
 
@@ -42,6 +42,11 @@ const error = ref<string | null>(null);
 
 // Volume control (0-2, where 1 is normal, 0 is muted, 2 is 2x gain)
 const inputVolume = ref(1);
+
+// Encoder target (bits/s). audioBitsPerSecond is fixed at MediaRecorder
+// construction, so changing this mid-broadcast restarts the recorder — the
+// sub-second gap is covered by the harbor's mksafe (#276).
+const streamBitsPerSecond = ref(STREAM_AUDIO_BITS_PER_SECOND);
 
 // Use shallowRef for non-reactive objects
 const mediaStream = shallowRef<MediaStream | null>(null);
@@ -83,6 +88,20 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
    */
   function setOnError(callback: ((error: string) => void) | null): void {
     currentOnError = callback;
+  }
+
+  /**
+   * Change the encoder target. If a recorder is running it is restarted with
+   * the new rate (fresh WebM header, <1 s gap — the relay's mksafe covers it,
+   * same mechanism restartRecording() already uses for file recordings).
+   */
+  function setStreamBitsPerSecond(bitsPerSecond: number): void {
+    if (bitsPerSecond === streamBitsPerSecond.value) return;
+    streamBitsPerSecond.value = bitsPerSecond;
+    if (isRecording.value) {
+      console.log('[AudioCapture] Encoder target →', bitsPerSecond, 'bps; restarting recorder');
+      restartRecording();
+    }
   }
 
   function setInputVolume(volume: number): void {
@@ -298,7 +317,7 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
 
       mediaRecorder = new MediaRecorder(streamToRecord, {
         mimeType,
-        audioBitsPerSecond: STREAM_AUDIO_BITS_PER_SECOND,
+        audioBitsPerSecond: streamBitsPerSecond.value,
       });
 
       mediaRecorder.ondataavailable = async (event) => {
@@ -371,6 +390,8 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
 
     isCapturing.value = false;
     selectedDeviceId.value = '';
+    // Auto/manual bitrate choices are per-broadcast — next show starts fresh.
+    streamBitsPerSecond.value = STREAM_AUDIO_BITS_PER_SECOND;
     console.log('[AudioCapture] Capture stopped');
   }
 
@@ -389,6 +410,8 @@ export function useAudioCapture(options: UseAudioCaptureOptions = {}) {
     processedStream,
     analyserNode,
     inputVolume,
+    streamBitsPerSecond,
+    setStreamBitsPerSecond,
     setInputVolume,
     setOnData,
     setOnError,

--- a/frontend/src/admin/composables/useAutoBitrate.ts
+++ b/frontend/src/admin/composables/useAutoBitrate.ts
@@ -18,6 +18,13 @@ export const STEP_DOWN_BUFFER_S = 0.5;
 export const STEP_DOWN_TICKS = 3;
 /** Consecutive clean ticks (≈ seconds) before stepping back up a notch. */
 export const STEP_UP_TICKS = 30;
+/**
+ * Ticks skipped after every switch. bufferSeconds is relative to the target,
+ * so a step-down makes the same backlog read as MORE seconds against a lower
+ * bar — without a settle window one congestion event could cascade two
+ * notches before the buffer had a chance to drain at the new rate.
+ */
+export const STEP_SETTLE_TICKS = 5;
 
 /** 'auto' or a fixed kbps value from QUALITY_STEPS_KBPS. */
 export type UploadQualityMode = 'auto' | number;
@@ -25,39 +32,57 @@ export type UploadQualityMode = 'auto' | number;
 export interface AutoBitrateState {
   congestedTicks: number;
   stableTicks: number;
+  /** Remaining post-switch ticks during which no decision is made. */
+  settleTicks: number;
 }
 
 export function initialAutoState(): AutoBitrateState {
-  return { congestedTicks: 0, stableTicks: 0 };
+  return { congestedTicks: 0, stableTicks: 0, settleTicks: 0 };
+}
+
+function afterStep(): AutoBitrateState {
+  return { congestedTicks: 0, stableTicks: 0, settleTicks: STEP_SETTLE_TICKS };
 }
 
 /**
  * One auto-mode decision per telemetry tick. Pure — unit tested.
  * Returns the kbps to switch to (or null to stay) plus the carried state;
- * any step decision resets both counters so switches can't cascade.
+ * any step starts a settle window so switches can't cascade.
  */
 export function decideBitrate(
   currentKbps: number,
   bufferSeconds: number,
   state: AutoBitrateState
 ): { nextKbps: number | null; state: AutoBitrateState } {
+  if (state.settleTicks > 0) {
+    return { nextKbps: null, state: { ...state, settleTicks: state.settleTicks - 1 } };
+  }
+
+  // Entering auto from a manual 320: come back to the ceiling right away —
+  // above it there is no congestion escape hatch (step-up is ceiling-capped).
+  if (currentKbps > AUTO_CEILING_KBPS) {
+    return { nextKbps: AUTO_CEILING_KBPS, state: afterStep() };
+  }
+
   if (bufferSeconds > STEP_DOWN_BUFFER_S) {
     const congestedTicks = state.congestedTicks + 1;
     if (congestedTicks >= STEP_DOWN_TICKS) {
       // Ladder is sorted high→low, so the first smaller entry is one notch down.
       const lower = QUALITY_STEPS_KBPS.find((k) => k < currentKbps) ?? null;
-      return { nextKbps: lower, state: initialAutoState() };
+      return { nextKbps: lower, state: lower === null ? initialAutoState() : afterStep() };
     }
-    return { nextKbps: null, state: { congestedTicks, stableTicks: 0 } };
+    return { nextKbps: null, state: { ...state, congestedTicks, stableTicks: 0 } };
   }
 
   const stableTicks = state.stableTicks + 1;
   if (stableTicks >= STEP_UP_TICKS && currentKbps < AUTO_CEILING_KBPS) {
     const higher = [...QUALITY_STEPS_KBPS].reverse().find((k) => k > currentKbps);
     const next = Math.min(higher ?? currentKbps, AUTO_CEILING_KBPS);
-    return { nextKbps: next !== currentKbps ? next : null, state: initialAutoState() };
+    return next !== currentKbps
+      ? { nextKbps: next, state: afterStep() }
+      : { nextKbps: null, state: initialAutoState() };
   }
-  return { nextKbps: null, state: { congestedTicks: 0, stableTicks } };
+  return { nextKbps: null, state: { ...state, congestedTicks: 0, stableTicks } };
 }
 
 /**

--- a/frontend/src/admin/composables/useAutoBitrate.ts
+++ b/frontend/src/admin/composables/useAutoBitrate.ts
@@ -1,0 +1,89 @@
+import { watch, type Ref } from 'vue';
+
+/**
+ * Upload quality ladder + auto stepping (#276).
+ *
+ * The upload bitrate only shapes the *source* feed — as long as it stays
+ * above the Icecast mount's output encoding, listeners hear no difference,
+ * so stepping down is aggressive and stepping up is patient.
+ */
+
+/** Selectable encoder targets, highest first (kbps). */
+export const QUALITY_STEPS_KBPS = [320, 192, 128, 96] as const;
+/** Auto never climbs above this — 320 is manual-only headroom. */
+export const AUTO_CEILING_KBPS = 192;
+/** Buffer depth that counts as congestion (matches the "tight" verdict). */
+export const STEP_DOWN_BUFFER_S = 0.5;
+/** Consecutive congested ticks (≈ seconds) before stepping down a notch. */
+export const STEP_DOWN_TICKS = 3;
+/** Consecutive clean ticks (≈ seconds) before stepping back up a notch. */
+export const STEP_UP_TICKS = 30;
+
+/** 'auto' or a fixed kbps value from QUALITY_STEPS_KBPS. */
+export type UploadQualityMode = 'auto' | number;
+
+export interface AutoBitrateState {
+  congestedTicks: number;
+  stableTicks: number;
+}
+
+export function initialAutoState(): AutoBitrateState {
+  return { congestedTicks: 0, stableTicks: 0 };
+}
+
+/**
+ * One auto-mode decision per telemetry tick. Pure — unit tested.
+ * Returns the kbps to switch to (or null to stay) plus the carried state;
+ * any step decision resets both counters so switches can't cascade.
+ */
+export function decideBitrate(
+  currentKbps: number,
+  bufferSeconds: number,
+  state: AutoBitrateState
+): { nextKbps: number | null; state: AutoBitrateState } {
+  if (bufferSeconds > STEP_DOWN_BUFFER_S) {
+    const congestedTicks = state.congestedTicks + 1;
+    if (congestedTicks >= STEP_DOWN_TICKS) {
+      // Ladder is sorted high→low, so the first smaller entry is one notch down.
+      const lower = QUALITY_STEPS_KBPS.find((k) => k < currentKbps) ?? null;
+      return { nextKbps: lower, state: initialAutoState() };
+    }
+    return { nextKbps: null, state: { congestedTicks, stableTicks: 0 } };
+  }
+
+  const stableTicks = state.stableTicks + 1;
+  if (stableTicks >= STEP_UP_TICKS && currentKbps < AUTO_CEILING_KBPS) {
+    const higher = [...QUALITY_STEPS_KBPS].reverse().find((k) => k > currentKbps);
+    const next = Math.min(higher ?? currentKbps, AUTO_CEILING_KBPS);
+    return { nextKbps: next !== currentKbps ? next : null, state: initialAutoState() };
+  }
+  return { nextKbps: null, state: { congestedTicks: 0, stableTicks } };
+}
+
+/**
+ * Drive auto bitrate off the upload-health telemetry: evaluates one decision
+ * per completed tick while `mode` is 'auto', and calls `onChange` with the new
+ * kbps when a step is due. Counters reset whenever the mode flips (manual →
+ * auto starts a fresh observation window).
+ */
+export function useAutoBitrate(opts: {
+  mode: Ref<UploadQualityMode>;
+  currentKbps: Ref<number>;
+  bufferSeconds: Ref<number>;
+  /** Tick counter from useUploadHealth — one decision per increment. */
+  ticks: Ref<number>;
+  onChange: (kbps: number) => void;
+}): void {
+  let state = initialAutoState();
+
+  watch(opts.mode, () => {
+    state = initialAutoState();
+  });
+
+  watch(opts.ticks, () => {
+    if (opts.mode.value !== 'auto') return;
+    const decision = decideBitrate(opts.currentKbps.value, opts.bufferSeconds.value, state);
+    state = decision.state;
+    if (decision.nextKbps !== null) opts.onChange(decision.nextKbps);
+  });
+}

--- a/frontend/src/admin/composables/useUploadHealth.ts
+++ b/frontend/src/admin/composables/useUploadHealth.ts
@@ -76,6 +76,8 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
   const lateCount = ref(0);
   /** Last HISTORY_SECONDS egress samples (kbps), oldest first. */
   const history = ref<number[]>([]);
+  /** Completed telemetry ticks — watch this to react once per second (#276). */
+  const ticks = ref(0);
 
   const neededKbps = computed(() => (targetBitsPerSecond.value * CONTAINER_OVERHEAD) / 1000);
   const verdict = computed<UploadVerdict>(() => verdictFor(bufferSeconds.value));
@@ -105,6 +107,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
       bufferSeconds.value = t.bufferSeconds;
       if (t.bufferSeconds > LATE_BUFFER_S) lateCount.value++;
       history.value = [...history.value.slice(-(HISTORY_SECONDS - 1)), t.egressKbps];
+      ticks.value++;
     }
 
     prev = cur;
@@ -117,6 +120,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
     bufferSeconds.value = 0;
     lateCount.value = 0;
     history.value = [];
+    ticks.value = 0;
     prev = null;
     prevTs = 0;
   }
@@ -148,6 +152,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
     bufferSeconds,
     lateCount,
     history,
+    ticks,
     neededKbps,
     verdict,
     verdictText,

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -192,6 +192,15 @@ function onInputGain(event: Event) {
   audioCapture?.setInputVolume(pct / 100);
 }
 
+// ─── Upload bitrate (selectable + auto, #276) ───────────────────────────────
+const uploadBitsPerSecond = computed(
+  () => audioCapture?.streamBitsPerSecond.value ?? STREAM_AUDIO_BITS_PER_SECOND
+);
+
+function onSelectBitrate(bitsPerSecond: number) {
+  audioCapture?.setStreamBitsPerSecond(bitsPerSecond);
+}
+
 // ─── Stream socket ──────────────────────────────────────────────────────────
 const streamSocket = useStreamSocket({
   onLive: () => {
@@ -771,7 +780,8 @@ onUnmounted(() => {
       <ConnectionCard
         v-if="isLiveMode"
         :active="streamActive"
-        :target-bits-per-second="STREAM_AUDIO_BITS_PER_SECOND"
+        :target-bits-per-second="uploadBitsPerSecond"
+        @select-bitrate="onSelectBitrate"
       />
 
       <!-- 4 · Live chat — Telegram bridge lands with the chat issue. -->

--- a/frontend/tests/useAutoBitrate.test.ts
+++ b/frontend/tests/useAutoBitrate.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { nextTick, ref } from 'vue';
 import {
   decideBitrate,
   initialAutoState,
+  useAutoBitrate,
   QUALITY_STEPS_KBPS,
   AUTO_CEILING_KBPS,
   STEP_DOWN_TICKS,
   STEP_UP_TICKS,
+  STEP_SETTLE_TICKS,
   type AutoBitrateState,
+  type UploadQualityMode,
 } from '../src/admin/composables/useAutoBitrate';
 
 const CONGESTED = 1.0; // > STEP_DOWN_BUFFER_S
@@ -30,13 +34,15 @@ describe('decideBitrate', () => {
   });
 
   it('steps down only one notch at a time', () => {
-    expect(run(320, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBe(192);
     expect(run(128, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBe(96);
   });
 
   it('has nowhere to go below the lowest step', () => {
     const floor = QUALITY_STEPS_KBPS[QUALITY_STEPS_KBPS.length - 1];
-    expect(run(floor, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBeNull();
+    const last = run(floor, CONGESTED, STEP_DOWN_TICKS);
+    expect(last.nextKbps).toBeNull();
+    // No switch happened, so no settle window either.
+    expect(last.state.settleTicks).toBe(0);
   });
 
   it('a clean tick resets the congestion counter', () => {
@@ -55,7 +61,14 @@ describe('decideBitrate', () => {
 
   it('never climbs above the auto ceiling', () => {
     expect(run(AUTO_CEILING_KBPS, CLEAN, STEP_UP_TICKS * 2).nextKbps).toBeNull();
-    expect(run(320, CLEAN, STEP_UP_TICKS * 2).nextKbps).toBeNull();
+  });
+
+  it('steps straight down to the ceiling when entering auto above it', () => {
+    // Manual 320 → Auto on a clean link: without this, 320 would stick forever.
+    const clean = decideBitrate(320, CLEAN, initialAutoState());
+    expect(clean.nextKbps).toBe(AUTO_CEILING_KBPS);
+    const congested = decideBitrate(320, CONGESTED, initialAutoState());
+    expect(congested.nextKbps).toBe(AUTO_CEILING_KBPS);
   });
 
   it('a congested tick resets the stability counter', () => {
@@ -65,12 +78,67 @@ describe('decideBitrate', () => {
     expect(run(96, CLEAN, STEP_UP_TICKS, s).nextKbps).toBe(128);
   });
 
-  it('resets both counters after a step so switches cannot cascade', () => {
+  it('every switch starts a settle window so steps cannot cascade', () => {
     const down = run(192, CONGESTED, STEP_DOWN_TICKS);
     expect(down.nextKbps).toBe(128);
-    expect(down.state).toEqual(initialAutoState());
-    const up = run(96, CLEAN, STEP_UP_TICKS);
-    expect(up.nextKbps).toBe(128);
-    expect(up.state).toEqual(initialAutoState());
+    expect(down.state.settleTicks).toBe(STEP_SETTLE_TICKS);
+    // The backlog still reads congested at the new lower target, but the
+    // settle window absorbs it — no decision until it elapses.
+    const settling = run(128, CONGESTED, STEP_SETTLE_TICKS, down.state);
+    expect(settling.nextKbps).toBeNull();
+    expect(settling.state.settleTicks).toBe(0);
+    // After settling, a real congestion streak still steps down normally.
+    expect(run(128, CONGESTED, STEP_DOWN_TICKS, settling.state).nextKbps).toBe(96);
+    // Step-up also settles.
+    expect(run(96, CLEAN, STEP_UP_TICKS).state.settleTicks).toBe(STEP_SETTLE_TICKS);
+  });
+});
+
+describe('useAutoBitrate (watcher glue)', () => {
+  function harness(bufferSeconds = CONGESTED) {
+    const mode = ref<UploadQualityMode>('auto');
+    const currentKbps = ref(192);
+    const buffer = ref(bufferSeconds);
+    const ticks = ref(0);
+    const changes: number[] = [];
+    useAutoBitrate({
+      mode,
+      currentKbps,
+      bufferSeconds: buffer,
+      ticks,
+      onChange: (kbps) => changes.push(kbps),
+    });
+    const tick = async () => {
+      ticks.value++;
+      await nextTick();
+    };
+    return { mode, currentKbps, buffer, tick, changes };
+  }
+
+  it('calls onChange with the new kbps after the congestion window', async () => {
+    const h = harness();
+    for (let i = 0; i < STEP_DOWN_TICKS; i++) await h.tick();
+    expect(h.changes).toEqual([128]);
+  });
+
+  it('makes no decisions while a fixed quality is selected', async () => {
+    const h = harness();
+    h.mode.value = 192;
+    for (let i = 0; i < STEP_DOWN_TICKS * 2; i++) await h.tick();
+    expect(h.changes).toEqual([]);
+  });
+
+  it('flipping the mode resets the observation window', async () => {
+    const h = harness();
+    for (let i = 0; i < STEP_DOWN_TICKS - 1; i++) await h.tick();
+    h.mode.value = 192;
+    await nextTick();
+    h.mode.value = 'auto';
+    await nextTick();
+    // Counter restarted — the partial streak from before doesn't carry over.
+    for (let i = 0; i < STEP_DOWN_TICKS - 1; i++) await h.tick();
+    expect(h.changes).toEqual([]);
+    await h.tick();
+    expect(h.changes).toEqual([128]);
   });
 });

--- a/frontend/tests/useAutoBitrate.test.ts
+++ b/frontend/tests/useAutoBitrate.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideBitrate,
+  initialAutoState,
+  QUALITY_STEPS_KBPS,
+  AUTO_CEILING_KBPS,
+  STEP_DOWN_TICKS,
+  STEP_UP_TICKS,
+  type AutoBitrateState,
+} from '../src/admin/composables/useAutoBitrate';
+
+const CONGESTED = 1.0; // > STEP_DOWN_BUFFER_S
+const CLEAN = 0.0;
+
+/** Run N identical ticks, returning the last decision. */
+function run(currentKbps: number, bufferSeconds: number, ticks: number, state?: AutoBitrateState) {
+  let s = state ?? initialAutoState();
+  let last: ReturnType<typeof decideBitrate> = { nextKbps: null, state: s };
+  for (let i = 0; i < ticks; i++) {
+    last = decideBitrate(currentKbps, bufferSeconds, s);
+    s = last.state;
+  }
+  return last;
+}
+
+describe('decideBitrate', () => {
+  it('steps down one notch after STEP_DOWN_TICKS congested ticks', () => {
+    expect(run(192, CONGESTED, STEP_DOWN_TICKS - 1).nextKbps).toBeNull();
+    expect(run(192, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBe(128);
+  });
+
+  it('steps down only one notch at a time', () => {
+    expect(run(320, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBe(192);
+    expect(run(128, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBe(96);
+  });
+
+  it('has nowhere to go below the lowest step', () => {
+    const floor = QUALITY_STEPS_KBPS[QUALITY_STEPS_KBPS.length - 1];
+    expect(run(floor, CONGESTED, STEP_DOWN_TICKS).nextKbps).toBeNull();
+  });
+
+  it('a clean tick resets the congestion counter', () => {
+    let s = run(192, CONGESTED, STEP_DOWN_TICKS - 1).state;
+    s = decideBitrate(192, CLEAN, s).state;
+    // Needs the full window again after the interruption.
+    expect(run(192, CONGESTED, STEP_DOWN_TICKS - 1, s).nextKbps).toBeNull();
+    expect(run(192, CONGESTED, STEP_DOWN_TICKS, s).nextKbps).toBe(128);
+  });
+
+  it('steps back up after STEP_UP_TICKS stable ticks', () => {
+    expect(run(96, CLEAN, STEP_UP_TICKS - 1).nextKbps).toBeNull();
+    expect(run(96, CLEAN, STEP_UP_TICKS).nextKbps).toBe(128);
+    expect(run(128, CLEAN, STEP_UP_TICKS).nextKbps).toBe(192);
+  });
+
+  it('never climbs above the auto ceiling', () => {
+    expect(run(AUTO_CEILING_KBPS, CLEAN, STEP_UP_TICKS * 2).nextKbps).toBeNull();
+    expect(run(320, CLEAN, STEP_UP_TICKS * 2).nextKbps).toBeNull();
+  });
+
+  it('a congested tick resets the stability counter', () => {
+    let s = run(96, CLEAN, STEP_UP_TICKS - 1).state;
+    s = decideBitrate(96, CONGESTED, s).state;
+    expect(run(96, CLEAN, STEP_UP_TICKS - 1, s).nextKbps).toBeNull();
+    expect(run(96, CLEAN, STEP_UP_TICKS, s).nextKbps).toBe(128);
+  });
+
+  it('resets both counters after a step so switches cannot cascade', () => {
+    const down = run(192, CONGESTED, STEP_DOWN_TICKS);
+    expect(down.nextKbps).toBe(128);
+    expect(down.state).toEqual(initialAutoState());
+    const up = run(96, CLEAN, STEP_UP_TICKS);
+    expect(up.nextKbps).toBe(128);
+    expect(up.state).toEqual(initialAutoState());
+  });
+});


### PR DESCRIPTION
## Summary

Live Panel 2.0 issue #4 of 6 (closes #276). Adds the **Upload quality** segmented control (`Auto | 320 | 192 | 128 | 96 kbps`) to the connection card footer, per the spec in `docs/stream-rework/live-panel-2.0.md`.

### How it works

- **Switching restarts the recorder.** `audioBitsPerSecond` is fixed at `MediaRecorder` construction, so the encoder target became singleton state in `useAudioCapture` (`streamBitsPerSecond` + `setStreamBitsPerSecond()`). A change mid-broadcast stops and recreates the recorder — the <1 s gap is covered by the harbor's `mksafe`, the exact mechanism `restartRecording()` already uses for fresh WebM headers on file recordings.
- **Auto mode (default)** — aggressive down, patient up, per the locked design note ("lowering only degrades the source feed; listeners hear no difference"):
  - step **down** one notch after **3 consecutive ticks** with >0.5 s send-buffer (the "tight" threshold),
  - step **up** one notch after **30 clean ticks**,
  - ceiling **192 kbps** in auto — 320 is manual-only headroom,
  - every step resets both counters, so switches can't cascade.
- The decision logic (`decideBitrate` in `useAutoBitrate.ts`) is pure and unit-tested. It's driven by a new `ticks` counter on `useUploadHealth` — a steady `bufferSeconds` value never fires a watcher, so counting completed telemetry ticks is the reliable 1/s heartbeat.
- The card shows the effective rate while in auto ("Auto · currently 128 kbps · …"), and the "needed for target" dashed line + verdict follow the applied bitrate reactively.
- Bitrate choice is per-broadcast: resets to 192 kbps when capture stops.

### Test plan

- [x] `npm run lint`, `npm run build` clean
- [x] 110/110 vitest green — 8 new cases for `decideBitrate` (step-down window, one-notch-at-a-time, floor, counter resets both directions, step-up window, auto ceiling, no cascading)
- [x] `gitnexus detect_changes`: low risk, only expected symbols
- [ ] Live smoke test on next broadcast: manual switch audible-glitch-free through the relay, auto step-down under throttling