### PR TITLE
ci: inject TELEGRAM_LIVE_CHAT_ID into backend deploy env

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -162,6 +162,7 @@ jobs:
             782620cd-7d54-4cef-95b5-b3eb01660ff9 > OPENAI_API_KEY
             2470e0a8-7e96-4113-9931-b3ed0180cf59 > TELEGRAM_BOT_TOKEN
             3d3c982b-6933-4c23-bb11-b3ee000687d6 > TELEGRAM_ADMIN_CHAT_ID
+            e7dd127f-7e64-4cef-9ff0-b47f00a6e740 > TELEGRAM_LIVE_CHAT_ID
             0ede7c60-027a-45af-99ae-b3ec013f22a7 > SOUNDCLOUD_CLIENT_ID
             fb23eb6e-139b-45be-a95a-b3ec013f2eac > SOUNDCLOUD_CLIENT_SECRET
 
@@ -217,6 +218,7 @@ jobs:
             echo "# Telegram bot"
             echo "TELEGRAM_BOT_TOKEN=${{ steps.bitwarden-secrets.outputs.TELEGRAM_BOT_TOKEN }}"
             echo "TELEGRAM_ADMIN_CHAT_ID=${{ steps.bitwarden-secrets.outputs.TELEGRAM_ADMIN_CHAT_ID }}"
+            echo "TELEGRAM_LIVE_CHAT_ID=${{ steps.bitwarden-secrets.outputs.TELEGRAM_LIVE_CHAT_ID }}"
             echo "TELEGRAM_INSTAGRAM_ACCOUNT=prod"
             echo "TELEGRAM_ARTIST_PREVIEW_HOUR=16"
             echo ""
@@ -313,6 +315,7 @@ jobs:
             782620cd-7d54-4cef-95b5-b3eb01660ff9 > OPENAI_API_KEY
             2470e0a8-7e96-4113-9931-b3ed0180cf59 > TELEGRAM_BOT_TOKEN
             3d3c982b-6933-4c23-bb11-b3ee000687d6 > TELEGRAM_ADMIN_CHAT_ID
+            e7dd127f-7e64-4cef-9ff0-b47f00a6e740 > TELEGRAM_LIVE_CHAT_ID
             0ede7c60-027a-45af-99ae-b3ec013f22a7 > SOUNDCLOUD_CLIENT_ID
             fb23eb6e-139b-45be-a95a-b3ec013f2eac > SOUNDCLOUD_CLIENT_SECRET
 
@@ -381,6 +384,7 @@ jobs:
             echo "# Telegram bot"
             echo "TELEGRAM_BOT_TOKEN=${{ steps.bitwarden-secrets.outputs.TELEGRAM_BOT_TOKEN }}"
             echo "TELEGRAM_ADMIN_CHAT_ID=${{ steps.bitwarden-secrets.outputs.TELEGRAM_ADMIN_CHAT_ID }}"
+            echo "TELEGRAM_LIVE_CHAT_ID=${{ steps.bitwarden-secrets.outputs.TELEGRAM_LIVE_CHAT_ID }}"
             echo "TELEGRAM_INSTAGRAM_ACCOUNT=prod"
             echo "TELEGRAM_ARTIST_PREVIEW_HOUR=16"
             echo ""


### PR DESCRIPTION
Maps the new Bitwarden SM secret (`TELEGRAM_LIVE_CHAT_ID`, the channel discussion group's chat id) into the generated production `.env` in both the `deploy-hetzner` and Lightsail `deploy` jobs — mirrored per the keep-in-sync comment.

This activates the #278 live-chat bridge, which is deliberately inert while the variable is unset. Merging auto-deploys the backend to Hetzner (stream status checked: no broadcast active).

Post-deploy check: send a message in the discussion group and confirm it appears in the on-air panel's chat card; reply as host and confirm it lands in the group. Requires MoafunkBot to be a member of the group with privacy mode off (or admin).