### PR TITLE
feat(telegram): live chat bridge — discussion group ⇄ panel WS

### DIFF
--- a/backend/src/chat_bridge.rs
+++ b/backend/src/chat_bridge.rs
@@ -1,0 +1,108 @@
+//! Live-chat bridge between the Telegram discussion group and the panel (#278).
+//!
+//! The bot's dispatcher publishes messages from the configured live-chat group
+//! into a [`ChatHub`]; every connected panel WebSocket subscribes to the hub's
+//! broadcast channel and receives them in real time. Host replies travel the
+//! other way: panel → bot API → group, and are echoed into the hub directly
+//! (Telegram never delivers a bot its own messages, so there is no loop).
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use tokio::sync::{broadcast, Mutex};
+
+/// Messages kept for panels that connect mid-show.
+const HISTORY_CAP: usize = 100;
+/// Broadcast buffer per subscriber; lagging panels skip, they don't block.
+const BROADCAST_CAP: usize = 64;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    /// Telegram message id, or 0 for host replies that failed to report one.
+    pub id: i64,
+    pub author: String,
+    pub text: String,
+    /// Unix seconds.
+    pub ts: i64,
+    /// True for replies sent by the panel host via the bot.
+    pub host: bool,
+}
+
+pub struct ChatHub {
+    history: Mutex<VecDeque<ChatMessage>>,
+    tx: broadcast::Sender<ChatMessage>,
+}
+
+impl Default for ChatHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ChatHub {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(BROADCAST_CAP);
+        Self {
+            history: Mutex::new(VecDeque::with_capacity(HISTORY_CAP)),
+            tx,
+        }
+    }
+
+    /// Append to the ring buffer and fan out to all connected panels.
+    pub async fn publish(&self, msg: ChatMessage) {
+        {
+            let mut history = self.history.lock().await;
+            if history.len() == HISTORY_CAP {
+                history.pop_front();
+            }
+            history.push_back(msg.clone());
+        }
+        // Err just means no panel is connected right now.
+        let _ = self.tx.send(msg);
+    }
+
+    /// Snapshot of the retained history, oldest first.
+    pub async fn recent(&self) -> Vec<ChatMessage> {
+        self.history.lock().await.iter().cloned().collect()
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ChatMessage> {
+        self.tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(id: i64) -> ChatMessage {
+        ChatMessage {
+            id,
+            author: format!("user{id}"),
+            text: format!("hello {id}"),
+            ts: 1_700_000_000 + id,
+            host: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn history_keeps_order_and_caps() {
+        let hub = ChatHub::new();
+        for i in 0..(HISTORY_CAP as i64 + 10) {
+            hub.publish(msg(i)).await;
+        }
+        let recent = hub.recent().await;
+        assert_eq!(recent.len(), HISTORY_CAP);
+        assert_eq!(recent.first().unwrap().id, 10);
+        assert_eq!(recent.last().unwrap().id, HISTORY_CAP as i64 + 9);
+    }
+
+    #[tokio::test]
+    async fn subscribers_receive_published_messages() {
+        let hub = ChatHub::new();
+        let mut rx = hub.subscribe();
+        hub.publish(msg(1)).await;
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.id, 1);
+        assert_eq!(received.text, "hello 1");
+    }
+}

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -146,6 +146,10 @@ pub struct Config {
     /// Hour of day (0-23) in Berlin time when artist Instagram previews should be sent
     #[serde(default = "default_telegram_artist_preview_hour")]
     pub telegram_artist_preview_hour: u32,
+    /// Chat id of the public channel's discussion group for the live-chat
+    /// bridge (#278). Unset = bridge inactive; the panel card shows an error
+    /// on reply and no messages are forwarded. Distinct from the admin group.
+    pub telegram_live_chat_id: Option<i64>,
 
     // Admin panel base URL (used in Telegram notifications to link to artist profiles)
     #[serde(default = "default_admin_base_url")]

--- a/backend/src/handlers/chat_ws.rs
+++ b/backend/src/handlers/chat_ws.rs
@@ -1,0 +1,152 @@
+//! WebSocket handler for the live-chat bridge (#278).
+//!
+//! Fans the Telegram discussion group's messages out to the panel and posts
+//! host replies back through the bot. Frames are JSON with a `type` field:
+//!
+//! - server → panel: `{"type":"history","messages":[ChatMessage…]}` on
+//!   connect, then `{"type":"message","message":ChatMessage}` per message,
+//!   `{"type":"error","error":"…"}` when a reply can't be delivered.
+//! - panel → server: a plain text frame is a host reply.
+
+use crate::auth::get_current_user;
+use crate::chat_bridge::ChatMessage;
+use crate::{AppState, Result};
+use axum::extract::ws::{Message, WebSocket};
+use axum::{
+    extract::{State, WebSocketUpgrade},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use teloxide::prelude::*;
+
+/// Longest accepted host reply — matches Telegram's own message limit.
+const MAX_REPLY_CHARS: usize = 4096;
+
+pub async fn chat_ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<Response> {
+    // Session-cookie auth, same pattern as stream_ws.
+    let token = headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies.split(';').find_map(|cookie| {
+                cookie
+                    .trim()
+                    .strip_prefix("session=")
+                    .map(|token| token.to_string())
+            })
+        });
+
+    let user = match get_current_user(&state, token.as_deref()).await {
+        Some(u) => u,
+        None => {
+            return Ok((StatusCode::UNAUTHORIZED, "Not authenticated").into_response());
+        }
+    };
+
+    let username = user.username.clone();
+    Ok(ws.on_upgrade(move |socket| handle_chat_socket(socket, state, username)))
+}
+
+async fn handle_chat_socket(socket: WebSocket, state: Arc<AppState>, username: String) {
+    let (mut sender, mut receiver) = socket.split();
+
+    // History first, so a panel connecting mid-show has context.
+    let history = state.chat_hub.recent().await;
+    let frame = serde_json::json!({ "type": "history", "messages": history });
+    if sender.send(Message::Text(frame.to_string())).await.is_err() {
+        return;
+    }
+
+    let mut rx = state.chat_hub.subscribe();
+
+    loop {
+        tokio::select! {
+            broadcast = rx.recv() => {
+                match broadcast {
+                    Ok(msg) => {
+                        let frame = serde_json::json!({ "type": "message", "message": msg });
+                        if sender.send(Message::Text(frame.to_string())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!("Chat panel for '{}' lagged, skipped {} messages", username, skipped);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            incoming = receiver.next() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Some(err) = send_host_reply(&state, &username, text.trim()).await {
+                            let frame = serde_json::json!({ "type": "error", "error": err });
+                            if sender.send(Message::Text(frame.to_string())).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        tracing::debug!("Chat WS error for '{}': {}", username, e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Post a host reply to the Telegram group and echo it into the hub.
+/// Returns a user-facing error string on failure, None on success or no-op.
+async fn send_host_reply(state: &Arc<AppState>, username: &str, text: &str) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+    if text.chars().count() > MAX_REPLY_CHARS {
+        return Some(format!("Reply too long (max {MAX_REPLY_CHARS} characters)"));
+    }
+
+    let bot = match &state.telegram_bot {
+        Some(b) => b.clone(),
+        None => return Some("Telegram bot is not configured on this server".to_string()),
+    };
+    let chat_id = match state.config.telegram_live_chat_id {
+        Some(id) => id,
+        None => {
+            return Some("Live chat group is not configured (TELEGRAM_LIVE_CHAT_ID)".to_string())
+        }
+    };
+
+    let sent = bot
+        .send_message(ChatId(chat_id), format!("🎙 {username}: {text}"))
+        .await;
+
+    match sent {
+        Ok(msg) => {
+            // Telegram never delivers a bot its own messages, so echo it into
+            // the hub ourselves — every panel (incl. the sender) sees it.
+            state
+                .chat_hub
+                .publish(ChatMessage {
+                    id: msg.id.0 as i64,
+                    author: username.to_string(),
+                    text: text.to_string(),
+                    ts: chrono::Utc::now().timestamp(),
+                    host: true,
+                })
+                .await;
+            None
+        }
+        Err(e) => {
+            tracing::error!("Failed to post host reply to Telegram: {}", e);
+            Some("Could not deliver the reply to Telegram".to_string())
+        }
+    }
+}

--- a/backend/src/handlers/chat_ws.rs
+++ b/backend/src/handlers/chat_ws.rs
@@ -56,14 +56,17 @@ pub async fn chat_ws_handler(
 async fn handle_chat_socket(socket: WebSocket, state: Arc<AppState>, username: String) {
     let (mut sender, mut receiver) = socket.split();
 
+    // Subscribe BEFORE snapshotting history — the other order drops any
+    // message published in between (in neither snapshot nor subscription).
+    // A message caught by both is deduped client-side by id.
+    let mut rx = state.chat_hub.subscribe();
+
     // History first, so a panel connecting mid-show has context.
     let history = state.chat_hub.recent().await;
     let frame = serde_json::json!({ "type": "history", "messages": history });
     if sender.send(Message::Text(frame.to_string())).await.is_err() {
         return;
     }
-
-    let mut rx = state.chat_hub.subscribe();
 
     loop {
         tokio::select! {
@@ -76,7 +79,14 @@ async fn handle_chat_socket(socket: WebSocket, state: Arc<AppState>, username: S
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        // Self-heal: a fresh history frame replaces the panel's
+                        // list, closing the gap the lag just created.
                         tracing::warn!("Chat panel for '{}' lagged, skipped {} messages", username, skipped);
+                        let history = state.chat_hub.recent().await;
+                        let frame = serde_json::json!({ "type": "history", "messages": history });
+                        if sender.send(Message::Text(frame.to_string())).await.is_err() {
+                            break;
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
@@ -103,15 +113,30 @@ async fn handle_chat_socket(socket: WebSocket, state: Arc<AppState>, username: S
     }
 }
 
+/// Build the group message for a host reply, validating the COMPOSED length
+/// against Telegram's limit — the prefix counts too. Pure — unit tested.
+/// `Ok(None)` = nothing to send (empty reply), `Err` = user-facing rejection.
+fn compose_host_reply(username: &str, text: &str) -> std::result::Result<Option<String>, String> {
+    if text.is_empty() {
+        return Ok(None);
+    }
+    let composed = format!("🎙 {username}: {text}");
+    if composed.chars().count() > MAX_REPLY_CHARS {
+        let budget =
+            MAX_REPLY_CHARS.saturating_sub(composed.chars().count() - text.chars().count());
+        return Err(format!("Reply too long (max {budget} characters)"));
+    }
+    Ok(Some(composed))
+}
+
 /// Post a host reply to the Telegram group and echo it into the hub.
 /// Returns a user-facing error string on failure, None on success or no-op.
 async fn send_host_reply(state: &Arc<AppState>, username: &str, text: &str) -> Option<String> {
-    if text.is_empty() {
-        return None;
-    }
-    if text.chars().count() > MAX_REPLY_CHARS {
-        return Some(format!("Reply too long (max {MAX_REPLY_CHARS} characters)"));
-    }
+    let composed = match compose_host_reply(username, text) {
+        Ok(Some(c)) => c,
+        Ok(None) => return None,
+        Err(e) => return Some(e),
+    };
 
     let bot = match &state.telegram_bot {
         Some(b) => b.clone(),
@@ -124,9 +149,7 @@ async fn send_host_reply(state: &Arc<AppState>, username: &str, text: &str) -> O
         }
     };
 
-    let sent = bot
-        .send_message(ChatId(chat_id), format!("🎙 {username}: {text}"))
-        .await;
+    let sent = bot.send_message(ChatId(chat_id), composed).await;
 
     match sent {
         Ok(msg) => {
@@ -148,5 +171,41 @@ async fn send_host_reply(state: &Arc<AppState>, username: &str, text: &str) -> O
             tracing::error!("Failed to post host reply to Telegram: {}", e);
             Some("Could not deliver the reply to Telegram".to_string())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compose_prefixes_and_passes_normal_replies() {
+        assert_eq!(
+            compose_host_reply("anton", "hello chat"),
+            Ok(Some("🎙 anton: hello chat".to_string()))
+        );
+    }
+
+    #[test]
+    fn compose_skips_empty_replies() {
+        assert_eq!(compose_host_reply("anton", ""), Ok(None));
+    }
+
+    #[test]
+    fn compose_rejects_when_prefix_pushes_past_the_limit() {
+        // Text alone fits exactly; prefix must tip it over.
+        let text = "x".repeat(MAX_REPLY_CHARS);
+        let result = compose_host_reply("anton", &text);
+        assert!(result.is_err());
+        // The reported budget accounts for the prefix.
+        let budget = MAX_REPLY_CHARS - "🎙 anton: ".chars().count();
+        assert!(result.unwrap_err().contains(&format!("{budget}")));
+    }
+
+    #[test]
+    fn compose_accepts_text_at_the_composed_limit() {
+        let prefix_chars = "🎙 anton: ".chars().count();
+        let text = "x".repeat(MAX_REPLY_CHARS - prefix_chars);
+        assert!(compose_host_reply("anton", &text).is_ok());
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod backup_trigger;
+pub mod chat_ws;
 pub mod download;
 pub mod recording;
 pub mod settings;

--- a/backend/src/handlers/recording.rs
+++ b/backend/src/handlers/recording.rs
@@ -1977,6 +1977,7 @@ mod tests {
             telegram_bot: None,
             pending_show_notifications: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             telegram_edit_sessions: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            chat_hub: Arc::new(crate::chat_bridge::ChatHub::new()),
         });
 
         let raw_key = format!("recordings/{}/{}/raw.webm", show_id, version);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,7 @@
 mod ai;
 mod audio;
 mod auth;
+mod chat_bridge;
 mod config;
 mod db;
 mod error;
@@ -79,6 +80,8 @@ pub struct AppState {
     pub pending_show_notifications: PendingShowNotifications,
     /// Active Telegram edit sessions (chat_id -> session)
     pub telegram_edit_sessions: TelegramEditSessions,
+    /// Live-chat bridge hub: Telegram discussion group ⇄ panel WS (#278)
+    pub chat_hub: Arc<chat_bridge::ChatHub>,
 }
 
 // Stream handler wrappers that extract stream_state from AppState
@@ -315,6 +318,7 @@ async fn main() -> anyhow::Result<()> {
         telegram_bot,
         pending_show_notifications,
         telegram_edit_sessions,
+        chat_hub: Arc::new(chat_bridge::ChatHub::new()),
     });
 
     // One-shot admin subcommands: run against the same config/db/R2 as the server,
@@ -712,6 +716,7 @@ async fn main() -> anyhow::Result<()> {
         )
         // Stream WebSocket and API
         .route("/ws/stream", get(stream_ws_handler))
+        .route("/ws/chat", get(handlers::chat_ws::chat_ws_handler))
         .route(
             "/ws/stream-test",
             get(handlers::stream_test_ws::stream_test_ws_handler),

--- a/backend/src/telegram.rs
+++ b/backend/src/telegram.rs
@@ -1483,11 +1483,17 @@ async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>
     let chat_id = msg.chat.id.0;
 
     // Live-chat bridge: forward listener messages to the panel. Only real
-    // (non-bot) senders with text — service messages, channel auto-forwards
-    // and other bots stay out of the panel feed.
-    if state.config.telegram_live_chat_id == Some(chat_id) {
+    // (non-bot) senders with text — service messages, other bots, channel
+    // auto-forwards (from = service account 777000, is_bot false — needs the
+    // is_automatic_forward check) and anonymous "post as group/channel"
+    // messages (sender_chat set) stay out of the panel feed. If the live
+    // group is misconfigured to the admin group, admin behavior (edit
+    // sessions below) wins and the bridge is skipped.
+    if state.config.telegram_live_chat_id == Some(chat_id)
+        && state.config.telegram_admin_chat_id != Some(chat_id)
+    {
         if let (Some(user), Some(text)) = (msg.from.as_ref(), msg.text()) {
-            if !user.is_bot {
+            if !user.is_bot && !msg.is_automatic_forward() && msg.sender_chat.is_none() {
                 state
                     .chat_hub
                     .publish(crate::chat_bridge::ChatMessage {

--- a/backend/src/telegram.rs
+++ b/backend/src/telegram.rs
@@ -1473,12 +1473,35 @@ async fn handle_aig_sort(
     Ok(())
 }
 
-/// Handle non-command messages: check for active edit sessions.
+/// Handle non-command messages: live-chat bridge, then edit sessions.
 ///
-/// If an edit session is active for this chat, the message is treated as
-/// the new caption (text) or new image (photo). Otherwise, silently ignored.
+/// A text message in the configured live-chat group is fanned out to the
+/// panel WebSockets (#278). Otherwise, if an edit session is active for this
+/// chat, the message is treated as the new caption (text) or new image
+/// (photo). Anything else is silently ignored.
 async fn handle_non_command_message(bot: Bot, msg: Message, state: Arc<AppState>) -> HandlerResult {
     let chat_id = msg.chat.id.0;
+
+    // Live-chat bridge: forward listener messages to the panel. Only real
+    // (non-bot) senders with text — service messages, channel auto-forwards
+    // and other bots stay out of the panel feed.
+    if state.config.telegram_live_chat_id == Some(chat_id) {
+        if let (Some(user), Some(text)) = (msg.from.as_ref(), msg.text()) {
+            if !user.is_bot {
+                state
+                    .chat_hub
+                    .publish(crate::chat_bridge::ChatMessage {
+                        id: msg.id.0 as i64,
+                        author: user.full_name(),
+                        text: text.to_string(),
+                        ts: msg.date.timestamp(),
+                        host: false,
+                    })
+                    .await;
+            }
+        }
+        return Ok(());
+    }
 
     // Check for active edit session
     let session = {

--- a/frontend/src/admin/components/LiveChatCard.vue
+++ b/frontend/src/admin/components/LiveChatCard.vue
@@ -1,0 +1,214 @@
+<script setup lang="ts">
+// Live chat card (Live Panel 2.0, #278): the Telegram discussion group
+// bridged into the panel. Messages fan out over /ws/chat; replies go back
+// through the bot with a host badge.
+import { ref, watch, nextTick, toRef } from 'vue';
+import { useLiveChat } from '@admin/composables';
+
+const props = defineProps<{
+  /** Keep the chat socket open while true (i.e. while on air). */
+  active: boolean;
+}>();
+
+const { messages, connected, error, send } = useLiveChat(toRef(props, 'active'));
+
+const draft = ref('');
+const sendError = ref<string | null>(null);
+const listEl = ref<HTMLElement | null>(null);
+
+function timeLabel(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function onSend() {
+  const text = draft.value.trim();
+  if (!text) return;
+  if (send(text)) {
+    draft.value = '';
+    sendError.value = null;
+  } else {
+    sendError.value = 'Not connected — reply not sent';
+  }
+}
+
+// Follow new messages unless the host scrolled up to read history.
+watch(
+  () => messages.value.length,
+  async () => {
+    const el = listEl.value;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    await nextTick();
+    if (nearBottom) el.scrollTop = el.scrollHeight;
+  }
+);
+</script>
+
+<template>
+  <div class="panel-card chat-card">
+    <div class="chat-head">
+      <span class="chat-title">💬 Live chat · Moafunk channel</span>
+      <span :class="['chat-pill', connected ? 'chat-pill-on' : 'chat-pill-off']">
+        {{ connected ? 'Connected' : 'Offline' }}
+      </span>
+    </div>
+
+    <div ref="listEl" class="chat-list">
+      <p v-if="messages.length === 0" class="chat-empty">
+        No messages yet — the channel's discussion group appears here.
+      </p>
+      <div v-for="m in messages" :key="`${m.id}-${m.ts}`" class="chat-msg">
+        <span :class="['chat-author', { 'chat-author-host': m.host }]"
+          >{{ m.author }}<template v-if="m.host"> (host)</template></span
+        >
+        <span class="chat-text">{{ m.text }}</span>
+        <span class="chat-time">{{ timeLabel(m.ts) }}</span>
+      </div>
+    </div>
+
+    <p v-if="error || sendError" class="chat-error">{{ sendError ?? error }}</p>
+
+    <form class="chat-input-row" @submit.prevent="onSend">
+      <input
+        v-model="draft"
+        type="text"
+        class="chat-input"
+        placeholder="Reply as host…"
+        maxlength="4096"
+        :disabled="!connected"
+      />
+      <button type="submit" class="chat-send" :disabled="!connected || !draft.trim()">Send</button>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.chat-card {
+  padding: var(--spacing-md) var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.chat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.chat-title {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+}
+
+.chat-pill {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.chat-pill-on {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.chat-pill-off {
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.chat-list {
+  max-height: 240px;
+  min-height: 96px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-right: 4px;
+}
+
+.chat-empty {
+  margin: auto 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.chat-msg {
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.chat-author {
+  font-family: var(--font-ui);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-accent, #7f77dd);
+  margin-right: 6px;
+}
+
+.chat-author-host {
+  color: var(--color-success);
+}
+
+.chat-text {
+  color: var(--color-text);
+  overflow-wrap: anywhere;
+}
+
+.chat-time {
+  margin-left: 6px;
+  font-family: var(--font-ui);
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+
+.chat-error {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+}
+
+.chat-input-row {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.chat-input {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.chat-input:focus {
+  outline: none;
+  border-color: var(--color-text-muted);
+}
+
+.chat-send {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  padding: 6px 16px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--color-success);
+  color: #fff;
+  cursor: pointer;
+}
+
+.chat-send:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+</style>

--- a/frontend/src/admin/composables/index.ts
+++ b/frontend/src/admin/composables/index.ts
@@ -40,6 +40,12 @@ export {
   type AutoBitrateState,
 } from './useAutoBitrate';
 export {
+  useLiveChat,
+  parseChatFrame,
+  type ChatMessage,
+  type ChatFrame,
+} from './useLiveChat';
+export {
   useRecordingSession,
   type TrackType,
   type TrackState,

--- a/frontend/src/admin/composables/useLiveChat.ts
+++ b/frontend/src/admin/composables/useLiveChat.ts
@@ -1,0 +1,148 @@
+import { ref, watch, onUnmounted, type Ref } from 'vue';
+
+/**
+ * Live-chat bridge client (#278): connects to the backend's `/ws/chat`,
+ * which fans out the Telegram discussion group and posts host replies
+ * back through the bot.
+ */
+
+export interface ChatMessage {
+  id: number;
+  author: string;
+  text: string;
+  /** Unix seconds. */
+  ts: number;
+  /** True for replies sent from the panel. */
+  host: boolean;
+}
+
+export type ChatFrame =
+  | { type: 'history'; messages: ChatMessage[] }
+  | { type: 'message'; message: ChatMessage }
+  | { type: 'error'; error: string };
+
+function isChatMessage(o: unknown): o is ChatMessage {
+  if (typeof o !== 'object' || o === null) return false;
+  const m = o as Record<string, unknown>;
+  return (
+    typeof m.id === 'number' &&
+    typeof m.author === 'string' &&
+    typeof m.text === 'string' &&
+    typeof m.ts === 'number' &&
+    typeof m.host === 'boolean'
+  );
+}
+
+/** Parse a server chat frame; null for anything malformed. Pure — unit tested. */
+export function parseChatFrame(raw: string): ChatFrame | null {
+  let o: unknown;
+  try {
+    o = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof o !== 'object' || o === null) return null;
+  const f = o as Record<string, unknown>;
+  if (f.type === 'history' && Array.isArray(f.messages) && f.messages.every(isChatMessage)) {
+    return { type: 'history', messages: f.messages };
+  }
+  if (f.type === 'message' && isChatMessage(f.message)) {
+    return { type: 'message', message: f.message };
+  }
+  if (f.type === 'error' && typeof f.error === 'string') {
+    return { type: 'error', error: f.error };
+  }
+  return null;
+}
+
+/** Messages kept client-side (server history is 100; leave headroom for live). */
+const MESSAGE_CAP = 200;
+const MAX_RECONNECT_ATTEMPTS = 3;
+
+/**
+ * Connect to the chat bridge while `active` is true. Per-component (the chat
+ * card owns its connection) — unlike the stream socket there is no singleton
+ * to protect, and unmount tears the socket down.
+ */
+export function useLiveChat(active: Ref<boolean>) {
+  const messages = ref<ChatMessage[]>([]);
+  const connected = ref(false);
+  const error = ref<string | null>(null);
+
+  let socket: WebSocket | null = null;
+  let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAttempts = 0;
+
+  function append(msg: ChatMessage) {
+    messages.value = [...messages.value.slice(-(MESSAGE_CAP - 1)), msg];
+  }
+
+  function connect() {
+    disconnect();
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    socket = new WebSocket(`${protocol}//${window.location.host}/ws/chat`);
+
+    socket.onopen = () => {
+      connected.value = true;
+      error.value = null;
+      reconnectAttempts = 0;
+    };
+
+    socket.onmessage = (event) => {
+      if (typeof event.data !== 'string') return;
+      const frame = parseChatFrame(event.data);
+      if (!frame) return;
+      if (frame.type === 'history') {
+        messages.value = frame.messages.slice(-MESSAGE_CAP);
+      } else if (frame.type === 'message') {
+        append(frame.message);
+      } else {
+        error.value = frame.error;
+      }
+    };
+
+    socket.onclose = () => {
+      connected.value = false;
+      if (active.value && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+        reconnectAttempts++;
+        const delay = Math.pow(2, reconnectAttempts - 1) * 1000;
+        reconnectTimeout = setTimeout(connect, delay);
+      }
+    };
+  }
+
+  function disconnect() {
+    if (reconnectTimeout) {
+      clearTimeout(reconnectTimeout);
+      reconnectTimeout = null;
+    }
+    if (socket) {
+      socket.onclose = null; // no auto-reconnect on deliberate teardown
+      socket.close(1000, 'Chat closed');
+      socket = null;
+    }
+    connected.value = false;
+  }
+
+  /** Send a host reply. Returns false when the socket isn't open. */
+  function send(text: string): boolean {
+    const trimmed = text.trim();
+    if (!trimmed || !socket || socket.readyState !== WebSocket.OPEN) return false;
+    socket.send(trimmed);
+    return true;
+  }
+
+  watch(
+    active,
+    (on) => {
+      reconnectAttempts = 0;
+      if (on) connect();
+      else disconnect();
+    },
+    { immediate: true }
+  );
+
+  onUnmounted(disconnect);
+
+  return { messages, connected, error, send };
+}

--- a/frontend/src/admin/composables/useLiveChat.ts
+++ b/frontend/src/admin/composables/useLiveChat.ts
@@ -74,6 +74,9 @@ export function useLiveChat(active: Ref<boolean>) {
   let reconnectAttempts = 0;
 
   function append(msg: ChatMessage) {
+    // Dedupe by id: the server subscribes before snapshotting history, so a
+    // message published in between arrives via both paths.
+    if (messages.value.some((m) => m.id === msg.id)) return;
     messages.value = [...messages.value.slice(-(MESSAGE_CAP - 1)), msg];
   }
 

--- a/frontend/src/admin/pages/flow/FlowOnAir.vue
+++ b/frontend/src/admin/pages/flow/FlowOnAir.vue
@@ -12,6 +12,7 @@ import {
 } from '@admin/composables';
 import { streamApi, recordingApi, hostFlowApi, type StreamMetrics } from '@admin/api';
 import ConnectionCard from '@admin/components/ConnectionCard.vue';
+import LiveChatCard from '@admin/components/LiveChatCard.vue';
 import DbMeter from '@admin/components/DbMeter.vue';
 import SpectrumBars from '@admin/components/SpectrumBars.vue';
 import StreamPreviewPlayer from '@admin/components/StreamPreviewPlayer.vue';
@@ -784,16 +785,8 @@ onUnmounted(() => {
         @select-bitrate="onSelectBitrate"
       />
 
-      <!-- 4 · Live chat — Telegram bridge lands with the chat issue. -->
-      <div class="panel-card slot-card slot-placeholder">
-        <div class="slot-head">
-          <span class="slot-title">💬 Live chat · Moafunk channel</span>
-          <span class="slot-badge">Coming soon</span>
-        </div>
-        <p class="slot-hint">
-          Messages from the channel's discussion group will appear here — reply as host.
-        </p>
-      </div>
+      <!-- 4 · Live chat — Telegram discussion group bridge (#278) -->
+      <LiveChatCard :active="streamActive" />
     </template>
 
     <!-- ═══════════════════════════════════════════════════════════════════ -->
@@ -1227,12 +1220,6 @@ onUnmounted(() => {
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
   color: var(--color-text);
-}
-
-/* Slot waiting on a later Live Panel 2.0 issue. */
-.slot-placeholder {
-  border-style: dashed;
-  opacity: 0.7;
 }
 
 /* dB meter shown during the waiting countdown */

--- a/frontend/tests/useLiveChat.test.ts
+++ b/frontend/tests/useLiveChat.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseChatFrame } from '../src/admin/composables/useLiveChat';
+
+const MSG = { id: 7, author: 'anna', text: 'nice set!', ts: 1_760_000_000, host: false };
+
+describe('parseChatFrame', () => {
+  it('parses a history frame', () => {
+    const raw = JSON.stringify({ type: 'history', messages: [MSG, { ...MSG, id: 8 }] });
+    const frame = parseChatFrame(raw);
+    expect(frame).toEqual({ type: 'history', messages: [MSG, { ...MSG, id: 8 }] });
+  });
+
+  it('parses a single message frame', () => {
+    const raw = JSON.stringify({ type: 'message', message: { ...MSG, host: true } });
+    expect(parseChatFrame(raw)).toEqual({ type: 'message', message: { ...MSG, host: true } });
+  });
+
+  it('parses an error frame', () => {
+    expect(parseChatFrame('{"type":"error","error":"bot not configured"}')).toEqual({
+      type: 'error',
+      error: 'bot not configured',
+    });
+  });
+
+  it('rejects frames with malformed messages', () => {
+    expect(parseChatFrame('{"type":"message","message":{"id":"x"}}')).toBeNull();
+    expect(parseChatFrame('{"type":"history","messages":[{"id":1}]}')).toBeNull();
+  });
+
+  it('rejects unknown types, malformed JSON, and non-objects', () => {
+    expect(parseChatFrame('{"type":"nope"}')).toBeNull();
+    expect(parseChatFrame('{oops')).toBeNull();
+    expect(parseChatFrame('"connected"')).toBeNull();
+    expect(parseChatFrame('42')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Live Panel 2.0 issue #6 of 6 (closes #278) — the last one in the milestone. Bridges the channel's discussion group into the on-air panel and lets the host reply from there.

### Backend

- **`chat_bridge.rs`** — `ChatHub`: 100-message ring buffer (for panels connecting mid-show) + `tokio::broadcast` fan-out (lagging panels skip, they don't block). Unit-tested (ring cap/order, subscriber delivery).
- **Inbound** — the bot's existing dispatcher catch-all gets a branch: text messages in the configured group (`TELEGRAM_LIVE_CHAT_ID`, new env var) are published to the hub. Service messages, channel auto-forwards, and other bots (e.g. Alertmanager) are filtered out. **The bridge is inert until the env var is set** — needs the discussion group's chat id configured on the Hetzner box (Bitwarden → deploy env).
- **`/ws/chat`** — session-cookie auth (same pattern as the stream WS). Sends `{"type":"history"}` on connect, streams `{"type":"message"}` frames, accepts plain-text host replies: posted to the group via the bot as `🎙 <name>: <text>`, then echoed into the hub — Telegram never delivers a bot its own messages, so no loop. Delivery failures come back as `{"type":"error"}` frames shown in the card.

### Frontend

- **`LiveChatCard`** replaces the "Coming soon" placeholder: Connected pill, auto-scrolling list (usernames accent-colored, host replies green with "(host)"), "Reply as host…" input. Auto-scroll only when already near the bottom, so reading history isn't yanked away.
- **`useLiveChat`** — per-component composable (no singleton needed here, unlike the stream socket): connects while on air, 3 reconnect attempts with backoff, tears down on unmount. `parseChatFrame` is pure and unit-tested.

### Risk note

`gitnexus detect_changes` flags HIGH — driven by `main`/`AppState`/`Config` being hub symbols at step 1 of every startup flow. The actual changes there are additive: one `Option` config field (defaults `None`), one `AppState` field, one route. All existing flows are behaviorally unchanged while `TELEGRAM_LIVE_CHAT_ID` is unset.

### Test plan

- [x] Frontend: lint/build clean, 124/124 vitest (5 new for `parseChatFrame`)
- [x] Backend: `cargo clippy` clean on new modules (fixed `manual_strip` rather than copying the legacy pattern), `cargo fmt`, 77 tests pass (2 new hub tests; the pre-existing `video::tests::test_brightness_analysis` failure is unrelated, fails on clean main)
- [ ] After merge: set `TELEGRAM_LIVE_CHAT_ID` on the Hetzner deploy, send a message in the discussion group, confirm it appears in the panel and a host reply lands in the group