### PR TITLE
feat(stream): WS ack/RTT + late-chunk telemetry

### DIFF
--- a/backend/src/handlers/stream_ws.rs
+++ b/backend/src/handlers/stream_ws.rs
@@ -34,9 +34,11 @@ pub struct StreamQuery {
 /// a new one — so a flaky connection doesn't fragment the recording.
 const FINALIZE_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Inter-chunk arrival gap above which a chunk counts as "late" (#277).
-/// The browser's MediaRecorder emits every 250 ms; a gap this large means
-/// chunks stalled in the network and arrived bunched up.
+/// Inter-chunk cadence gap above which a chunk counts as "late" (#277).
+/// The browser's MediaRecorder emits every 250 ms. Note this measures the
+/// receive cadence as seen by this task — network stall AND server-side
+/// processing (relay write / lock contention) both widen it — so treat it
+/// as "delivery fell behind", not as a pure network metric.
 const LATE_CHUNK_GAP: std::time::Duration = std::time::Duration::from_millis(1000);
 
 /// WebSocket upgrade handler for streaming.
@@ -287,12 +289,14 @@ async fn handle_stream_socket(
                     // Parse-and-reformat instead of echoing raw text so a
                     // malformed payload can't inject into the JSON reply.
                     if let Ok(echo_ms) = echo.parse::<f64>() {
+                        // No `dropped` here: a write error breaks the loop, so
+                        // a live pong could only ever report 0. It surfaces in
+                        // the end-of-stream log instead.
                         let payload = serde_json::json!({
                             "echo": echo_ms,
                             "chunks": chunks_received,
                             "bytes": bytes_received,
                             "late": late_chunks,
-                            "dropped": dropped_chunks,
                         });
                         if sender
                             .send(Message::Text(format!("pong:{}", payload).into()))

--- a/backend/src/handlers/stream_ws.rs
+++ b/backend/src/handlers/stream_ws.rs
@@ -34,6 +34,11 @@ pub struct StreamQuery {
 /// a new one — so a flaky connection doesn't fragment the recording.
 const FINALIZE_GRACE: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Inter-chunk arrival gap above which a chunk counts as "late" (#277).
+/// The browser's MediaRecorder emits every 250 ms; a gap this large means
+/// chunks stalled in the network and arrived bunched up.
+const LATE_CHUNK_GAP: std::time::Duration = std::time::Duration::from_millis(1000);
+
 /// WebSocket upgrade handler for streaming.
 ///
 /// Authentication is done via session cookie.
@@ -238,12 +243,33 @@ async fn handle_stream_socket(
 
     // Process incoming messages (audio chunks). `explicit_stop` distinguishes a
     // deliberate end (finalize immediately) from a network drop (grace period).
+    //
+    // Per-connection delivery telemetry (#277): browsers can't send protocol
+    // pings from JS, so the panel sends `ping:<client-timestamp>` text frames
+    // and we echo `pong:{...}` with the counters piggybacked — that both
+    // measures RTT and confirms how much audio actually arrived.
     let mut explicit_stop = false;
+    let mut chunks_received: u64 = 0;
+    let mut bytes_received: u64 = 0;
+    let mut late_chunks: u64 = 0;
+    let mut dropped_chunks: u64 = 0;
+    let mut last_chunk_at: Option<std::time::Instant> = None;
     while let Some(msg) = receiver.next().await {
         match msg {
             Ok(Message::Binary(data)) => {
+                let now = std::time::Instant::now();
+                if let Some(prev) = last_chunk_at {
+                    if now.duration_since(prev) > LATE_CHUNK_GAP {
+                        late_chunks += 1;
+                    }
+                }
+                last_chunk_at = Some(now);
+                chunks_received += 1;
+                bytes_received += data.len() as u64;
+
                 let mut stream = stream_state.lock().await;
                 if let Err(e) = stream.write_chunk(&data).await {
+                    dropped_chunks += 1;
                     tracing::error!("Failed to write audio chunk: {}", e);
                     let _ = sender
                         .send(Message::Text(format!("error: {}", e).into()))
@@ -257,6 +283,25 @@ async fn handle_stream_socket(
                     tracing::info!("Received stop command from '{}'", username);
                     explicit_stop = true;
                     break;
+                } else if let Some(echo) = text.as_str().strip_prefix("ping:") {
+                    // Parse-and-reformat instead of echoing raw text so a
+                    // malformed payload can't inject into the JSON reply.
+                    if let Ok(echo_ms) = echo.parse::<f64>() {
+                        let payload = serde_json::json!({
+                            "echo": echo_ms,
+                            "chunks": chunks_received,
+                            "bytes": bytes_received,
+                            "late": late_chunks,
+                            "dropped": dropped_chunks,
+                        });
+                        if sender
+                            .send(Message::Text(format!("pong:{}", payload).into()))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                 }
             }
             Ok(Message::Close(_)) => {
@@ -311,7 +356,14 @@ async fn handle_stream_socket(
         }
     }
 
-    tracing::info!("Stream ended for user '{}'", username);
+    tracing::info!(
+        "Stream ended for user '{}': {} chunks / {} bytes received, {} late, {} dropped",
+        username,
+        chunks_received,
+        bytes_received,
+        late_chunks,
+        dropped_chunks
+    );
 
     // Notify admin via Telegram (fire-and-forget). Suppressed for a test.
     if !test {

--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -156,7 +156,13 @@ onUnmounted(() => resizeObserver?.disconnect());
         </div>
         <div class="conn-tile">
           <p class="conn-tile-label">RTT</p>
-          <p v-if="rttMs !== null" class="conn-tile-value">{{ rttMs }} ms</p>
+          <p
+            v-if="rttMs !== null"
+            class="conn-tile-value"
+            title="Message round-trip incl. send-buffer wait — rises with congestion, not pure network latency"
+          >
+            {{ rttMs }} ms
+          </p>
           <p v-else class="conn-tile-value conn-tile-muted" title="Waiting for the first pong">—</p>
         </div>
         <div class="conn-tile">

--- a/frontend/src/admin/components/ConnectionCard.vue
+++ b/frontend/src/admin/components/ConnectionCard.vue
@@ -27,7 +27,8 @@ const emit = defineEmits<{
 }>();
 
 const health = useUploadHealth(toRef(props, 'active'), toRef(props, 'targetBitsPerSecond'));
-const { uploadKbps, bufferSeconds, lateCount, history, neededKbps, verdict, verdictText } = health;
+const { uploadKbps, bufferSeconds, lateCount, history, rttMs, neededKbps, verdict, verdictText } =
+  health;
 
 // ─── Upload quality selector (#276) ─────────────────────────────────────────
 const qualityMode = ref<UploadQualityMode>('auto');
@@ -155,9 +156,8 @@ onUnmounted(() => resizeObserver?.disconnect());
         </div>
         <div class="conn-tile">
           <p class="conn-tile-label">RTT</p>
-          <p class="conn-tile-value conn-tile-muted" title="Arrives with the stream WS telemetry">
-            —
-          </p>
+          <p v-if="rttMs !== null" class="conn-tile-value">{{ rttMs }} ms</p>
+          <p v-else class="conn-tile-value conn-tile-muted" title="Waiting for the first pong">—</p>
         </div>
         <div class="conn-tile">
           <p class="conn-tile-label">Late</p>

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -2,8 +2,10 @@ export { useFlash, type FlashMessage } from './useFlash';
 export {
   useStreamSocket,
   getStreamSocketStats,
+  parsePong,
   type StreamConnectionState,
   type StreamSocketStats,
+  type PongStats,
   type UseStreamSocketOptions,
 } from './useStreamSocket';
 export {

--- a/frontend/src/admin/composables/useStreamSocket.ts
+++ b/frontend/src/admin/composables/useStreamSocket.ts
@@ -21,6 +21,13 @@ let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 // Together with bufferedAmount this is the browser-side upload-health signal
 // (#275): egress = Δqueued − Δbuffered, buffer-seconds = buffered / byte-rate.
 let bytesQueued = 0;
+// App-level ping/pong telemetry (#277) — browsers can't send protocol pings
+// from JS, so `ping:<performance.now()>` text frames measure RTT and carry
+// back the server's per-connection delivery counters.
+const PING_INTERVAL_MS = 2000;
+let pingInterval: ReturnType<typeof setInterval> | null = null;
+let rttMs: number | null = null;
+let serverStats = { chunks: 0, bytes: 0, late: 0, dropped: 0 };
 // Remembered across reconnects so the backend keeps auto-recording the same show.
 let currentShowId: number | null = null;
 // Remembered across reconnects so a rehearsal stays on the private `/test` mount.
@@ -51,6 +58,60 @@ export interface StreamSocketStats {
   bufferedAmount: number;
   /** Total binary payload bytes queued since the socket (re)connected. */
   bytesQueued: number;
+  /** Last measured round-trip time (ms), or null before the first pong (#277). */
+  rttMs: number | null;
+  /** Chunks the server confirmed received on this connection. */
+  serverChunks: number;
+  /** Payload bytes the server confirmed received on this connection. */
+  serverBytes: number;
+  /** Chunks that arrived after a >1 s inter-chunk gap (server-side). */
+  serverLate: number;
+  /** Chunks the server failed to relay (write errors). */
+  serverDropped: number;
+}
+
+/** Server pong frame: `pong:{"echo":…,"chunks":…,"bytes":…,"late":…,"dropped":…}` */
+export interface PongStats {
+  echoMs: number;
+  chunks: number;
+  bytes: number;
+  late: number;
+  dropped: number;
+}
+
+/** Parse a pong text frame; null for anything malformed. Pure — unit tested. */
+export function parsePong(msg: string): PongStats | null {
+  if (!msg.startsWith('pong:')) return null;
+  try {
+    const o = JSON.parse(msg.slice(5)) as Record<string, unknown>;
+    if (typeof o.echo !== 'number') return null;
+    return {
+      echoMs: o.echo,
+      chunks: typeof o.chunks === 'number' ? o.chunks : 0,
+      bytes: typeof o.bytes === 'number' ? o.bytes : 0,
+      late: typeof o.late === 'number' ? o.late : 0,
+      dropped: typeof o.dropped === 'number' ? o.dropped : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function startPings(): void {
+  stopPings();
+  pingInterval = setInterval(() => {
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(`ping:${performance.now()}`);
+    }
+  }, PING_INTERVAL_MS);
+}
+
+function stopPings(): void {
+  if (pingInterval) {
+    clearInterval(pingInterval);
+    pingInterval = null;
+  }
+  rttMs = null;
 }
 
 /**
@@ -66,6 +127,11 @@ export function getStreamSocketStats(): StreamSocketStats {
     connected: socket !== null && socket.readyState === WebSocket.OPEN,
     bufferedAmount: socket?.bufferedAmount ?? 0,
     bytesQueued,
+    rttMs,
+    serverChunks: serverStats.chunks,
+    serverBytes: serverStats.bytes,
+    serverLate: serverStats.late,
+    serverDropped: serverStats.dropped,
   };
 }
 
@@ -105,10 +171,13 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
       socket = new WebSocket(wsUrl);
       socket.binaryType = 'arraybuffer';
       bytesQueued = 0;
+      rttMs = null;
+      serverStats = { chunks: 0, bytes: 0, late: 0, dropped: 0 };
 
       socket.onopen = () => {
         console.log('[StreamSocket] Connected');
         state.value = 'connected';
+        startPings();
         currentCallbacks.onConnected?.();
         resolve();
       };
@@ -118,6 +187,17 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
         if (msg === 'connected') {
           state.value = 'live';
           currentCallbacks.onLive?.();
+        } else if (typeof msg === 'string' && msg.startsWith('pong:')) {
+          const pong = parsePong(msg);
+          if (pong) {
+            rttMs = Math.max(0, Math.round(performance.now() - pong.echoMs));
+            serverStats = {
+              chunks: pong.chunks,
+              bytes: pong.bytes,
+              late: pong.late,
+              dropped: pong.dropped,
+            };
+          }
         } else if (typeof msg === 'string' && msg.startsWith('error:')) {
           const errMsg = msg.substring(7);
           error.value = errMsg;
@@ -135,6 +215,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
 
       socket.onclose = (event) => {
         console.log('[StreamSocket] Closed:', event.code, event.reason);
+        stopPings();
         const wasLive = state.value === 'live';
 
         if (event.code !== 1000 && reconnectAttempts.value < maxReconnectAttempts && wasLive) {
@@ -177,6 +258,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
    * Use this ONLY for the explicit "Stop Streaming" user action.
    */
   function stopStream() {
+    stopPings();
     if (reconnectTimeout) {
       clearTimeout(reconnectTimeout);
       reconnectTimeout = null;
@@ -202,6 +284,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
    * The stream continues on the backend until explicitly stopped.
    */
   function cleanup() {
+    stopPings();
     if (reconnectTimeout) {
       clearTimeout(reconnectTimeout);
       reconnectTimeout = null;

--- a/frontend/src/admin/composables/useStreamSocket.ts
+++ b/frontend/src/admin/composables/useStreamSocket.ts
@@ -27,7 +27,7 @@ let bytesQueued = 0;
 const PING_INTERVAL_MS = 2000;
 let pingInterval: ReturnType<typeof setInterval> | null = null;
 let rttMs: number | null = null;
-let serverStats = { chunks: 0, bytes: 0, late: 0, dropped: 0 };
+let serverStats = { chunks: 0, bytes: 0, late: 0 };
 // Remembered across reconnects so the backend keeps auto-recording the same show.
 let currentShowId: number | null = null;
 // Remembered across reconnects so a rehearsal stays on the private `/test` mount.
@@ -64,19 +64,16 @@ export interface StreamSocketStats {
   serverChunks: number;
   /** Payload bytes the server confirmed received on this connection. */
   serverBytes: number;
-  /** Chunks that arrived after a >1 s inter-chunk gap (server-side). */
+  /** Chunks that arrived after a >1 s cadence gap (server-side). */
   serverLate: number;
-  /** Chunks the server failed to relay (write errors). */
-  serverDropped: number;
 }
 
-/** Server pong frame: `pong:{"echo":…,"chunks":…,"bytes":…,"late":…,"dropped":…}` */
+/** Server pong frame: `pong:{"echo":…,"chunks":…,"bytes":…,"late":…}` */
 export interface PongStats {
   echoMs: number;
   chunks: number;
   bytes: number;
   late: number;
-  dropped: number;
 }
 
 /** Parse a pong text frame; null for anything malformed. Pure — unit tested. */
@@ -90,7 +87,6 @@ export function parsePong(msg: string): PongStats | null {
       chunks: typeof o.chunks === 'number' ? o.chunks : 0,
       bytes: typeof o.bytes === 'number' ? o.bytes : 0,
       late: typeof o.late === 'number' ? o.late : 0,
-      dropped: typeof o.dropped === 'number' ? o.dropped : 0,
     };
   } catch {
     return null;
@@ -131,7 +127,6 @@ export function getStreamSocketStats(): StreamSocketStats {
     serverChunks: serverStats.chunks,
     serverBytes: serverStats.bytes,
     serverLate: serverStats.late,
-    serverDropped: serverStats.dropped,
   };
 }
 
@@ -172,7 +167,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
       socket.binaryType = 'arraybuffer';
       bytesQueued = 0;
       rttMs = null;
-      serverStats = { chunks: 0, bytes: 0, late: 0, dropped: 0 };
+      serverStats = { chunks: 0, bytes: 0, late: 0 };
 
       socket.onopen = () => {
         console.log('[StreamSocket] Connected');
@@ -191,12 +186,7 @@ export function useStreamSocket(options: UseStreamSocketOptions = {}) {
           const pong = parsePong(msg);
           if (pong) {
             rttMs = Math.max(0, Math.round(performance.now() - pong.echoMs));
-            serverStats = {
-              chunks: pong.chunks,
-              bytes: pong.bytes,
-              late: pong.late,
-              dropped: pong.dropped,
-            };
+            serverStats = { chunks: pong.chunks, bytes: pong.bytes, late: pong.late };
           }
         } else if (typeof msg === 'string' && msg.startsWith('error:')) {
           const errMsg = msg.substring(7);

--- a/frontend/src/admin/composables/useUploadHealth.ts
+++ b/frontend/src/admin/composables/useUploadHealth.ts
@@ -78,6 +78,8 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
   const history = ref<number[]>([]);
   /** Completed telemetry ticks — watch this to react once per second (#276). */
   const ticks = ref(0);
+  /** Last ping/pong round-trip (ms), null until the first pong (#277). */
+  const rttMs = ref<number | null>(null);
 
   const neededKbps = computed(() => (targetBitsPerSecond.value * CONTAINER_OVERHEAD) / 1000);
   const verdict = computed<UploadVerdict>(() => verdictFor(bufferSeconds.value));
@@ -107,6 +109,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
       bufferSeconds.value = t.bufferSeconds;
       if (t.bufferSeconds > LATE_BUFFER_S) lateCount.value++;
       history.value = [...history.value.slice(-(HISTORY_SECONDS - 1)), t.egressKbps];
+      rttMs.value = cur.rttMs ?? null;
       ticks.value++;
     }
 
@@ -121,6 +124,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
     lateCount.value = 0;
     history.value = [];
     ticks.value = 0;
+    rttMs.value = null;
     prev = null;
     prevTs = 0;
   }
@@ -153,6 +157,7 @@ export function useUploadHealth(active: Ref<boolean>, targetBitsPerSecond: Ref<n
     lateCount,
     history,
     ticks,
+    rttMs,
     neededKbps,
     verdict,
     verdictText,

--- a/frontend/tests/useStreamSocket.test.ts
+++ b/frontend/tests/useStreamSocket.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parsePong } from '../src/admin/composables/useStreamSocket';
+
+describe('parsePong', () => {
+  it('parses a full server pong frame', () => {
+    const msg = 'pong:{"echo":12345.678,"chunks":40,"bytes":276000,"late":2,"dropped":0}';
+    expect(parsePong(msg)).toEqual({
+      echoMs: 12345.678,
+      chunks: 40,
+      bytes: 276000,
+      late: 2,
+      dropped: 0,
+    });
+  });
+
+  it('defaults missing counters to zero', () => {
+    expect(parsePong('pong:{"echo":1}')).toEqual({
+      echoMs: 1,
+      chunks: 0,
+      bytes: 0,
+      late: 0,
+      dropped: 0,
+    });
+  });
+
+  it('rejects frames without a numeric echo', () => {
+    expect(parsePong('pong:{"echo":"nope"}')).toBeNull();
+    expect(parsePong('pong:{"chunks":1}')).toBeNull();
+  });
+
+  it('rejects malformed JSON and non-pong frames', () => {
+    expect(parsePong('pong:{oops')).toBeNull();
+    expect(parsePong('connected')).toBeNull();
+    expect(parsePong('error: nope')).toBeNull();
+  });
+});

--- a/frontend/tests/useStreamSocket.test.ts
+++ b/frontend/tests/useStreamSocket.test.ts
@@ -3,13 +3,12 @@ import { parsePong } from '../src/admin/composables/useStreamSocket';
 
 describe('parsePong', () => {
   it('parses a full server pong frame', () => {
-    const msg = 'pong:{"echo":12345.678,"chunks":40,"bytes":276000,"late":2,"dropped":0}';
+    const msg = 'pong:{"echo":12345.678,"chunks":40,"bytes":276000,"late":2}';
     expect(parsePong(msg)).toEqual({
       echoMs: 12345.678,
       chunks: 40,
       bytes: 276000,
       late: 2,
-      dropped: 0,
     });
   });
 
@@ -19,7 +18,6 @@ describe('parsePong', () => {
       chunks: 0,
       bytes: 0,
       late: 0,
-      dropped: 0,
     });
   });
 

--- a/frontend/tests/useUploadHealth.test.ts
+++ b/frontend/tests/useUploadHealth.test.ts
@@ -106,6 +106,24 @@ describe('useUploadHealth (stateful)', () => {
     // First tick only seeds prev; every following tick is late.
     expect(health.lateCount.value).toBe(ticks - 1);
     expect(health.verdict.value).toBe('slow');
+    // No rttMs in the stats → stays null (pre-#277 socket or no pong yet).
+    expect(health.rttMs.value).toBeNull();
+    unmount();
+  });
+
+  it('passes the socket RTT through on each tick', () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'performance'] });
+    let queued = 0;
+    statsMock.mockImplementation(() => ({
+      connected: true,
+      bufferedAmount: 0,
+      bytesQueued: (queued += 27_600),
+      rttMs: 42,
+    }));
+
+    const { health, unmount } = mountHealth(ref(true));
+    vi.advanceTimersByTime(2000);
+    expect(health.rttMs.value).toBe(42);
     unmount();
   });
 


### PR DESCRIPTION
## Summary

Live Panel 2.0 issue #5 of 6 (closes #277). Fills the RTT tile on the connection card and gives the panel server-confirmed delivery counters — the first backend change of the milestone.

### Protocol

Browsers can't send protocol-level WS pings from JS, so this is app-level, on the existing stream socket:

- Panel → server: `ping:<performance.now()>` text frame every 2 s.
- Server → panel: `pong:{"echo":…,"chunks":…,"bytes":…,"late":…,"dropped":…}` — the echo is parsed as `f64` and re-emitted (never reflected raw, so a malformed payload can't inject into the JSON), with per-connection counters piggybacked:
  - `chunks` / `bytes` — received on this connection (delivery confirmation),
  - `late` — arrivals after a >1 s inter-chunk gap (MediaRecorder emits every 250 ms, so a gap that size means chunks stalled and bunched up),
  - `dropped` — relay write errors.
- Final counters are logged at stream end. The rehearsal path (`?test=true`) uses the same handler, so the pre-air check gets RTT too. The `/ws/stream-test` loopback is untouched.

### Frontend

`useStreamSocket` runs the ping interval (started on open, torn down on close/stop/cleanup, state reset per connect) and exposes `rttMs` + server counters through the existing `getStreamSocketStats()` poll surface. `useUploadHealth` passes `rttMs` through once per telemetry tick; the RTT tile shows it (— until the first pong). `parsePong` is pure and unit-tested.

### Test plan

- [x] Frontend: lint/build clean, 119/119 vitest (9 new: parsePong parsing/rejection, RTT tick passthrough, null default)
- [x] Backend: `cargo clippy` (no new warnings), `cargo test` — 75 passed; `video::tests::test_brightness_analysis` fails identically on a clean main checkout (pre-existing, environment-dependent, unrelated)
- [x] `gitnexus detect_changes`: both stream flows touch only `handle_stream_socket` step 2, additive changes
- [ ] Live smoke test: RTT tile populates within ~2 s of connect, counters climb during broadcast